### PR TITLE
fix(board): tiles order not respected on firefox

### DIFF
--- a/apps/nextjs/src/components/board/sections/content.tsx
+++ b/apps/nextjs/src/components/board/sections/content.tsx
@@ -19,7 +19,7 @@ export const SectionContent = () => {
         return itemA.xOffset - itemB.xOffset;
       }
 
-      return itemA.yOffset - itemB.xOffset;
+      return itemA.yOffset - itemB.yOffset;
     });
   }, [section.items, innerSections]);
 

--- a/apps/nextjs/src/components/board/sections/content.tsx
+++ b/apps/nextjs/src/components/board/sections/content.tsx
@@ -10,6 +10,12 @@ import { useSectionContext } from "./section-context";
 export const SectionContent = () => {
   const { section, innerSections, refs } = useSectionContext();
   const board = useRequiredBoard();
+
+  /**
+   * IMPORTANT: THE ORDER OF THE BELOW ITEMS HAS TO MATCH THE ORDER OF
+   * THE ITEMS RENDERED WITH GRIDSTACK, OTHERWISE THE ITEMS WILL BE MIXED UP
+   * @see https://github.com/homarr-labs/homarr/pull/1770
+   */
   const sortedItems = useMemo(() => {
     return [
       ...section.items.map((item) => ({ ...item, type: "item" as const })),


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Closes #1102 

The bug happens because the order in the virtual DOM (React) and in the real dom (Modified by Gridstack) do not match. The reason for this is that Gridstack creates the items itself and places them in the correct x / y order into the gridstack section. While we did not respect the correct order during the rendering of the virtual DOM it resulted in a mixed up order which then was rendered in the wrong order because suspense only had a reference to the elements at the specific places