### PR TITLE
feat: Add Simple-Icons and Selfh.st collections

### DIFF
--- a/packages/icons/src/icons-fetcher.ts
+++ b/packages/icons/src/icons-fetcher.ts
@@ -11,6 +11,22 @@ const repositories = [
     new URL("https://api.github.com/repos/walkxcode/dashboard-icons/git/trees/main?recursive=true"),
     "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/{0}",
   ),
+  new GitHubIconRepository(
+    "selfh.st",
+    "selfhst/icons",
+    "CC0-1.0",
+    new URL("https://github.com/selfhst/icons"),
+    new URL("https://api.github.com/repos/selfhst/icons/git/trees/main?recursive=true"),
+    "https://cdn.jsdelivr.net/gh/selfhst/icons/{0}",
+  ),
+  new GitHubIconRepository(
+    "SimpleIcons",
+    "simple-icons/simple-icons",
+    "CC0-1.0",
+    new URL("https://github.com/simple-icons/simple-icons"),
+    new URL("https://api.github.com/repos/simple-icons/simple-icons/git/trees/master?recursive=true"),
+    "https://cdn.simpleicons.org/{1}",
+  ),
   new JsdelivrIconRepository(
     "Papirus",
     "PapirusDevelopmentTeam/papirus-icon-theme",

--- a/packages/icons/src/repositories/github.icon-repository.ts
+++ b/packages/icons/src/repositories/github.icon-repository.ts
@@ -29,7 +29,9 @@ export class GitHubIconRepository extends IconRepository {
     return {
       success: true,
       icons: listOfFiles.tree
-        .filter(({ path }) => this.allowedImageFileTypes.some((allowedExtension) => path.includes(allowedExtension)))
+        .filter(({ path }) =>
+          this.allowedImageFileTypes.some((allowedImageFileType) => parse(path).ext === allowedImageFileType),
+        )
         .map(({ path, size: sizeInBytes, sha: checksum }) => {
           const file = parse(path);
           const fileNameWithExtension = file.base;

--- a/packages/icons/src/repositories/icon-repository.ts
+++ b/packages/icons/src/repositories/icon-repository.ts
@@ -29,8 +29,4 @@ export abstract class IconRepository {
   }
 
   protected abstract getAllIconsInternalAsync(): Promise<RepositoryIconGroup>;
-
-  protected getFileNameWithoutExtensionFromPath(path: string) {
-    return path.replace(/^.*[\\/]/, "");
-  }
 }

--- a/packages/icons/src/repositories/jsdelivr.icon-repository.ts
+++ b/packages/icons/src/repositories/jsdelivr.icon-repository.ts
@@ -1,3 +1,5 @@
+import { parse } from "path";
+
 import { fetchWithTimeout } from "@homarr/common";
 
 import type { IconRepositoryLicense } from "../types/icon-repository-license";
@@ -23,18 +25,19 @@ export class JsdelivrIconRepository extends IconRepository {
     return {
       success: true,
       icons: listOfFiles.files
-        .filter((file) =>
-          this.allowedImageFileTypes.some((allowedImageFileType) => file.name.includes(allowedImageFileType)),
+        .filter(({ name: path }) =>
+          this.allowedImageFileTypes.some((allowedImageFileType) => path.includes(allowedImageFileType)),
         )
-        .map((file) => {
-          const fileNameWithExtension = this.getFileNameWithoutExtensionFromPath(file.name);
+        .map(({ name: path, size: sizeInBytes, hash: checksum }) => {
+          const file = parse(path);
+          const fileNameWithExtension = file.base;
 
           return {
-            imageUrl: new URL(this.repositoryBlobUrlTemplate.replace("{0}", file.name)),
-            fileNameWithExtension: fileNameWithExtension,
+            imageUrl: new URL(this.repositoryBlobUrlTemplate.replace("{0}", path).replace("{1}", file.name)),
+            fileNameWithExtension,
             local: false,
-            sizeInBytes: file.size,
-            checksum: file.hash,
+            sizeInBytes,
+            checksum,
           };
         }),
       slug: this.slug,

--- a/packages/icons/src/repositories/jsdelivr.icon-repository.ts
+++ b/packages/icons/src/repositories/jsdelivr.icon-repository.ts
@@ -26,7 +26,7 @@ export class JsdelivrIconRepository extends IconRepository {
       success: true,
       icons: listOfFiles.files
         .filter(({ name: path }) =>
-          this.allowedImageFileTypes.some((allowedImageFileType) => path.includes(allowedImageFileType)),
+          this.allowedImageFileTypes.some((allowedImageFileType) => parse(path).ext === allowedImageFileType),
         )
         .map(({ name: path, size: sizeInBytes, hash: checksum }) => {
           const file = parse(path);

--- a/packages/icons/src/types/icon-repository-license.ts
+++ b/packages/icons/src/types/icon-repository-license.ts
@@ -1,1 +1,1 @@
-export type IconRepositoryLicense = "MIT" | "GPL-3.0" | undefined;
+export type IconRepositoryLicense = "MIT" | "GPL-3.0" | "CC0-1.0" | undefined;


### PR DESCRIPTION
Closes #1105

Add Simple-Icons:
> Monochrome Icons.
> Can change color by adding "/{colour}" at the end of the link, can also be in hex format.

Add Selfh.st icons:
> Self-hosting focused collection.
> Completes current collections with icons that are not available from other sources.

Refactor:
> Change regex function (Wrongly named too btw) with path parse.
> Add blob replace: "{1}" -> icon name only and not whole path.
> Improve file extension checker

This pushes us over the 10k icons