### PR TITLE
fix: renovate approval workflow not running

### DIFF
--- a/.github/workflows/renovate-automatic-approval.yml
+++ b/.github/workflows/renovate-automatic-approval.yml
@@ -6,9 +6,8 @@ on:
 jobs:
   approve-renovate-prs:
     runs-on: ubuntu-latest
+    if: github.actor_id == 816230 # Id of renovate bot see https://github.com/organizations/homarr-labs/settings/apps/homarr-renovate
     steps:
-      - name: Echo github payload
-        run: echo '${{ toJson(github) }}' && exit 1
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Obtain token

--- a/.github/workflows/renovate-automatic-approval.yml
+++ b/.github/workflows/renovate-automatic-approval.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches:
-      - "renovate/**"
+      - "test/**"
 
 jobs:
   approve-renovate-prs:

--- a/.github/workflows/renovate-automatic-approval.yml
+++ b/.github/workflows/renovate-automatic-approval.yml
@@ -2,8 +2,6 @@ name: "[Dependency Updates] Auto Approve"
 on:
   pull_request:
     types: [opened, synchronize]
-    branches:
-      - "test/**"
 
 jobs:
   approve-renovate-prs:

--- a/.github/workflows/renovate-automatic-approval.yml
+++ b/.github/workflows/renovate-automatic-approval.yml
@@ -8,8 +8,9 @@ on:
 jobs:
   approve-renovate-prs:
     runs-on: ubuntu-latest
-    if: github.actor == 'homarr-renovate'
     steps:
+      - name: Echo github payload
+        run: echo '${{ toJson(github) }}' && exit 1
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Obtain token


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

The issue lied in my understanding of the branches restriction. I meant that it would restrict the head branches but it actually restricts based on the base branches. Additionally I replaced the actor name with an id so now it is impossible to fake it as only the github app has this id