### PR TITLE
ci: add github action that approves pull requests from renovate automatically

### DIFF
--- a/.github/workflows/renovate-automatic-approval
+++ b/.github/workflows/renovate-automatic-approval
@@ -1,0 +1,23 @@
+name: Approve Renovate PRs
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  approve-renovate-prs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install GitHub CLI
+        run: sudo apt-get install -y gh
+
+      - name: Approve Renovate PRs
+        env:
+          GITHUB_TOKEN: ${{ secrets.RENOVATE_APPROVE_TOKEN }}
+        run: |
+          for pr in $(gh pr list --author homarr-renovate[bot] --json number --jq .[].number); do
+            gh pr review $pr --approve --body "Automatically approved by GitHub Action"
+          done


### PR DESCRIPTION

<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

This allows us to use auto merge while we require a approval at least.