### PR TITLE
fix: empty wrappers without items should not be visible in view mode

### DIFF
--- a/apps/nextjs/src/styles/gridstack.scss
+++ b/apps/nextjs/src/styles/gridstack.scss
@@ -100,7 +100,9 @@
   transition: none;
 }
 
-.gridstack-empty-wrapper {
-  height: 0px;
-  min-height: 0px !important;
+/**
+ * Hide empty wrapper (class is used when no items are inside and not in edit mode)
+ */
+.grid-stack-empty-wrapper {
+  display: none !important;
 }


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

This will resolve the following issues from oldmarr:
- https://github.com/ajnart/homarr/issues/746
- https://github.com/ajnart/homarr/issues/1496
- https://github.com/ajnart/homarr/issues/1901