### PR TITLE
fix: various issues with docker image workflow

### DIFF
--- a/.github/workflows/deployment-docker-image.yml
+++ b/.github/workflows/deployment-docker-image.yml
@@ -38,7 +38,7 @@ jobs:
         node-version: [20]
     steps:
       - name: Discord notification
-        if: ${{ github.events.inputs.send-notifications || true }}
+        if: ${{ github.events.inputs.send-notifications != false }}
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master
@@ -52,7 +52,7 @@ jobs:
           token: ${{ github.token }}
           branch: dev
       - name: Discord notification
-        if: ${{ github.events.inputs.send-notifications || true }}
+        if: ${{ github.events.inputs.send-notifications != false }}
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master
@@ -66,7 +66,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Discord notification
-        if: ${{ github.events.inputs.send-notifications || true }}
+        if: ${{ github.events.inputs.send-notifications != false }}
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master
@@ -120,14 +120,14 @@ jobs:
         env:
           SKIP_ENV_VALIDATION: true
       - name: Discord notification
-        if: ${{ github.events.inputs.send-notifications || true && (github.events.inputs.push-image == 'true' || github.events.inputs.push-image == null) }}
+        if: ${{ github.events.inputs.send-notifications != false && (github.events.inputs.push-image == 'true' || github.events.inputs.push-image == null) }}
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master
         with:
           args: "Deployment of image has completed. Image ID is '${{ steps.buildPushAction.outputs.imageid }}'."
       - name: Discord notification
-        if: ${{ github.events.inputs.send-notifications || true && !(github.events.inputs.push-image == 'true' || github.events.inputs.push-image == null) }}
+        if: ${{ github.events.inputs.send-notifications != false && !(github.events.inputs.push-image == 'true' || github.events.inputs.push-image == null) }}
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         uses: Ilshidur/action-discord@master


### PR DESCRIPTION
The conditional statements were all in the form of `input || true`, presumably in an effort to treat this as `true` if the input was not set as it would be when the trigger is a push rather than a manual dispatch (`null || true` => `true`). However `false || true` also results in `true`, so this would just always result in `true`.

Changing this to `!= false` does result in the desired behaviour:

- Enabled: `true != false` => `true`
- Disabled: `false != false` => `false`
- Unset: `null != false` => `true`

---

It was always looking at the `dev` branch for the commit messages in the versioning step, which meant that running it against a different branch would not have the desired result.