### PR TITLE
fix: allow additional file-type for oldmarr import

### DIFF
--- a/.github/workflows/deployment-docker-image.yml
+++ b/.github/workflows/deployment-docker-image.yml
@@ -139,7 +139,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           context: .
-          push: ${{ env.PUSH_IMAGE}}
+          push: true #$ {{ env.PUSH_IMAGE}}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           network: host

--- a/.github/workflows/deployment-docker-image.yml
+++ b/.github/workflows/deployment-docker-image.yml
@@ -139,7 +139,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           context: .
-          push: true #$ {{ env.PUSH_IMAGE}}
+          push: ${{ env.PUSH_IMAGE}}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           network: host

--- a/apps/nextjs/src/app/[locale]/init/_steps/import/import-dropzone.tsx
+++ b/apps/nextjs/src/app/[locale]/init/_steps/import/import-dropzone.tsx
@@ -28,6 +28,9 @@ export const ImportDropZone = ({ loading, updateFile }: ImportDropZoneProps) => 
       loading={loading}
       multiple={false}
       maxSize={1024 * 1024 * 1024 * 64} // 64 MB
+      onReject={(files) => {
+        console.error("Rejected files", files);
+      }}
     >
       <Group justify="center" gap="xl" mih={220} style={{ pointerEvents: "none" }}>
         <Dropzone.Accept>

--- a/apps/nextjs/src/app/[locale]/init/_steps/import/import-dropzone.tsx
+++ b/apps/nextjs/src/app/[locale]/init/_steps/import/import-dropzone.tsx
@@ -24,12 +24,18 @@ export const ImportDropZone = ({ loading, updateFile }: ImportDropZoneProps) => 
       }}
       acceptColor="blue.6"
       rejectColor="red.6"
-      accept={[MIME_TYPES.zip]}
+      accept={[MIME_TYPES.zip, "application/x-zip-compressed"]}
       loading={loading}
       multiple={false}
       maxSize={1024 * 1024 * 1024 * 64} // 64 MB
-      onReject={(files) => {
-        console.error("Rejected files", files);
+      onReject={(rejections) => {
+        console.error(
+          "Rejected files",
+          rejections.map(
+            (rejection) =>
+              `File: ${rejection.file.name} size=${rejection.file.size} fileType=${rejection.file.type}\n - ${rejection.errors.map((error) => error.message).join("\n - ")}`,
+          ),
+        );
       }}
     >
       <Group justify="center" gap="xl" mih={220} style={{ pointerEvents: "none" }}>


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Some users were unable to import the zip archive as we only supported default `application/zip` but not compressed variant