### PR TITLE
fix: controller is already closed trpc subscription observable error

### DIFF
--- a/packages/api/src/router/log.ts
+++ b/packages/api/src/router/log.ts
@@ -9,10 +9,17 @@ import { createTRPCRouter, publicProcedure } from "../trpc";
 export const logRouter = createTRPCRouter({
   subscribe: publicProcedure.subscription(() => {
     return observable<LoggerMessage>((emit) => {
+      let isConnectionClosed = false;
+
       loggingChannel.subscribe((data) => {
+        if (isConnectionClosed) return;
         emit.next(data);
       });
       logger.info("A tRPC client has connected to the logging procedure");
+
+      return () => {
+        isConnectionClosed = true;
+      };
     });
   }),
 });

--- a/packages/api/src/router/user.ts
+++ b/packages/api/src/router/user.ts
@@ -1,11 +1,9 @@
 import { TRPCError } from "@trpc/server";
-import { observable } from "@trpc/server/observable";
 
 import { createSaltAsync, hashPasswordAsync } from "@homarr/auth";
 import type { Database } from "@homarr/db";
 import { and, createId, eq, schema } from "@homarr/db";
 import { groupMembers, groupPermissions, groups, invites, users } from "@homarr/db/schema/sqlite";
-import { exampleChannel } from "@homarr/redis";
 import { validation, z } from "@homarr/validation";
 
 import { createTRPCRouter, protectedProcedure, publicProcedure } from "../trpc";
@@ -231,16 +229,6 @@ export const userRouter = createTRPCRouter({
         password: hashedPassword,
       })
       .where(eq(users.id, input.userId));
-  }),
-  setMessage: publicProcedure.input(z.string()).mutation(async ({ input }) => {
-    await exampleChannel.publishAsync({ message: input });
-  }),
-  test: publicProcedure.subscription(() => {
-    return observable<{ message: string }>((emit) => {
-      exampleChannel.subscribe((message) => {
-        emit.next(message);
-      });
-    });
   }),
 });
 

--- a/packages/api/src/router/widgets/app.ts
+++ b/packages/api/src/router/widgets/app.ts
@@ -27,14 +27,19 @@ export const appRouter = createTRPCRouter({
       const pingResult = await sendPingRequestAsync(input.url);
 
       return observable<{ url: string; statusCode: number } | { url: string; error: string }>((emit) => {
+        let isConnectionClosed = false;
+
         emit.next({ url: input.url, ...pingResult });
         pingChannel.subscribe((message) => {
+          if (isConnectionClosed) return;
+
           // Only emit if same url
           if (message.url !== input.url) return;
           emit.next(message);
         });
 
         return () => {
+          isConnectionClosed = true;
           void pingUrlChannel.removeAsync(input.url);
         };
       });

--- a/packages/api/src/router/widgets/smart-home.ts
+++ b/packages/api/src/router/widgets/smart-home.ts
@@ -13,12 +13,19 @@ export const smartHomeRouter = createTRPCRouter({
       entityId: string;
       state: string;
     }>((emit) => {
+      let isConnectionClosed = false;
+
       homeAssistantEntityState.subscribe((message) => {
+        if (isConnectionClosed) return;
         if (message.entityId !== input.entityId) {
           return;
         }
         emit.next(message);
       });
+
+      return () => {
+        isConnectionClosed = true;
+      };
     });
   }),
   switchEntity: publicProcedure


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

```
@homarr/websocket:dev: node:internal/webstreams/readablestream:1069
@homarr/websocket:dev:       throw new ERR_INVALID_STATE.TypeError('Controller is already closed');
@homarr/websocket:dev:       ^
@homarr/websocket:dev:
@homarr/websocket:dev: TypeError [ERR_INVALID_STATE]: Invalid state: Controller is already closed
@homarr/websocket:dev:     at ReadableStreamDefaultController.enqueue (node:internal/webstreams/readablestream:1069:13)
@homarr/websocket:dev:     at Object.next (homarr/node_modules/@trpc/server/dist/observable/observable.mjs:117:32)
@homarr/websocket:dev:     at Object.next (homarr/node_modules/@trpc/server/dist/observable/observable.mjs:31:36)
@homarr/websocket:dev:     at <anonymous> (homarr\packages\api\src\router\widgets\smart-home.ts:20:14)
@homarr/websocket:dev:     at EventEmitter.<anonymous> (homarr\packages\redis\src\lib\channel.ts:42:9)
@homarr/websocket:dev:     at EventEmitter.emit (node:events:530:35)
@homarr/websocket:dev:     at EventEmitter.emit (node:domain:488:12)
@homarr/websocket:dev:     at DataHandler.handleSubscriberReply (homarr\node_modules\ioredis\built\DataHandler.js:80:32)
@homarr/websocket:dev:     at DataHandler.returnReply (homarr\node_modules\ioredis\built\DataHandler.js:47:18)
@homarr/websocket:dev:     at JavascriptRedisParser.returnReply (homarr\node_modules\ioredis\built\DataHandler.js:21:22) {
@homarr/websocket:dev:   code: 'ERR_INVALID_STATE'
@homarr/websocket:dev: }
@homarr/websocket:dev:
@homarr/websocket:dev: Node.js v20.11.1
@homarr/websocket:dev:  ELIFECYCLE  Command failed with exit code 1.
```