### PR TITLE
fix: container image always being on AMD64 arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:20.17.0-alpine AS base
+FROM node:20.17.0-alpine AS base
 
 FROM base AS builder
 RUN apk add --no-cache libc6-compat


### PR DESCRIPTION
The container image always used an amd64 image as base, both for the build steps as well as for the runtime. For the runner this resulted in the containers just not booting with the error `exec /usr/local/bin/docker-entrypoint.sh: exec format error`.

I first tried fixing this by adjusting this only for the runner, but this resulted in a segfault later on, presumably due to some binary component in the build/dependencies that was now build for the wrong architecture, so I just ended up switching the entire thing over to use the target architecture.

Fixes #1125.