### PR TITLE
fix: hard to move iframe widget #1075

### DIFF
--- a/packages/widgets/src/iframe/component.tsx
+++ b/packages/widgets/src/iframe/component.tsx
@@ -7,7 +7,7 @@ import { useI18n } from "@homarr/translation/client";
 import type { WidgetComponentProps } from "../definition";
 import classes from "./component.module.css";
 
-export default function IFrameWidget({ options }: WidgetComponentProps<"iframe">) {
+export default function IFrameWidget({ options, isEditMode }: WidgetComponentProps<"iframe">) {
   const t = useI18n();
   const { embedUrl, ...permissions } = options;
   const allowedPermissions = getAllowedPermissions(permissions);
@@ -16,7 +16,13 @@ export default function IFrameWidget({ options }: WidgetComponentProps<"iframe">
 
   return (
     <Box h="100%" w="100%">
-      <iframe className={classes.iframe} src={embedUrl} title="widget iframe" allow={allowedPermissions.join(" ")}>
+      <iframe
+        style={isEditMode ? { userSelect: "none", pointerEvents: "none" } : undefined}
+        className={classes.iframe}
+        src={embedUrl}
+        title="widget iframe"
+        allow={allowedPermissions.join(" ")}
+      >
         <Text>{t("widget.iframe.error.noBrowerSupport")}</Text>
       </iframe>
     </Box>


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Now the iframe can be moved in edit mode as the user wants, the content can not be interacted with during edit mode.
Closes #1075