### PR TITLE
refactor: Remove typed-rpc dependency and used fetch instead

### DIFF
--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -33,8 +33,7 @@
     "@homarr/log": "workspace:^0.1.0",
     "@homarr/translation": "workspace:^0.1.0",
     "@homarr/validation": "workspace:^0.1.0",
-    "@jellyfin/sdk": "^0.10.0",
-    "typed-rpc": "^5.1.0"
+    "@jellyfin/sdk": "^0.10.0"
   },
   "devDependencies": {
     "@homarr/eslint-config": "workspace:^0.2.0",

--- a/packages/integrations/src/download-client/nzbget/nzbget-types.ts
+++ b/packages/integrations/src/download-client/nzbget/nzbget-types.ts
@@ -1,20 +1,9 @@
-export interface NzbGetClient {
-  version: () => string;
-  status: () => NzbGetStatus;
-  listgroups: () => NzbGetGroup[];
-  history: () => NzbGetHistory[];
-  pausedownload: () => void;
-  resumedownload: () => void;
-  editqueue: (Command: string, Param: string, IDs: number[]) => void;
-  listfiles: (IDFrom: number, IDTo: number, NZBID: number) => { ID: number }[];
-}
-
-interface NzbGetStatus {
+export interface NzbGetStatus {
   DownloadPaused: boolean;
   DownloadRate: number;
 }
 
-interface NzbGetGroup {
+export interface NzbGetGroup {
   Status: string;
   NZBID: number;
   MaxPriority: number;
@@ -30,7 +19,7 @@ interface NzbGetGroup {
   FileSizeMB: number;
 }
 
-interface NzbGetHistory {
+export interface NzbGetHistory {
   ScriptStatus: string;
   NZBID: number;
   Name: string;

--- a/packages/integrations/src/download-client/nzbget/nzbget-types.ts
+++ b/packages/integrations/src/download-client/nzbget/nzbget-types.ts
@@ -1,9 +1,20 @@
-export interface NzbGetStatus {
+export interface NzbGetClient {
+  version: () => string;
+  status: () => NzbGetStatus;
+  listgroups: () => NzbGetGroup[];
+  history: () => NzbGetHistory[];
+  pausedownload: () => void;
+  resumedownload: () => void;
+  editqueue: (Command: string, Param: string, IDs: number[]) => void;
+  listfiles: (IDFrom: number, IDTo: number, NZBID: number) => { ID: number }[];
+}
+
+interface NzbGetStatus {
   DownloadPaused: boolean;
   DownloadRate: number;
 }
 
-export interface NzbGetGroup {
+interface NzbGetGroup {
   Status: string;
   NZBID: number;
   MaxPriority: number;
@@ -19,7 +30,7 @@ export interface NzbGetGroup {
   FileSizeMB: number;
 }
 
-export interface NzbGetHistory {
+interface NzbGetHistory {
   ScriptStatus: string;
   NZBID: number;
   Name: string;

--- a/packages/integrations/test/nzbget.spec.ts
+++ b/packages/integrations/test/nzbget.spec.ts
@@ -125,7 +125,7 @@ describe("Nzbget integration", () => {
 
     // Act
     const getAsync = async () => await nzbGetIntegration.getClientJobsAndStatusAsync();
-    const actAsync = async () => await nzbGetIntegration.deleteItemAsync(item, false);
+    const actAsync = async () => await nzbGetIntegration.deleteItemAsync(item, true);
 
     // Assert
     await expect(actAsync()).resolves.not.toThrow();

--- a/packages/widgets/src/downloads/component.tsx
+++ b/packages/widgets/src/downloads/component.tsx
@@ -831,6 +831,7 @@ const ClientsControl = ({ clients, style }: ClientsControlProps) => {
         px="calc(var(--space-size)*2)"
         fw="500"
         onClick={open}
+        styles={{ label: { height: "fit-content", paddingBottom: "calc(var(--space-size)*0.75)" } }}
       >
         {totalSpeed}
       </Button>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -986,9 +986,6 @@ importers:
       '@jellyfin/sdk':
         specifier: ^0.10.0
         version: 0.10.0(axios@1.7.2)
-      typed-rpc:
-        specifier: ^5.1.0
-        version: 5.1.0
     devDependencies:
       '@homarr/eslint-config':
         specifier: workspace:^0.2.0
@@ -7203,9 +7200,6 @@ packages:
   typed-array-length@1.0.6:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
-
-  typed-rpc@5.1.0:
-    resolution: {integrity: sha512-qPWUQrLye3Z5kQ8GuVLIURIUNPaDrKgBBts5nXVjR87j8+4sva/sw7lmaBfOw+7m/S4F9jplkv9XZl0hUDUHZg==}
 
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
@@ -13991,8 +13985,6 @@ snapshots:
       has-proto: 1.0.3
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
-
-  typed-rpc@5.1.0: {}
 
   typedarray-to-buffer@3.1.5:
     dependencies:


### PR DESCRIPTION
Fetch method POST achieves basically the same as typed-rpc.
Could actually use all that was already made and just swap it.
Allows to remove a dependency.

Closes #1104 
To delete once merged