### PR TITLE
fix: matcher for translation middleware only supports en and de

### DIFF
--- a/packages/translation/src/middleware.ts
+++ b/packages/translation/src/middleware.ts
@@ -1,6 +1,7 @@
 import createMiddleware from "next-intl/middleware";
 
 import type { SupportedLanguage } from ".";
+import { supportedLanguages } from "./config";
 import { createRouting } from "./routing";
 
 export const createI18nMiddleware = (defaultLocale: SupportedLanguage) =>
@@ -8,5 +9,5 @@ export const createI18nMiddleware = (defaultLocale: SupportedLanguage) =>
 
 export const config = {
   // Match only internationalized pathnames
-  matcher: ["/", "/(de|en)/:path*"],
+  matcher: ["/", `/(${supportedLanguages.join("|")})/:path*`],
 };


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

