### PR TITLE
feat: add hotkeys list to about page

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/about/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/about/page.tsx
@@ -170,20 +170,16 @@ export default async function AboutPage() {
               </thead>
               <tbody>
                 <tr>
+                  <td><Kbd>mod+e</Kbd></td>
+                  <td>{t("accordion.hotkeys.keys.toggleEdit")}</td>
+                </tr>
+                <tr>
                   <td><Kbd>mod+j</Kbd></td>
                   <td>{t("accordion.hotkeys.keys.toggleTheme")}</td>
                 </tr>
                 <tr>
-                  <td><Kbd>mod+k</Kbd></td>
-                  <td>{t("accordion.hotkeys.keys.focusSearchBar")}</td>
-                </tr>
-                <tr>
-                  <td><Kbd>mod+b</Kbd></td>
-                  <td>{t("accordion.hotkeys.keys.openDocker")}</td>
-                </tr>
-                <tr>
-                  <td><Kbd>mod+e</Kbd></td>
-                  <td>{t("accordion.hotkeys.keys.toggleEdit")}</td>
+                  <td><Kbd>mod+s</Kbd></td>
+                  <td>{t("accordion.hotkeys.keys.saveNotebook")}</td>
                 </tr>
               </tbody>
             </Table>

--- a/apps/nextjs/src/app/[locale]/manage/about/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/about/page.tsx
@@ -11,13 +11,15 @@ import {
   Center,
   Flex,
   Group,
+  Kbd,
   List,
   ListItem,
   Stack,
+  Table,
   Text,
   Title,
 } from "@mantine/core";
-import { IconLanguage, IconLibrary, IconUsers } from "@tabler/icons-react";
+import { IconKeyboard, IconLanguage, IconLibrary, IconUsers } from "@tabler/icons-react";
 
 import { getScopedI18n } from "@homarr/translation/server";
 
@@ -147,6 +149,47 @@ export default async function AboutPage() {
                   </ListItem>
                 ))}
             </List>
+          </AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value="hotkeys">
+          <AccordionControl icon={<IconKeyboard size="1rem" />}>
+            <Stack gap={0}>
+              <Text>{t("accordion.hotkeys.title")}</Text>
+              <Text size="sm" c="dimmed">
+                {t("accordion.hotkeys.subtitle")}
+              </Text>
+            </Stack>
+          </AccordionControl>
+          <AccordionPanel>
+            <Table>
+              <thead>
+                <tr>
+                  <th>Shortcut</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><Kbd>mod+j</Kbd></td>
+                  <td>{t("accordion.hotkeys.keys.toggleTheme")}</td>
+                </tr>
+                <tr>
+                  <td><Kbd>mod+k</Kbd></td>
+                  <td>{t("accordion.hotkeys.keys.focusSearchBar")}</td>
+                </tr>
+                <tr>
+                  <td><Kbd>mod+b</Kbd></td>
+                  <td>{t("accordion.hotkeys.keys.openDocker")}</td>
+                </tr>
+                <tr>
+                  <td><Kbd>mod+e</Kbd></td>
+                  <td>{t("accordion.hotkeys.keys.toggleEdit")}</td>
+                </tr>
+              </tbody>
+            </Table>
+            <Text mt="sm" size="sm" c="dimmed">
+              {t("accordion.hotkeys.tip")}
+            </Text>
           </AccordionPanel>
         </AccordionItem>
       </Accordion>

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -2126,9 +2126,8 @@
             "subtitle": "Keyboard shortcuts to enhance your workflow",
             "keys": {
               "toggleTheme": "Toggle light/dark mode",
-              "focusSearchBar": "Focus on search bar",
-              "openDocker": "Open docker widget",
-              "toggleEdit": "Toggle edit mode"
+              "toggleEdit": "Toggle edit mode",
+              "saveNotebook": "Save notebook (only inside notebook widget)"
             },
             "tip": "Mod refers to your modifier key, it is Ctrl and Command/Super/Windows key"
           }

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -2120,6 +2120,17 @@
           "libraries": {
             "title": "Libraries",
             "subtitle": "{count} used in the Code of Homarr"
+          },
+          "hotkeys": {
+            "title": "Hotkeys",
+            "subtitle": "Keyboard shortcuts to enhance your workflow",
+            "keys": {
+              "toggleTheme": "Toggle light/dark mode",
+              "focusSearchBar": "Focus on search bar",
+              "openDocker": "Open docker widget",
+              "toggleEdit": "Toggle edit mode"
+            },
+            "tip": "Mod refers to your modifier key, it is Ctrl and Command/Super/Windows key"
           }
         }
       }


### PR DESCRIPTION
Fixes #994

Added a hotkeys section to the about page that shows all available keyboard shortcuts:

- Added new accordion section for hotkeys
- Used Mantine components (Kbd, Table) for consistent styling
- Added translations for all hotkeys and descriptions
- Included tip about the Mod key
- Follows the style of the existing about page

The hotkeys are displayed in a table format with proper keyboard shortcut styling using the Kbd component.