### PR TITLE
fix(translation): query parameter in search with escaped

### DIFF
--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -2882,7 +2882,7 @@
                 "description": "Set a default search engine in preferences"
               },
               "search": {
-                "label": "Search for '{query}' with {name}"
+                "label": "Search for \"{query}\" with {name}"
               },
               "from-integration": {
                 "description": "Start typing to search"


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Before
![image](https://github.com/user-attachments/assets/d034d207-c292-4e04-9520-80a54af06bc7)


After
![image](https://github.com/user-attachments/assets/cded93d9-5fa9-4692-bee4-1fb8b12533c0)
