### PR TITLE
fix: renovate approval run for all pull requests on every pull request change

### DIFF
--- a/.github/workflows/renovate-automatic-approval.yml
+++ b/.github/workflows/renovate-automatic-approval.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   approve-renovate-prs:
     runs-on: ubuntu-latest
+    if: github.actor == 'homarr-renovate[bot]'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/renovate-automatic-approval.yml
+++ b/.github/workflows/renovate-automatic-approval.yml
@@ -21,6 +21,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.obtainToken.outputs.token }}
         run: |
-          for pr in $(gh pr list --author homarr-renovate[bot] --json number --jq .[].number); do
-            gh pr review $pr --approve --body "Automatically approved by GitHub Action"
-          done
+          gh pr review ${{github.event.pull_request.number}} --approve --body "Automatically approved by GitHub Action"

--- a/.github/workflows/renovate-automatic-approval.yml
+++ b/.github/workflows/renovate-automatic-approval.yml
@@ -2,6 +2,8 @@ name: "[Dependency Updates] Auto Approve"
 on:
   pull_request:
     types: [opened, synchronize]
+    branches:
+      - "renovate/**"
 
 jobs:
   approve-renovate-prs:


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

This will no longer spam us when one pull request can not be merged and then other pull requests open / synchronize