### PR TITLE
fix: confirm not selected by default in confirm modal

### DIFF
--- a/packages/modals/src/confirm-modal.tsx
+++ b/packages/modals/src/confirm-modal.tsx
@@ -85,7 +85,7 @@ export const ConfirmModal = createModal<Omit<ConfirmModalProps, "title">>(({ act
           {cancelProps?.children ?? translateIfNecessary(t, cancelLabel)}
         </Button>
 
-        <Button {...confirmProps} onClick={handleConfirm} color="red.9" loading={loading}>
+        <Button data-autofocus {...confirmProps} onClick={handleConfirm} color="red.9" loading={loading}>
           {confirmProps?.children ?? translateIfNecessary(t, confirmLabel)}
         </Button>
       </Group>


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Resolves https://discord.com/channels/972958686051962910/1267085405631807548