### PR TITLE
fix: allow self-signed qBittorrent server certificates.

### DIFF
--- a/packages/integrations/src/download-client/qbittorrent/qbittorrent-integration.ts
+++ b/packages/integrations/src/download-client/qbittorrent/qbittorrent-integration.ts
@@ -1,5 +1,6 @@
 import { QBittorrent } from "@ctrl/qbittorrent";
 import dayjs from "dayjs";
+import https from "https";
 
 import type { DownloadClientJobsAndStatus } from "../../interfaces/downloads/download-client-data";
 import { DownloadClientIntegration } from "../../interfaces/downloads/download-client-integration";
@@ -70,10 +71,16 @@ export class QBitTorrentIntegration extends DownloadClientIntegration {
   }
 
   private getClient() {
+    const httpsAgent = new https.Agent({
+        rejectUnauthorized: false,
+    });
     return new QBittorrent({
       baseUrl: this.url("/").toString(),
       username: this.getSecretValue("username"),
       password: this.getSecretValue("password"),
+      requestConfig: {
+        httpsAgent,
+      },
     });
   }
 


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [ ] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [ ] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)


### Summary

This update improves the `getClient` method in the `QBitTorrentIntegration` class to support qBittorrent servers with self-signed SSL certificates. The implementation adds an `https.Agent` configuration to bypass certificate validation when connecting via HTTPS.

### Changes
- Added a custom `https.Agent` with `rejectUnauthorized: false` to allow self-signed certificates.
- Passed the `https.Agent` to the `requestConfig` parameter of the `QBittorrent` client.

### Benefits
- Ensures compatibility with qBittorrent servers using self-signed SSL certificates and full chain signed certificates.
- Maintains functionality for servers running over plain HTTP.

### Example Usage
The client now automatically works with:
- **HTTP Servers**: Connections proceed without changes.
- **HTTPS Servers (Self-Signed)**: The custom `https.Agent` handles certificate validation bypass.

# This is my first PR for this project so I haven't actually built or tested this.

I can't get the beta to work with OIDC, so this is just speculative.