### PR TITLE
fix: date & time widget padding cut off

### DIFF
--- a/packages/widgets/src/clock/component.tsx
+++ b/packages/widgets/src/clock/component.tsx
@@ -30,7 +30,7 @@ export default function ClockWidget({ options }: WidgetComponentProps<"clock">) 
         {dayjs(time).tz(timezone).format(timeFormat)}
       </Text>
       {options.showDate && (
-        <Text className="clock-date-text" size="12.5cqmin" pt="1cqmin" lineClamp={1}>
+        <Text className="clock-date-text" size="12.5cqmin" p="1cqmin" lineClamp={1}>
           {dayjs(time).tz(timezone).format(dateFormat)}
         </Text>
       )}


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

