### PR TITLE
feat: App tile scalability

### DIFF
--- a/packages/translation/src/lang/en.ts
+++ b/packages/translation/src/lang/en.ts
@@ -637,6 +637,9 @@ export default {
         openInNewTab: {
           label: "Open in new tab",
         },
+        showTitle: {
+          label: "Show app name",
+        },
         showDescriptionTooltip: {
           label: "Show description tooltip",
         },

--- a/packages/widgets/src/app/component.tsx
+++ b/packages/widgets/src/app/component.tsx
@@ -4,6 +4,7 @@ import type { PropsWithChildren } from "react";
 import { useState } from "react";
 import { Box, Center, Flex, Loader, Stack, Text, Tooltip, UnstyledButton } from "@mantine/core";
 import { IconDeviceDesktopX } from "@tabler/icons-react";
+import combineClasses from "clsx";
 
 import type { RouterOutputs } from "@homarr/api";
 import { clientApi } from "@homarr/api/client";
@@ -13,7 +14,7 @@ import { useScopedI18n } from "@homarr/translation/client";
 import type { WidgetComponentProps } from "../definition";
 import classes from "./app.module.css";
 
-export default function AppWidget({ options, serverData, isEditMode, width, height }: WidgetComponentProps<"app">) {
+export default function AppWidget({ options, serverData, isEditMode, width }: WidgetComponentProps<"app">) {
   const t = useScopedI18n("widget.app");
   const isQueryEnabled = Boolean(options.appId);
   const {
@@ -92,35 +93,31 @@ export default function AppWidget({ options, serverData, isEditMode, width, heig
 
   return (
     <AppLink href={app?.href ?? ""} openInNewTab={options.openInNewTab} enabled={Boolean(app?.href) && !isEditMode}>
-      <Flex align="center" justify="center" h="100%" pos="relative">
-        <Tooltip.Floating
-          label={app?.description}
-          position="right-start"
-          multiline
-          disabled={!options.showDescriptionTooltip || !app?.description}
-          styles={{ tooltip: { maxWidth: 300 } }}
+      <Tooltip.Floating
+        label={app?.description}
+        position="right-start"
+        multiline
+        disabled={!options.showDescriptionTooltip || !app?.description}
+        styles={{ tooltip: { maxWidth: 300 } }}
+      >
+        <Flex
+          className={combineClasses("app-flex-wrapper", app?.name, app?.id)}
+          h="100%"
+          w="100%"
+          direction="column"
+          p="7.5cqmin"
+          justify="center"
+          align="center"
         >
-          <Flex
-            h="100%"
-            direction="column"
-            align="center"
-            gap={0}
-            style={{
-              overflow: "visible",
-              flexGrow: 5,
-            }}
-          >
-            {height >= 96 && (
-              <Text fw={700} ta="center">
-                {app?.name}
-              </Text>
-            )}
-            <img src={app?.iconUrl} alt={app?.name} className={classes.appIcon} />
-          </Flex>
-        </Tooltip.Floating>
-
-        {shouldRunPing && <PingIndicator pingResult={pingResult} />}
-      </Flex>
+          {options.showTitle && (
+            <Text className="app-title" fw={700} size="12.5cqmin">
+              {app?.name}
+            </Text>
+          )}
+          <img src={app?.iconUrl} alt={app?.name} className={combineClasses(classes.appIcon, "app-icon")} />
+        </Flex>
+      </Tooltip.Floating>
+      {shouldRunPing && <PingIndicator pingResult={pingResult} />}
     </AppLink>
   );
 }

--- a/packages/widgets/src/app/index.ts
+++ b/packages/widgets/src/app/index.ts
@@ -8,6 +8,7 @@ export const { definition, componentLoader, serverDataLoader } = createWidgetDef
   options: optionsBuilder.from((factory) => ({
     appId: factory.app(),
     openInNewTab: factory.switch({ defaultValue: true }),
+    showTitle: factory.switch({ defaultValue: true }),
     showDescriptionTooltip: factory.switch({ defaultValue: false }),
     pingEnabled: factory.switch({ defaultValue: false }),
   })),


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [ ] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [ ] Pull request targets ``dev`` branch
- [ ] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)


![image](https://github.com/homarr-labs/homarr/assets/26098587/a9972d1b-9fa2-4f65-b796-ae2b8260393b)

CSS for putting the text in a row (just to show how easy it is)
```CSS
.app-row-elements { .app-flex-wrapper {
  flex-direction: row !important;
}}
```