### PR TITLE
feat: add hotkeys

### DIFF
--- a/apps/nextjs/src/app/[locale]/boards/(content)/_header-actions.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_header-actions.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback } from "react";
 import { Group, Menu } from "@mantine/core";
+import { useHotkeys } from "@mantine/hooks";
 import {
   IconBox,
   IconBoxAlignTop,
@@ -138,6 +139,8 @@ const EditModeMenu = () => {
     if (isEditMode) return saveBoard(board);
     setEditMode(true);
   }, [board, isEditMode, saveBoard, setEditMode]);
+
+  useHotkeys([["mod+e", toggle]]);
 
   return (
     <HeaderButton onClick={toggle} loading={isPending}>

--- a/apps/nextjs/src/components/user-avatar-menu.tsx
+++ b/apps/nextjs/src/components/user-avatar-menu.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Center, Menu, Stack, Text, useMantineColorScheme } from "@mantine/core";
-import { useTimeout } from "@mantine/hooks";
+import { useHotkeys, useTimeout } from "@mantine/hooks";
 import {
   IconCheck,
   IconHome,
@@ -33,6 +33,7 @@ interface UserAvatarMenuProps {
 export const UserAvatarMenu = ({ children }: UserAvatarMenuProps) => {
   const t = useScopedI18n("common.userAvatar.menu");
   const { colorScheme, toggleColorScheme } = useMantineColorScheme();
+  useHotkeys([["mod+J", toggleColorScheme]]);
 
   const ColorSchemeIcon = colorScheme === "dark" ? IconSun : IconMoon;
 

--- a/packages/widgets/src/notebook/notebook.tsx
+++ b/packages/widgets/src/notebook/notebook.tsx
@@ -15,7 +15,7 @@ import {
   useMantineColorScheme,
   useMantineTheme,
 } from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
+import { getHotkeyHandler, useDisclosure } from "@mantine/hooks";
 import { Link, RichTextEditor, useRichTextEditorContext } from "@mantine/tiptap";
 import {
   IconCheck,
@@ -231,6 +231,7 @@ export function Notebook({ options, isEditMode, boardId, itemId }: WidgetCompone
         p={0}
         mt={0}
         h="100%"
+        onKeyDown={isEditing ? getHotkeyHandler([["mod+s", handleEditToggle]]) : undefined}
         editor={editor}
         styles={(theme) => ({
           root: {


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

This adds the following hotkeys:

- `mod + e` to toggle edit mode
- `mod + j` to toggle color scheme
- `mod + s` (only inside the notebook widget) save the notebook
