### PR TITLE
fix: fix binary conflicts for linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
This fixes an issue on linux where the line endings would result in the following changes:

![image](https://github.com/user-attachments/assets/bcffd542-3f6a-4e7f-9fa9-b90f3440f12e)
