### PR TITLE
fix: icon picker suspense issue

### DIFF
--- a/apps/nextjs/src/components/icons/picker/icon-picker.tsx
+++ b/apps/nextjs/src/components/icons/picker/icon-picker.tsx
@@ -38,7 +38,7 @@ export const IconPicker = ({ initialValue, onChange, error, onFocus, onBlur }: I
   const [debouncedSearch] = useDebouncedValue(search, 100);
 
   // We use not useSuspenseQuery as it would cause an above Suspense boundary to trigger and so searching for something is bad UX.
-  const { data, isLoading } = clientApi.icon.findIcons.useQuery({
+  const { data } = clientApi.icon.findIcons.useQuery({
     searchText: debouncedSearch,
   });
 


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Previously the whole page showed a loading spinner and most of the times you were not able to enter even one character. Now it just works. Also added a debounce to not spam the server to much.