### PR TITLE
feat: finish media requests widgets

### DIFF
--- a/packages/api/src/middlewares/integration.ts
+++ b/packages/api/src/middlewares/integration.ts
@@ -126,7 +126,7 @@ export const createManyIntegrationMiddleware = <TKind extends IntegrationKind>(
       if (offset !== 0) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: `${offset} of the specified integrations not found or not of kinds ${kinds.join(",")}: ([${input.integrationIds.join(',')}] compared to [${dbIntegrations.join(',')}])`,
+          message: `${offset} of the specified integrations not found or not of kinds ${kinds.join(",")}: ([${input.integrationIds.join(",")}] compared to [${dbIntegrations.join(",")}])`,
         });
       }
 

--- a/packages/api/src/router/widgets/index.ts
+++ b/packages/api/src/router/widgets/index.ts
@@ -2,12 +2,12 @@ import { createTRPCRouter } from "../../trpc";
 import { appRouter } from "./app";
 import { calendarRouter } from "./calendar";
 import { dnsHoleRouter } from "./dns-hole";
+import { mediaRequestsRouter } from "./media-requests";
 import { mediaServerRouter } from "./media-server";
 import { notebookRouter } from "./notebook";
 import { rssFeedRouter } from "./rssFeed";
 import { smartHomeRouter } from "./smart-home";
 import { weatherRouter } from "./weather";
-import { mediaRequestsRouter } from "./media-requests";
 
 export const widgetRouter = createTRPCRouter({
   notebook: notebookRouter,

--- a/packages/cron-jobs/src/index.ts
+++ b/packages/cron-jobs/src/index.ts
@@ -2,12 +2,12 @@ import { analyticsJob } from "./jobs/analytics";
 import { iconsUpdaterJob } from "./jobs/icons-updater";
 import { smartHomeEntityStateJob } from "./jobs/integrations/home-assistant";
 import { mediaOrganizerJob } from "./jobs/integrations/media-organizer";
+import { mediaRequestsJob } from "./jobs/integrations/media-requests";
 import { mediaServerJob } from "./jobs/integrations/media-server";
 import { pingJob } from "./jobs/ping";
 import type { RssFeed } from "./jobs/rss-feeds";
 import { rssFeedsJob } from "./jobs/rss-feeds";
 import { createCronJobGroup } from "./lib";
-import { mediaRequestsJob } from "./jobs/integrations/media-requests";
 
 export const jobGroup = createCronJobGroup({
   analytics: analyticsJob,

--- a/packages/integrations/src/base/creator.ts
+++ b/packages/integrations/src/base/creator.ts
@@ -2,11 +2,11 @@ import type { IntegrationKind } from "@homarr/definitions";
 
 import { HomeAssistantIntegration } from "../homeassistant/homeassistant-integration";
 import { JellyfinIntegration } from "../jellyfin/jellyfin-integration";
+import { JellyseerrIntegration } from "../jellyseerr/jellyseerr-integration";
 import { SonarrIntegration } from "../media-organizer/sonarr/sonarr-integration";
+import { OverseerrIntegration } from "../overseerr/overseerr-integration";
 import { PiHoleIntegration } from "../pi-hole/pi-hole-integration";
 import type { IntegrationInput } from "./integration";
-import { OverseerrIntegration } from "../overseerr/overseerr-integration";
-import { JellyseerrIntegration } from "../jellyseerr/jellyseerr-integration";
 
 export const integrationCreatorByKind = (kind: IntegrationKind, integration: IntegrationInput) => {
   switch (kind) {

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -8,9 +8,8 @@ export { OverseerrIntegration } from "./overseerr/overseerr-integration";
 
 // Types
 export type { StreamSession } from "./interfaces/media-server/session";
-export type { MediaRequest } from "./interfaces/media-requests/media-request";
 export { MediaRequestStatus } from "./interfaces/media-requests/media-request";
-export type { MediaRequestStats } from "./interfaces/media-requests/media-request-stats";
+export type { MediaRequestList, MediaRequestStats } from "./interfaces/media-requests/media-request";
 
 // Helpers
 export { IntegrationTestConnectionError } from "./base/test-connection-error";

--- a/packages/integrations/src/interfaces/media-requests/media-request-stats.ts
+++ b/packages/integrations/src/interfaces/media-requests/media-request-stats.ts
@@ -1,8 +1,0 @@
-export interface MediaRequestStats {
-  values: NumericMediaRequestStat[];
-}
-
-interface NumericMediaRequestStat {
-  name: "approved" | "pending" | "declined" | "shows" | "movies" | "total";
-  value: number;
-}

--- a/packages/integrations/src/interfaces/media-requests/media-request.ts
+++ b/packages/integrations/src/interfaces/media-requests/media-request.ts
@@ -1,7 +1,7 @@
 export interface MediaRequest {
   id: number;
   name: string;
-  type: 'movie' | 'tv';
+  type: "movie" | "tv";
   backdropImageUrl: string;
   posterImagePath: string;
   href: string;
@@ -12,11 +12,39 @@ export interface MediaRequest {
   requestedBy?: RequestUser;
 }
 
+export interface MediaRequestList {
+  integration: {
+    id: string;
+  };
+  medias: MediaRequest[];
+}
+
+export interface RequestStats {
+  total: number;
+  movie: number;
+  tv: number;
+  pending: number;
+  approved: number;
+  declined: number;
+  processing: number;
+  available: number;
+}
+
 export interface RequestUser {
   id: number;
-  username: string;
-  profilePictureUrl: string;
+  displayName: string;
+  avatar: string;
+  requestCount: number;
   link: string;
+}
+
+export interface MediaRequestStats {
+  integration: {
+    kind: string;
+    name: string;
+  };
+  stats: RequestStats;
+  users: RequestUser[];
 }
 
 export enum MediaRequestStatus {

--- a/packages/integrations/src/jellyseerr/jellyseerr-integration.ts
+++ b/packages/integrations/src/jellyseerr/jellyseerr-integration.ts
@@ -1,5 +1,3 @@
 import { OverseerrIntegration } from "../overseerr/overseerr-integration";
 
-export class JellyseerrIntegration extends OverseerrIntegration {
-
-}
+export class JellyseerrIntegration extends OverseerrIntegration {}

--- a/packages/integrations/src/overseerr/overseerr-integration.ts
+++ b/packages/integrations/src/overseerr/overseerr-integration.ts
@@ -1,39 +1,60 @@
 import { z } from "@homarr/validation";
+
 import { Integration } from "../base/integration";
-import type { MediaRequest, RequestUser} from "../interfaces/media-requests/media-request";
+import type { MediaRequest, RequestStats, RequestUser } from "../interfaces/media-requests/media-request";
 import { MediaAvailability, MediaRequestStatus } from "../interfaces/media-requests/media-request";
 
 /**
  * Overseerr Integration. See https://api-docs.overseerr.dev
  */
 export class OverseerrIntegration extends Integration {
-    public async testConnectionAsync(): Promise<void> {
-      const response = await fetch(`${this.integration.url}/api/v1/auth/me`, {
-        headers: {
-          'X-Api-Key': this.getSecretValue('apiKey')
-        }
-      });
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const json: object = await response.json();
-      if (Object.keys(json).includes("id")) {
-        return;
-      }
-      throw new Error(`Received response but unable to parse it: ${JSON.stringify(json)}`);
+  public async testConnectionAsync(): Promise<void> {
+    const response = await fetch(`${this.integration.url}/api/v1/auth/me`, {
+      headers: {
+        "X-Api-Key": this.getSecretValue("apiKey"),
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const json: object = await response.json();
+    if (Object.keys(json).includes("id")) {
+      return;
     }
+    throw new Error(`Received response but unable to parse it: ${JSON.stringify(json)}`);
+  }
 
-    public async getRequestsAsync(): Promise<MediaRequest[]> {
-      //Change 20 to integration setting
-      const response = await fetch(`${this.integration.url}/api/v1/request?take=20`, {
-        headers: {
-          'X-Api-Key': this.getSecretValue('apiKey')
-        }
-      });
+  public async getRequestsAsync(): Promise<MediaRequest[]> {
+    //Ensure to get all pending request first
+    const pendingRequests = await fetch(`${this.integration.url}/api/v1/request?take=-1&filter=pending`, {
+      headers: {
+        "X-Api-Key": this.getSecretValue("apiKey"),
+      },
+    });
 
-      const requests = await getRequestsSchema.parseAsync(await response.json());
+    //Change 20 to integration setting (set to -1 for all)
+    const allRequests = await fetch(`${this.integration.url}/api/v1/request?take=20`, {
+      headers: {
+        "X-Api-Key": this.getSecretValue("apiKey"),
+      },
+    });
 
-      return await Promise.all(requests.results.map(async (request): Promise<MediaRequest> => {
+    const pendingResults = (await getRequestsSchema.parseAsync(await pendingRequests.json())).results;
+    const allResults = (await getRequestsSchema.parseAsync(await allRequests.json())).results;
+
+    //Concat the 2 lists while remove any duplicate pending from the all items list
+    let requests;
+
+    if (pendingResults.length > 0 && allResults.length > 0) {
+      requests = pendingResults.concat(
+        allResults.filter(({ status }) => status !== MediaRequestStatus.PendingApproval),
+      );
+    } else if (pendingResults.length > 0) requests = pendingResults;
+    else if (allResults.length > 0) requests = allResults;
+    else return Promise.all([]);
+
+    return await Promise.all(
+      requests.map(async (request): Promise<MediaRequest> => {
         const information = await this.getItemInformationAsync(request.media.tmdbId, request.type);
-        return ({
+        return {
           id: request.id,
           name: information.name,
           status: request.status,
@@ -44,60 +65,91 @@ export class OverseerrIntegration extends Integration {
           type: request.type,
           createdAt: request.createdAt,
           airDate: new Date(information.airDate),
-          requestedBy: request.requestedBy ? {
-            id: request.requestedBy.id,
-            username: request.requestedBy.displayName,
-            link: `${this.integration.url}/users/${request.requestedBy.id}`,
-            profilePictureUrl: constructAvatarUrl(this.integration.url, request.requestedBy.avatar) } as RequestUser : undefined,
-        });
-      }));
-    }
+          requestedBy: request.requestedBy
+            ? ({
+                ...request.requestedBy,
+                displayName: request.requestedBy.displayName,
+                link: `${this.integration.url}/users/${request.requestedBy.id}`,
+                avatar: constructAvatarUrl(this.integration.url, request.requestedBy.avatar),
+              } as RequestUser)
+            : undefined,
+        };
+      }),
+    );
+  }
 
-    public async approveRequestAsync(requestId: number): Promise<void> {
-      await fetch(`${this.integration.url}/api/v1/request/${requestId}/approve`, {
-        headers: {
-          'X-Api-Key': this.getSecretValue('apiKey')
-        }
-      });
-    }
-
-  public async declineRequestAsync(requestId: number): Promise<void> {
-    await fetch(`${this.integration.url}/api/v1/request/${requestId}/decline`, {
+  public async getStatsAsync(): Promise<RequestStats> {
+    const response = await fetch(`${this.integration.url}/api/v1/request/count`, {
       headers: {
-        'X-Api-Key': this.getSecretValue('apiKey')
-      }
+        "X-Api-Key": this.getSecretValue("apiKey"),
+      },
+    });
+    return await getStatsSchema.parseAsync(await response.json());
+  }
+
+  public async getUsersAsync(): Promise<RequestUser[]> {
+    const response = await fetch(`${this.integration.url}/api/v1/user?take=-1`, {
+      headers: {
+        "X-Api-Key": this.getSecretValue("apiKey"),
+      },
+    });
+    const users = (await getUsersSchema.parseAsync(await response.json())).results;
+    return users.map((user): RequestUser => {
+      return {
+        ...user,
+        link: `${this.integration.url}/users/${user.id}`,
+        avatar: constructAvatarUrl(this.integration.url, user.avatar),
+      };
     });
   }
 
-    private async getItemInformationAsync(id: number, type: MediaRequest['type']): Promise<MediaInformation> {
-      const response = await fetch(`${this.integration.url}/api/v1/${type}/${id}`, {
-        headers: {
-          'X-Api-Key': this.getSecretValue('apiKey')
-        },
-      });
+  public async approveRequestAsync(requestId: number): Promise<void> {
+    await fetch(`${this.integration.url}/api/v1/request/${requestId}/approve`, {
+      method: "POST",
+      headers: {
+        "X-Api-Key": this.getSecretValue("apiKey"),
+      },
+    });
+  }
 
-      if(type === "tv") {
-        const series = (await response.json()) as TvInformation;
-        return {
-          name: series.name,
-          backdropPath: series.backdropPath ?? series.posterPath,
-          posterPath: series.posterPath ?? series.backdropPath,
-          airDate: series.firstAirDate,
-        } as MediaInformation
-      }
+  public async declineRequestAsync(requestId: number): Promise<void> {
+    await fetch(`${this.integration.url}/api/v1/request/${requestId}/decline`, {
+      method: "POST",
+      headers: {
+        "X-Api-Key": this.getSecretValue("apiKey"),
+      },
+    });
+  }
 
-      const movie = (await response.json()) as MovieInformation;
+  private async getItemInformationAsync(id: number, type: MediaRequest["type"]): Promise<MediaInformation> {
+    const response = await fetch(`${this.integration.url}/api/v1/${type}/${id}`, {
+      headers: {
+        "X-Api-Key": this.getSecretValue("apiKey"),
+      },
+    });
+
+    if (type === "tv") {
+      const series = (await response.json()) as TvInformation;
       return {
-        name: movie.title,
-        backdropPath: movie.backdropPath ?? movie.posterPath,
-        posterPath: movie.posterPath ?? movie.backdropPath,
-        airDate: movie.releaseDate,
-      } as MediaInformation
+        name: series.name,
+        backdropPath: series.backdropPath ?? series.posterPath,
+        posterPath: series.posterPath ?? series.backdropPath,
+        airDate: series.firstAirDate,
+      } as MediaInformation;
     }
+
+    const movie = (await response.json()) as MovieInformation;
+    return {
+      name: movie.title,
+      backdropPath: movie.backdropPath ?? movie.posterPath,
+      posterPath: movie.posterPath ?? movie.backdropPath,
+      airDate: movie.releaseDate,
+    } as MediaInformation;
+  }
 }
 
 const constructAvatarUrl = (appUrl: string, avatar: string) => {
-  const isAbsolute = avatar.startsWith('http://') || avatar.startsWith('https://');
+  const isAbsolute = avatar.startsWith("http://") || avatar.startsWith("https://");
 
   if (isAbsolute) {
     return avatar;
@@ -128,19 +180,61 @@ interface MovieInformation {
 }
 
 const getRequestsSchema = z.object({
-  results: z.array(z.object({
-    id: z.number(),
-    status: z.nativeEnum(MediaRequestStatus),
-    createdAt: z.string().transform(value => new Date(value)),
-    media: z.object({
-      status: z.nativeEnum(MediaAvailability),
-      tmdbId: z.number(),
+  results: z
+    .array(
+      z.object({
+        id: z.number(),
+        status: z.nativeEnum(MediaRequestStatus),
+        createdAt: z.string().transform((value) => new Date(value)),
+        media: z.object({
+          status: z.nativeEnum(MediaAvailability),
+          tmdbId: z.number(),
+        }),
+        type: z.enum(["movie", "tv"]),
+        requestedBy: z
+          .object({
+            id: z.number(),
+            displayName: z.string(),
+            avatar: z.string(),
+          })
+          .optional(),
+      }),
+    )
+    .optional()
+    .transform((val) => {
+      if (!val) {
+        return [];
+      }
+      return val;
     }),
-    type: z.enum(['movie', 'tv']),
-    requestedBy: z.object({
-      id: z.number(),
-      displayName: z.string(),
-      avatar: z.string(),
-    }).optional(),
-  }))
-})
+});
+
+const getStatsSchema = z.object({
+  total: z.number(),
+  movie: z.number(),
+  tv: z.number(),
+  pending: z.number(),
+  approved: z.number(),
+  declined: z.number(),
+  processing: z.number(),
+  available: z.number(),
+});
+
+const getUsersSchema = z.object({
+  results: z
+    .array(
+      z.object({
+        id: z.number(),
+        displayName: z.string(),
+        avatar: z.string(),
+        requestCount: z.number(),
+      }),
+    )
+    .optional()
+    .transform((val) => {
+      if (!val) {
+        return [];
+      }
+      return val;
+    }),
+});

--- a/packages/translation/src/lang/en.ts
+++ b/packages/translation/src/lang/en.ts
@@ -1038,7 +1038,7 @@ export default {
       description: "See a list of all media requests from your Overseerr or Jellyseerr instance",
       option: {
         linksTargetNewTab: {
-          label: "Open links in new tab"
+          label: "Open links in new tab",
         },
       },
       pending: {
@@ -1064,9 +1064,11 @@ export default {
           main: "Media Stats",
           approved: "Already approved",
           pending: "Pending approvals",
+          processing: "Being processed",
           declined: "Already declined",
-          shows: "TV requests",
-          movies: "Movie requests",
+          available: "Already Available",
+          tv: "TV requests",
+          movie: "Movie requests",
           total: "Total",
         },
         users: {
@@ -1552,7 +1554,7 @@ export default {
               label: "Media Organizers",
             },
             mediaRequests: {
-              label: "Media Requests"
+              label: "Media Requests",
             },
             rssFeeds: {
               label: "RSS feeds",

--- a/packages/widgets/src/index.tsx
+++ b/packages/widgets/src/index.tsx
@@ -12,6 +12,8 @@ import type { WidgetComponentProps } from "./definition";
 import * as dnsHoleSummary from "./dns-hole/summary";
 import * as iframe from "./iframe";
 import type { WidgetImportRecord } from "./import";
+import * as mediaRequestsList from "./media-requests/list";
+import * as mediaRequestsStats from "./media-requests/stats";
 import * as mediaServer from "./media-server";
 import * as notebook from "./notebook";
 import * as rssFeed from "./rssFeed";
@@ -19,8 +21,6 @@ import * as smartHomeEntityState from "./smart-home/entity-state";
 import * as smartHomeExecuteAutomation from "./smart-home/execute-automation";
 import * as video from "./video";
 import * as weather from "./weather";
-import * as mediaRequestsList from "./media-requests/list";
-import * as mediaRequestsStats from "./media-requests/stats";
 
 export { reduceWidgetOptionsWithDefaultValues } from "./options";
 

--- a/packages/widgets/src/media-requests/list/component.tsx
+++ b/packages/widgets/src/media-requests/list/component.tsx
@@ -1,6 +1,7 @@
 import { ActionIcon, Anchor, Avatar, Badge, Card, Group, Image, ScrollArea, Stack, Text, Tooltip } from "@mantine/core";
 import { IconThumbDown, IconThumbUp } from "@tabler/icons-react";
 
+import { clientApi } from "@homarr/api/client";
 import { useScopedI18n } from "@homarr/translation/client";
 
 import {
@@ -9,7 +10,6 @@ import {
   MediaRequestStatus,
 } from "../../../../integrations/src/interfaces/media-requests/media-request";
 import type { WidgetComponentProps } from "../../definition";
-import {clientApi} from "@homarr/api/client";
 
 export default function MediaServerWidget({
   isEditMode,
@@ -110,7 +110,7 @@ export default function MediaServerWidget({
                 <Group className="mediaRequests-list-item-request-user" gap="2cqmin" wrap="nowrap">
                   <Avatar
                     className="mediaRequests-list-item-request-user-avatar"
-                    src={mediaRequest.requestedBy?.profilePictureUrl}
+                    src={mediaRequest.requestedBy?.avatar}
                     size="6cqmin"
                   />
                   <Anchor
@@ -122,7 +122,7 @@ export default function MediaServerWidget({
                     lineClamp={1}
                     style={{ wordBreak: "break-all" }}
                   >
-                    {(mediaRequest.requestedBy?.username ?? "") || "unknown"}
+                    {(mediaRequest.requestedBy?.displayName ?? "") || "unknown"}
                   </Anchor>
                 </Group>
                 {mediaRequest.status === MediaRequestStatus.PendingApproval && (
@@ -134,7 +134,11 @@ export default function MediaServerWidget({
                         color="green"
                         size="5cqmin"
                         onClick={() => {
-                          /*Place approving function here*/
+                          mutateRequestAnswer({
+                            integrationId: mediaRequest.integrationId,
+                            requestId: mediaRequest.id,
+                            answer: "approve",
+                          });
                         }}
                       >
                         <IconThumbUp size="4cqmin" />
@@ -147,7 +151,11 @@ export default function MediaServerWidget({
                         color="red"
                         size="5cqmin"
                         onClick={() => {
-                          /*Place declining function here*/
+                          mutateRequestAnswer({
+                            integrationId: mediaRequest.integrationId,
+                            requestId: mediaRequest.id,
+                            answer: "decline",
+                          });
                         }}
                       >
                         <IconThumbDown size="4cqmin" />

--- a/packages/widgets/src/media-requests/list/index.ts
+++ b/packages/widgets/src/media-requests/list/index.ts
@@ -1,15 +1,15 @@
 import { IconZoomQuestion } from "@tabler/icons-react";
+
 import { createWidgetDefinition } from "../../definition";
 import { optionsBuilder } from "../../options";
 
 export const { componentLoader, definition, serverDataLoader } = createWidgetDefinition("mediaRequests-requestList", {
   icon: IconZoomQuestion,
-  options: optionsBuilder.from(
-    (factory) => ({
-      linksTargetNewTab: factory.switch({
-        defaultValue: true,
-      })
-    })),
+  options: optionsBuilder.from((factory) => ({
+    linksTargetNewTab: factory.switch({
+      defaultValue: true,
+    }),
+  })),
   supportedIntegrations: ["overseerr", "jellyseerr"],
 })
   .withServerData(() => import("./serverData"))

--- a/packages/widgets/src/media-requests/list/serverData.ts
+++ b/packages/widgets/src/media-requests/list/serverData.ts
@@ -13,10 +13,14 @@ export default async function getServerDataAsync({ integrationIds, itemId }: Wid
 
   const requests = await api.widget.mediaRequests.getLatestRequests({
     integrationIds,
-    itemId
+    itemId,
   });
 
   return {
-    initialData: requests.filter(group => group != null).flatMap(group => group.data),
+    initialData: requests
+      .filter((group) => group != null)
+      .flatMap((group) =>
+        group.data.medias.flatMap((media) => ({ ...media, integrationId: group.data.integration.id })),
+      ),
   };
 }

--- a/packages/widgets/src/media-requests/stats/component.module.css
+++ b/packages/widgets/src/media-requests/stats/component.module.css
@@ -1,7 +1,7 @@
-.gridElement:not(:nth-child(6n)) {
+.gridElement:not(:nth-child(8n)) {
   border-right: 0.5cqmin solid var(--app-shell-border-color);
 }
 
-.gridElement:not(:nth-last-child(-n + 6)) {
+.gridElement:not(:nth-last-child(-n + 8)) {
   border-bottom: 0.5cqmin solid var(--app-shell-border-color);
 }

--- a/packages/widgets/src/media-requests/stats/index.ts
+++ b/packages/widgets/src/media-requests/stats/index.ts
@@ -1,4 +1,5 @@
 import { IconChartBar } from "@tabler/icons-react";
+
 import { createWidgetDefinition } from "../../definition";
 
 export const { componentLoader, definition, serverDataLoader } = createWidgetDefinition("mediaRequests-requestStats", {

--- a/packages/widgets/src/media-requests/stats/serverData.ts
+++ b/packages/widgets/src/media-requests/stats/serverData.ts
@@ -1,10 +1,13 @@
 "use server";
 
-import {api} from "@homarr/api/server";
+import { api } from "@homarr/api/server";
 
-import type {WidgetProps} from "../../definition";
+import type { WidgetProps } from "../../definition";
 
-export default async function getServerDataAsync({integrationIds, itemId}: WidgetProps<"mediaRequests-requestStats">) {
+export default async function getServerDataAsync({
+  integrationIds,
+  itemId,
+}: WidgetProps<"mediaRequests-requestStats">) {
   if (integrationIds.length === 0 || !itemId) {
     return {
       initialData: [],
@@ -13,12 +16,10 @@ export default async function getServerDataAsync({integrationIds, itemId}: Widge
 
   const stats = await api.widget.mediaRequests.getStats({
     integrationIds,
-    itemId
+    itemId,
   });
 
   return {
-    initialData: stats
-      .filter(group => group != null)
-      .flatMap(group => group.data),
+    initialData: stats.filter((group) => group != null).flatMap((group) => group.data),
   };
 }


### PR DESCRIPTION
Changed Stats to get from API call instead from counting current items. (fixes that bug present in oldmarr too)
Add processing and available to Media stats list.
Added Requests empty handling in backend.

Minor:
fixed missing post method to approve/decline mutations.
pnpm format:fix did a number on this one.

Todo: Link integration attributes to "SanitizedIntegratio" once 895 gets through.