### PR TITLE
chore: Update trpc logger info

### DIFF
--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -31,7 +31,7 @@ export const createTRPCContext = (opts: { headers: Headers; session: Session | n
   const session = opts.session;
   const source = opts.headers.get("x-trpc-source") ?? "unknown";
 
-  logger.info(`tRPC request from ${source} by user '${session?.user.id}'`, session?.user);
+  logger.info(`tRPC request from ${source} by user '${session?.user.name} (${session?.user.id})'`, session?.user);
 
   return {
     session,


### PR DESCRIPTION
It now includes the username of the person doing the tRPC request (because the user id is not enough)