### PR TITLE
fix: add beforeunload logic for board in edit mode

### DIFF
--- a/apps/nextjs/src/components/user-avatar-menu.tsx
+++ b/apps/nextjs/src/components/user-avatar-menu.tsx
@@ -61,7 +61,8 @@ export const UserAvatarMenu = ({ children }: UserAvatarMenuProps) => {
   }, [logoutUrl, openModal, router]);
 
   return (
-    <Menu width={300} withArrow withinPortal>
+    // We use keepMounted so we can add event listeners to prevent navigating away without saving the board
+    <Menu width={300} withArrow withinPortal keepMounted>
       <Menu.Dropdown>
         <Menu.Item onClick={toggleColorScheme} leftSection={<ColorSchemeIcon size="1rem" />}>
           {colorSchemeText}

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -1563,6 +1563,10 @@
             "title": "Unable to apply changes",
             "message": "The board could not be saved"
           }
+        },
+        "confirmLeave": {
+          "title": "Unsaved changes",
+          "message": "You have unsaved changes, are you sure you want to leave?"
         }
       },
       "oldImport": {


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

