### PR TITLE
fix: jellyfin integration does not allow username password auth

### DIFF
--- a/packages/integrations/src/base/integration.ts
+++ b/packages/integrations/src/base/integration.ts
@@ -29,6 +29,10 @@ export abstract class Integration {
     return secret.value;
   }
 
+  protected hasSecretValue(kind: IntegrationSecretKind) {
+    return this.integration.decryptedSecrets.some((secret) => secret.kind === kind);
+  }
+
   protected url(path: `/${string}`, queryParams?: Record<string, string | Date | number | boolean>) {
     const baseUrl = removeTrailingSlash(this.integration.url);
     const url = new URL(`${baseUrl}${path}`);


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

