### PR TITLE
fix: remove unnecessary complex copy and build steps in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,45 +6,14 @@ RUN apk update
 
 # Set working directory
 WORKDIR /app
-COPY . .
-RUN npm i -g turbo
-RUN turbo prune @homarr/nextjs --docker --out-dir ./next-out
-RUN turbo prune @homarr/tasks --docker --out-dir ./tasks-out
-RUN turbo prune @homarr/websocket --docker --out-dir ./websocket-out
-RUN turbo prune @homarr/db --docker --out-dir ./migration-out
-RUN turbo prune @homarr/cli --docker --out-dir ./cli-out
-
-# Add lockfile and package.json's of isolated subworkspace
-FROM base AS installer
 RUN apk add --no-cache libc6-compat curl bash
 RUN apk update
-WORKDIR /app
+COPY . .
 
-# First install the dependencies (as they change less often)
-COPY .gitignore .gitignore
-
-COPY --from=builder /app/tasks-out/json/ .
-COPY --from=builder /app/websocket-out/json/ .
-COPY --from=builder /app/migration-out/json/ .
-COPY --from=builder /app/cli-out/json/ .
-COPY --from=builder /app/next-out/json/ .
-COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
-
-# Is used for postinstall of docs definitions
-COPY --from=builder /app/packages/definitions/src/docs ./packages/definitions/src/docs
-
-# Uses the lockfile to install the dependencies
 RUN corepack enable pnpm && pnpm install --recursive --frozen-lockfile
 
 # Install sharp for image optimization
 RUN corepack enable pnpm && pnpm install sharp -w
-
-# Build the project
-COPY --from=builder /app/tasks-out/full/ .
-COPY --from=builder /app/websocket-out/full/ .
-COPY --from=builder /app/next-out/full/ .
-COPY --from=builder /app/migration-out/full/ .
-COPY --from=builder /app/cli-out/full/ .
 
 # Copy static data as it is not part of the build
 COPY static-data ./static-data
@@ -69,7 +38,7 @@ RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
 # Enable homarr cli
-COPY --from=installer --chown=nextjs:nodejs /app/packages/cli/cli.cjs /app/apps/cli/cli.cjs
+COPY --from=builder --chown=nextjs:nodejs /app/packages/cli/cli.cjs /app/apps/cli/cli.cjs
 RUN echo $'#!/bin/bash\ncd /app/apps/cli && node ./cli.cjs "$@"' > /usr/bin/homarr
 RUN chmod +x /usr/bin/homarr
 
@@ -83,20 +52,20 @@ RUN mkdir -p /var/cache/nginx && chown -R nextjs:nodejs /var/cache/nginx && \
     mkdir -p /etc/nginx/templates /etc/nginx/ssl/certs && chown -R nextjs:nodejs /etc/nginx
 USER nextjs
 
-COPY --from=installer /app/apps/nextjs/next.config.mjs .
-COPY --from=installer /app/apps/nextjs/package.json .
+COPY --from=builder /app/apps/nextjs/next.config.mjs .
+COPY --from=builder /app/apps/nextjs/package.json .
 
-COPY --from=installer --chown=nextjs:nodejs /app/apps/tasks/tasks.cjs ./apps/tasks/tasks.cjs
-COPY --from=installer --chown=nextjs:nodejs /app/apps/websocket/wssServer.cjs ./apps/websocket/wssServer.cjs
-COPY --from=installer --chown=nextjs:nodejs /app/node_modules/better-sqlite3/build/Release/better_sqlite3.node /app/build/better_sqlite3.node
+COPY --from=builder --chown=nextjs:nodejs /app/apps/tasks/tasks.cjs ./apps/tasks/tasks.cjs
+COPY --from=builder --chown=nextjs:nodejs /app/apps/websocket/wssServer.cjs ./apps/websocket/wssServer.cjs
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/better-sqlite3/build/Release/better_sqlite3.node /app/build/better_sqlite3.node
 
-COPY --from=installer --chown=nextjs:nodejs /app/packages/db/migrations ./db/migrations
+COPY --from=builder --chown=nextjs:nodejs /app/packages/db/migrations ./db/migrations
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=installer --chown=nextjs:nodejs /app/apps/nextjs/.next/standalone ./
-COPY --from=installer --chown=nextjs:nodejs /app/apps/nextjs/.next/static ./apps/nextjs/.next/static
-COPY --from=installer --chown=nextjs:nodejs /app/apps/nextjs/public ./apps/nextjs/public
+COPY --from=builder --chown=nextjs:nodejs /app/apps/nextjs/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/apps/nextjs/.next/static ./apps/nextjs/.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/apps/nextjs/public ./apps/nextjs/public
 COPY --chown=nextjs:nodejs scripts/run.sh ./run.sh
 COPY --chown=nextjs:nodejs scripts/generateEncryptionKey.js ./generateEncryptionKey.js
 COPY --chown=nextjs:nodejs packages/redis/redis.conf /app/redis.conf


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

We misused the prune functionality from turborepo which allows to only include the necessary things for installation and build. But as we need everything in the same image, we can simply skip this mess and build normally with all files present and then copy the build files to the run step.
This also resolves the issue with docker build in #1586 which occured because the patched dependency was no longer part of the package.json after prune.

I tested the image in this state locally, size is about 330 MB and it works as expected