### PR TITLE
fix: Manage banner animation hitch fix

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/_components/hero-banner.module.css
+++ b/apps/nextjs/src/app/[locale]/manage/_components/hero-banner.module.css
@@ -19,7 +19,7 @@
     transform: translateY(0);
   }
   100% {
-    transform: translateY(-50%);
+    transform: translateY(-50.8%);
   }
 }
 


### PR DESCRIPTION
fix the animation loop hitch in the banner of the management page.
Don't ask me why 50.8%, I just starred at my screen very long until the value caused the hitch to disappear.