### PR TITLE
ci: generate auth secret in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/nextjs/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/apps/nextjs/.next/static ./apps/nextjs/.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/apps/nextjs/public ./apps/nextjs/public
 COPY --chown=nextjs:nodejs scripts/run.sh ./run.sh
-COPY --chown=nextjs:nodejs scripts/generateEncryptionKey.js ./generateEncryptionKey.js
+COPY --chown=nextjs:nodejs scripts/generateRandomSecureKey.js ./generateRandomSecureKey.js
 COPY --chown=nextjs:nodejs packages/redis/redis.conf /app/redis.conf
 COPY --chown=nextjs:nodejs nginx.conf /etc/nginx/templates/nginx.conf
 

--- a/development/docker-run.cmd
+++ b/development/docker-run.cmd
@@ -1,1 +1,1 @@
-docker run -p 7575:7575 -e AUTH_SECRET='secrets' homarr:latest
+docker run -p 7575:7575 homarr:latest

--- a/e2e/shared/create-homarr-container.ts
+++ b/e2e/shared/create-homarr-container.ts
@@ -6,9 +6,6 @@ export const createHomarrContainer = () => {
   }
 
   return new GenericContainer("homarr-e2e")
-    .withEnvironment({
-      AUTH_SECRET: "secret",
-    })
     .withExposedPorts(7575)
     .withWaitStrategy(Wait.forHttp("/api/health/ready", 7575));
 };

--- a/packages/auth/configuration.ts
+++ b/packages/auth/configuration.ts
@@ -89,7 +89,6 @@ export const createConfiguration = (
       signIn: createSignInEventHandler(db),
     },
     redirectProxyUrl: createRedirectUri(headers, "/api/auth"),
-    secret: "secret-is-not-defined-yet", // TODO: This should be added later
     session: {
       strategy: "database",
       maxAge: env.AUTH_SESSION_EXPIRY_TIME,

--- a/scripts/generateEncryptionKey.js
+++ b/scripts/generateEncryptionKey.js
@@ -1,7 +1,0 @@
-// This script generates a random encryption key
-// This key is used to encrypt and decrypt the integration secrets
-// In production it is generated in run.sh and stored in the environment variable ENCRYPTION_KEY
-// during runtime, it's also stored in a file.
-
-const crypto = require("crypto");
-console.log(crypto.randomBytes(32).toString("hex"));

--- a/scripts/generateRandomSecureKey.js
+++ b/scripts/generateRandomSecureKey.js
@@ -1,0 +1,7 @@
+// This script generates a random secure key with a length of 64 characters
+// This key is used to encrypt and decrypt the integration secrets for auth.js
+// In production it is generated in run.sh and stored in the environment variables ENCRYPTION_KEY / AUTH_SECRET
+// during runtime, it's also stored in a file.
+
+const crypto = require("crypto");
+console.log(crypto.randomBytes(32).toString("hex"));

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -18,10 +18,23 @@ if [ -r /secrets/encryptionKey ]; then
     encryptionKey=$(cat /secrets/encryptionKey)
 else
     echo "Generating encryption key"
-    encryptionKey=$(node ./generateEncryptionKey.js)
+    encryptionKey=$(node ./generateRandomSecureKey.js)
     echo $encryptionKey > /secrets/encryptionKey
 fi
 export ENCRYPTION_KEY=$encryptionKey
+
+# Generates an auth secret if it doesn't exist and saves it to /secrets/authSecret
+# Also sets the AUTH_SECRET environment variable required for auth.js
+authSecret=""
+if [ -r /secrets/authSecret ]; then
+    echo "Auth secret already exists"
+    authSecret=$(cat /secrets/authSecret)
+else
+    echo "Generating auth secret"
+    authSecret=$(node ./generateRandomSecureKey.js)
+    echo $authSecret > /secrets/authSecret
+fi
+export AUTH_SECRET=$authSecret
 
 # Start nginx proxy
 # 1. Replace the HOSTNAME in the nginx template file


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Previously `AUTH_SECRET` was a required env variable during the early adopters program