### PR TITLE
fix: add missing old-import proxmox integration kind mapping

### DIFF
--- a/packages/old-import/src/mappers/map-integration.ts
+++ b/packages/old-import/src/mappers/map-integration.ts
@@ -25,7 +25,7 @@ const mapping: Record<OldmarrIntegrationType, IntegrationKind | null> = {
   overseerr: "overseerr",
   pihole: "piHole",
   prowlarr: "prowlarr",
-  proxmox: null,
+  proxmox: "proxmox",
   qBittorrent: "qBittorrent",
   radarr: "radarr",
   readarr: "readarr",


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

