### PR TITLE
fix: User options switch on load value always false

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_ping-icons-enabled.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_ping-icons-enabled.tsx
@@ -51,7 +51,10 @@ export const PingIconsEnabled = ({ user }: PingIconsEnabledProps) => {
   return (
     <form onSubmit={form.onSubmit(handleSubmit)}>
       <Stack gap="md">
-        <Switch {...form.getInputProps("pingIconsEnabled", { type: "checkbox" })} label={t("user.field.pingIconsEnabled.label")} />
+        <Switch
+          {...form.getInputProps("pingIconsEnabled", { type: "checkbox" })}
+          label={t("user.field.pingIconsEnabled.label")}
+        />
 
         <Group justify="end">
           <Button type="submit" color="teal" loading={isPending}>

--- a/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_ping-icons-enabled.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_ping-icons-enabled.tsx
@@ -51,7 +51,11 @@ export const PingIconsEnabled = ({ user }: PingIconsEnabledProps) => {
   return (
     <form onSubmit={form.onSubmit(handleSubmit)}>
       <Stack gap="md">
-        <Switch {...form.getInputProps("pingIconsEnabled")} label={t("user.field.pingIconsEnabled.label")} />
+        <Switch
+          checked={form.getInputProps("pingIconsEnabled").value as boolean}
+          {...form.getInputProps("pingIconsEnabled")}
+          label={t("user.field.pingIconsEnabled.label")}
+        />
 
         <Group justify="end">
           <Button type="submit" color="teal" loading={isPending}>

--- a/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_ping-icons-enabled.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_ping-icons-enabled.tsx
@@ -51,11 +51,7 @@ export const PingIconsEnabled = ({ user }: PingIconsEnabledProps) => {
   return (
     <form onSubmit={form.onSubmit(handleSubmit)}>
       <Stack gap="md">
-        <Switch
-          checked={form.getInputProps("pingIconsEnabled").value as boolean}
-          {...form.getInputProps("pingIconsEnabled")}
-          label={t("user.field.pingIconsEnabled.label")}
-        />
+        <Switch {...form.getInputProps("pingIconsEnabled", { type: "checkbox" })} label={t("user.field.pingIconsEnabled.label")} />
 
         <Group justify="end">
           <Button type="submit" color="teal" loading={isPending}>


### PR DESCRIPTION
Switch needs "checked" to be set instead of value.
Maybe could have changed the form to set a different field instead.

closes #1998 