### PR TITLE
fix: user is undefined when using use-suspense-query

### DIFF
--- a/apps/nextjs/src/app/[locale]/_client-providers/trpc.tsx
+++ b/apps/nextjs/src/app/[locale]/_client-providers/trpc.tsx
@@ -17,7 +17,7 @@ import {
 import superjson from "superjson";
 
 import type { AppRouter } from "@homarr/api";
-import { clientApi } from "@homarr/api/client";
+import { clientApi, createHeadersCallbackForSource, getTrpcUrl } from "@homarr/api/client";
 
 import { env } from "~/env.mjs";
 
@@ -86,16 +86,13 @@ export function TRPCReactProvider(props: PropsWithChildren) {
                   return data;
                 },
               },
-              url: `${getBaseUrl()}/api/trpc`,
+              url: getTrpcUrl(),
+              headers: createHeadersCallbackForSource("nextjs-react (form-data)"),
             }),
             false: unstable_httpBatchStreamLink({
               transformer: superjson,
-              url: `${getBaseUrl()}/api/trpc`,
-              headers() {
-                const headers = new Headers();
-                headers.set("x-trpc-source", "nextjs-react");
-                return headers;
-              },
+              url: getTrpcUrl(),
+              headers: createHeadersCallbackForSource("nextjs-react (json)"),
             }),
           }),
         }),
@@ -111,10 +108,4 @@ export function TRPCReactProvider(props: PropsWithChildren) {
       </QueryClientProvider>
     </clientApi.Provider>
   );
-}
-
-function getBaseUrl() {
-  if (typeof window !== "undefined") return window.location.origin;
-  if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
-  return `http://localhost:${process.env.PORT ?? 3000}`;
 }

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -7,13 +7,9 @@ export const clientApi = createTRPCReact<AppRouter>();
 export const fetchApi = createTRPCClient<AppRouter>({
   links: [
     httpLink({
-      url: `${getBaseUrl()}/api/trpc`,
+      url: getTrpcUrl(),
       transformer: SuperJSON,
-      headers() {
-        const headers = new Headers();
-        headers.set("x-trpc-source", "fetch");
-        return headers;
-      },
+      headers: createHeadersCallbackForSource("fetch"),
     }),
   ],
 });
@@ -22,4 +18,51 @@ function getBaseUrl() {
   if (typeof window !== "undefined") return window.location.origin;
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
   return `http://localhost:${process.env.PORT ?? 3000}`;
+}
+
+/**
+ * Creates the full url for the trpc api endpoint
+ * @returns
+ */
+export function getTrpcUrl() {
+  return `${getBaseUrl()}/api/trpc`;
+}
+
+/**
+ * Creates a headers callback for a given source
+ * It will set the x-trpc-source header and cookies if needed
+ * @param source trpc source request comes from
+ * @returns headers callback
+ */
+export function createHeadersCallbackForSource(source: string) {
+  return async () => {
+    const headers = new Headers();
+    headers.set("x-trpc-source", source);
+
+    const cookies = await importCookiesAsync();
+    // We need to set cookie for ssr requests (for example with useSuspenseQuery or middleware)
+    if (cookies) {
+      headers.set("cookie", cookies);
+    }
+
+    return headers;
+  };
+}
+
+/**
+ * This is a workarround as cookies are not passed to the server
+ * when using useSuspenseQuery or middleware
+ * @returns cookie string on server or null on client
+ */
+async function importCookiesAsync() {
+  if (typeof window === "undefined") {
+    return await import("next/headers").then(({ cookies }) =>
+      cookies()
+        .getAll()
+        .map(({ name, value }) => `${name}=${value}`)
+        .join(";"),
+    );
+  }
+
+  return null;
 }


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Thanks to esavitskiy I've found a pretty straight forward solution. We just pass the cookie string as header when suspense-query is executed server side. See https://github.com/apollographql/apollo-client-nextjs/issues/85#issuecomment-1952430214
Using cookies() directly does not work as it's a client component

**Before**
![image](https://github.com/user-attachments/assets/8010ac5a-4907-4b97-8633-9e6ea2fee23d)
![image](https://github.com/user-attachments/assets/50bba737-dff2-4ea2-8943-4028c6d1d46d)

**After**
![image](https://github.com/user-attachments/assets/2c0b6f11-2f50-492d-8016-4a93c6b60137)
