### PR TITLE
fix: dispatch request-logger hides negative numbers, dates and date times

### DIFF
--- a/apps/tasks/src/test/undici-log-agent-override.spec.ts
+++ b/apps/tasks/src/test/undici-log-agent-override.spec.ts
@@ -1,0 +1,99 @@
+import type { Dispatcher } from "undici";
+import { describe, expect, test, vi } from "vitest";
+
+import { logger } from "@homarr/log";
+
+import { LoggingAgent } from "~/undici-log-agent-override";
+
+vi.mock("undici", () => {
+  return {
+    Agent: class Agent {
+      dispatch(_options: Dispatcher.DispatchOptions, _handler: Dispatcher.DispatchHandlers): boolean {
+        return true;
+      }
+    },
+    setGlobalDispatcher: () => undefined,
+  };
+});
+
+const REDACTED = "REDACTED";
+
+describe("LoggingAgent should log all requests", () => {
+  test("should log all requests", () => {
+    // Arrange
+    const infoLogSpy = vi.spyOn(logger, "info");
+    const agent = new LoggingAgent();
+
+    // Act
+    agent.dispatch({ origin: "https://homarr.dev", path: "/", method: "GET" }, {});
+
+    // Assert
+    expect(infoLogSpy).toHaveBeenCalledWith("Dispatching request https://homarr.dev/ (0 headers)");
+  });
+
+  test("should show amount of headers", () => {
+    // Arrange
+    const infoLogSpy = vi.spyOn(logger, "info");
+    const agent = new LoggingAgent();
+
+    // Act
+    agent.dispatch(
+      {
+        origin: "https://homarr.dev",
+        path: "/",
+        method: "GET",
+        headers: {
+          "Content-Type": "text/html",
+          "User-Agent": "Mozilla/5.0",
+        },
+      },
+      {},
+    );
+
+    // Assert
+    expect(infoLogSpy).toHaveBeenCalledWith(expect.stringContaining("(2 headers)"));
+  });
+
+  test.each([
+    ["/?hex=a3815e8ada2ef9a31", `/?hex=${REDACTED}`],
+    ["/?uuid=f7c3f65e-c511-4f90-ba9a-3fd31418bd49", `/?uuid=${REDACTED}`],
+    ["/?password=complexPassword123", `/?password=${REDACTED}`],
+    [
+      // JWT for John Doe
+      "/?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+      `/?jwt=${REDACTED}`,
+    ],
+    ["/?one=a1&two=b2&three=c3", `/?one=${REDACTED}&two=${REDACTED}&three=${REDACTED}`],
+    ["/?numberWith13Chars=1234567890123", `/?numberWith13Chars=${REDACTED}`],
+    [`/?stringWith13Chars=${"a".repeat(13)}`, `/?stringWith13Chars=${REDACTED}`],
+  ])(`should redact sensitive data in url https://homarr.dev%s`, (path, expected) => {
+    // Arrange
+    const infoLogSpy = vi.spyOn(logger, "info");
+    const agent = new LoggingAgent();
+
+    // Act
+    agent.dispatch({ origin: "https://homarr.dev", path, method: "GET" }, {});
+
+    // Assert
+    expect(infoLogSpy).toHaveBeenCalledWith(expect.stringContaining(` https://homarr.dev${expected} `));
+  });
+  test.each([
+    ["empty", "/?empty"],
+    ["numbers with max 12 chars", "/?number=123456789012"],
+    ["true", "/?true=true"],
+    ["false", "/?false=false"],
+    ["strings with max 12 chars", `/?short=${"a".repeat(12)}`],
+    ["dates", "/?date=2022-01-01"],
+    ["date times", "/?datetime=2022-01-01T00:00:00.000Z"],
+  ])("should not redact values that are %s", (_reason, path) => {
+    // Arrange
+    const infoLogSpy = vi.spyOn(logger, "info");
+    const agent = new LoggingAgent();
+
+    // Act
+    agent.dispatch({ origin: "https://homarr.dev", path, method: "GET" }, {});
+
+    // Assert
+    expect(infoLogSpy).toHaveBeenCalledWith(expect.stringContaining(` https://homarr.dev${path} `));
+  });
+});

--- a/apps/tasks/src/test/undici-log-agent-override.spec.ts
+++ b/apps/tasks/src/test/undici-log-agent-override.spec.ts
@@ -66,7 +66,7 @@ describe("LoggingAgent should log all requests", () => {
     ["/?one=a1&two=b2&three=c3", `/?one=${REDACTED}&two=${REDACTED}&three=${REDACTED}`],
     ["/?numberWith13Chars=1234567890123", `/?numberWith13Chars=${REDACTED}`],
     [`/?stringWith13Chars=${"a".repeat(13)}`, `/?stringWith13Chars=${REDACTED}`],
-  ])(`should redact sensitive data in url https://homarr.dev%s`, (path, expected) => {
+  ])("should redact sensitive data in url https://homarr.dev%s", (path, expected) => {
     // Arrange
     const infoLogSpy = vi.spyOn(logger, "info");
     const agent = new LoggingAgent();

--- a/apps/tasks/src/undici-log-agent-override.ts
+++ b/apps/tasks/src/undici-log-agent-override.ts
@@ -3,7 +3,7 @@ import { Agent, setGlobalDispatcher } from "undici";
 
 import { logger } from "@homarr/log";
 
-class LoggingAgent extends Agent {
+export class LoggingAgent extends Agent {
   constructor(...props: ConstructorParameters<typeof Agent>) {
     super(...props);
   }
@@ -25,7 +25,7 @@ class LoggingAgent extends Agent {
     });
 
     logger.info(
-      `Dispatching request ${url.toString().replaceAll("=&", "&")} (${Object.keys(options.headers as object).length} headers)`,
+      `Dispatching request ${url.toString().replaceAll("=&", "&")} (${Object.keys(options.headers ?? {}).length} headers)`,
     );
     return super.dispatch(options, handler);
   }

--- a/apps/tasks/src/undici-log-agent-override.ts
+++ b/apps/tasks/src/undici-log-agent-override.ts
@@ -15,9 +15,11 @@ class LoggingAgent extends Agent {
     // some integrations use query parameters for auth
     url.searchParams.forEach((value, key) => {
       if (value === "") return; // Skip empty values
-      if (/^\d{1,12}$/.test(value)) return; // Skip small numbers
+      if (/^-?\d{1,12}$/.test(value)) return; // Skip small numbers
       if (value === "true" || value === "false") return; // Skip boolean values
       if (/^[a-zA-Z]{1,12}$/.test(value)) return; // Skip short strings
+      if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return; // Skip dates
+      if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) return; // Skip date times
 
       url.searchParams.set(key, "REDACTED");
     });


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

![image](https://github.com/user-attachments/assets/6c3f0600-447d-4e1d-835d-7c31e2e01f7c)
![image](https://github.com/user-attachments/assets/fb08163a-7a7f-4cc9-8dd1-1ca2d97d5675)
![image](https://github.com/user-attachments/assets/d18e45ef-29d1-4090-8227-82df1afa00cd)

**Tests**
![image](https://github.com/user-attachments/assets/19d8a8d8-1d75-45d2-a38e-77b2e5c1d7b9)
