### PR TITLE
test: adjust nzbget test to use append instead of scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "lint:ws": "pnpm dlx sherif@latest",
     "package:new": "turbo gen init",
     "release": "semantic-release",
-    "test": "cross-env NODE_ENV=development vitest run --exclude e2e --coverage.enabled ",
-    "test:e2e": "cross-env NODE_ENV=development vitest e2e",
-    "test:ui": "cross-env NODE_ENV=development vitest --exclude e2e --ui --coverage.enabled",
+    "test": "cross-env NODE_ENV=development CI=true vitest run --exclude e2e --coverage.enabled ",
+    "test:e2e": "cross-env NODE_ENV=development CI=true vitest e2e",
+    "test:ui": "cross-env NODE_ENV=development CI=true vitest --exclude e2e --ui --coverage.enabled",
     "typecheck": "turbo typecheck",
     "with-env": "dotenv -e .env --"
   },


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Reason: It always fails since the latest nzbget release and scan is no longer reliable (append is anyway the better solution)