### PR TITLE
fix: add mysql pool with keep-alive to not close the connection

### DIFF
--- a/packages/db/driver.ts
+++ b/packages/db/driver.ts
@@ -1,9 +1,11 @@
+import type { Database as BetterSqlite3Connection } from "better-sqlite3";
 import Database from "better-sqlite3";
 import type { Logger } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import { drizzle as drizzleSqlite } from "drizzle-orm/better-sqlite3";
 import type { MySql2Database } from "drizzle-orm/mysql2";
 import { drizzle as drizzleMysql } from "drizzle-orm/mysql2";
+import type { Pool as MysqlConnectionPool } from "mysql2";
 import mysql from "mysql2";
 
 import { logger } from "@homarr/log";
@@ -29,7 +31,7 @@ const init = () => {
   }
 };
 
-export let connection: Database.Database | mysql.Connection;
+export let connection: BetterSqlite3Connection | MysqlConnectionPool;
 export let database: HomarrDatabase;
 
 class WinstonDrizzleLogger implements Logger {
@@ -49,14 +51,17 @@ const initBetterSqlite = () => {
 
 const initMySQL2 = () => {
   if (!env.DB_HOST) {
-    connection = mysql.createConnection({ uri: env.DB_URL });
+    connection = mysql.createPool({ uri: env.DB_URL, maxIdle: 0, idleTimeout: 60000, enableKeepAlive: true });
   } else {
-    connection = mysql.createConnection({
+    connection = mysql.createPool({
       host: env.DB_HOST,
       database: env.DB_NAME,
       port: env.DB_PORT,
       user: env.DB_USER,
       password: env.DB_PASSWORD,
+      maxIdle: 0,
+      idleTimeout: 60000,
+      enableKeepAlive: true,
     });
   }
 


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm buid``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Closes #2021

When running the current version on dev and stopping the local mysql container, the app crashes (see logf from before). If I changed the code to pool with keep alive, it showed errors during the downtime and then it just continued as if nothing happened.

Before:
```
@homarr/nextjs:dev:  ✓ Compiled /[locale]/manage/users/[userId]/general in 10.4s
@homarr/nextjs:dev: (node:22980) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/tasks:dev: 2025-02-09T08:39:10.373Z info: The callback of 'mediaServer' cron job succeeded (before callback took 5 ms, callback took 10 ms)
@homarr/tasks:dev: 2025-02-09T08:39:10.374Z info: The callback of 'downloads' cron job succeeded (before callback took 5 ms, callback took 11 ms)
@homarr/tasks:dev: 2025-02-09T08:39:10.375Z info: The callback of 'dnsHole' cron job succeeded (before callback took 4 ms, callback took 12 ms)
@homarr/tasks:dev: 2025-02-09T08:39:10.376Z info: The callback of 'healthMonitoring' cron job succeeded (before callback took 4 ms, callback took 13 ms)
@homarr/nextjs:dev: 2025-02-09T08:39:10.436Z info: tRPC request from rsc by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/websocket:dev: 2025-02-09T08:39:10.530Z info: ➕ Connection (1) GET /websockets
@homarr/websocket:dev: 2025-02-09T08:39:10.530Z info: tRPC request from unknown by user 'undefined (undefined)'
@homarr/nextjs:dev:  GET /manage/users/x8mx6m1f56yfn390828spbs3/general 200 in 13996ms
@homarr/nextjs:dev:  ⚠ The "images.domains" configuration is deprecated. Please use "images.remotePatterns" configuration instead.
@homarr/websocket:dev: 2025-02-09T08:39:11.015Z info: ➕ Connection (2) GET /websockets
@homarr/websocket:dev: 2025-02-09T08:39:11.032Z info: tRPC request from unknown by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  ✓ Compiled /manifest.webmanifest in 257ms
@homarr/nextjs:dev:  GET /manifest.webmanifest 200 in 330ms
@homarr/tasks:dev: 2025-02-09T08:39:15.423Z info: The callback of 'mediaServer' cron job succeeded (before callback took 9 ms, callback took 20 ms)
@homarr/tasks:dev: 2025-02-09T08:39:15.425Z info: The callback of 'downloads' cron job succeeded (before callback took 8 ms, callback took 21 ms)
@homarr/tasks:dev: 2025-02-09T08:39:15.427Z info: The callback of 'dnsHole' cron job succeeded (before callback took 7 ms, callback took 23 ms)
@homarr/tasks:dev: 2025-02-09T08:39:15.432Z info: The callback of 'healthMonitoring' cron job succeeded (before callback took 15 ms, callback took 26 ms)
@homarr/tasks:dev: node:events:496
@homarr/tasks:dev:       throw er; // Unhandled 'error' event
@homarr/tasks:dev:       ^
@homarr/tasks:dev:
@homarr/tasks:dev: Error: Connection lost: The server closed the connection.
@homarr/tasks:dev:     at Socket.<anonymous> (C:\Dev\alparr-labs\homarr\node_modules\mysql2\lib\base\connection.js:113:31)
@homarr/websocket:dev: node:events:496
@homarr/websocket:dev:       throw er; // Unhandled 'error' event
@homarr/websocket:dev:       ^
@homarr/websocket:dev:
@homarr/websocket:dev: Error: Connection lost: The server closed the connection.
@homarr/websocket:dev:     at Socket.<anonymous> (C:\Dev\alparr-labs\homarr\node_modules\mysql2\lib\base\connection.js:113:31)
@homarr/websocket:dev:     at Socket.emit (node:events:518:28)
@homarr/websocket:dev:     at TCP.<anonymous> (node:net:343:12)
@homarr/tasks:dev:     at Socket.emit (node:events:518:28)
@homarr/tasks:dev:     at TCP.<anonymous> (node:net:343:12)
@homarr/tasks:dev: Emitted 'error' event on Connection instance at:
@homarr/tasks:dev:     at Connection._notifyError (C:\Dev\alparr-labs\homarr\node_modules\mysql2\lib\base\connection.js:247:12)
@homarr/tasks:dev:     at Socket.<anonymous> (C:\Dev\alparr-labs\homarr\node_modules\mysql2\lib\base\connection.js:119:12)
@homarr/tasks:dev:     at Socket.emit (node:events:518:28)
@homarr/tasks:dev:     at TCP.<anonymous> (node:net:343:12) {
@homarr/tasks:dev:   fatal: true,
@homarr/tasks:dev:   code: 'PROTOCOL_CONNECTION_LOST'
@homarr/websocket:dev: Emitted 'error' event on Connection instance at:
@homarr/websocket:dev:     at Connection._notifyError (C:\Dev\alparr-labs\homarr\node_modules\mysql2\lib\base\connection.js:247:12)
@homarr/tasks:dev: }
@homarr/websocket:dev:     at Socket.<anonymous> (C:\Dev\alparr-labs\homarr\node_modules\mysql2\lib\base\connection.js:119:12)
@homarr/websocket:dev:     at Socket.emit (node:events:518:28)
@homarr/tasks:dev:
@homarr/tasks:dev: Node.js v22.11.0
@homarr/websocket:dev:     at TCP.<anonymous> (node:net:343:12) {
@homarr/websocket:dev:   fatal: true,
@homarr/websocket:dev:   code: 'PROTOCOL_CONNECTION_LOST'
@homarr/websocket:dev: }
@homarr/websocket:dev:
@homarr/websocket:dev: Node.js v22.11.0
@homarr/nextjs:dev: [Error: Connection lost: The server closed the connection.] {
@homarr/nextjs:dev:   fatal: true,
@homarr/nextjs:dev:   code: 'PROTOCOL_CONNECTION_LOST'
@homarr/nextjs:dev: }
@homarr/nextjs:dev:  ⨯ uncaughtException: [Error: Connection lost: The server closed the connection.] {
@homarr/nextjs:dev:   fatal: true,
@homarr/nextjs:dev:   code: 'PROTOCOL_CONNECTION_LOST'
@homarr/nextjs:dev: }
@homarr/nextjs:dev:  ⨯ uncaughtException:  [Error: Connection lost: The server closed the connection.] {
@homarr/nextjs:dev:   fatal: true,
@homarr/nextjs:dev:   code: 'PROTOCOL_CONNECTION_LOST'
@homarr/nextjs:dev: }
@homarr/websocket:dev:  ELIFECYCLE  Command failed with exit code 1.
@homarr/tasks:dev:  ELIFECYCLE  Command failed with exit code 1.
@homarr/nextjs:dev: [Error: Connection lost: The server closed the connection.] {
@homarr/nextjs:dev:   fatal: true,
@homarr/nextjs:dev:   code: 'PROTOCOL_CONNECTION_LOST'
@homarr/nextjs:dev: }
@homarr/nextjs:dev:  ⨯ uncaughtException: [Error: Connection lost: The server closed the connection.] {
@homarr/nextjs:dev:   fatal: true,
@homarr/nextjs:dev:   code: 'PROTOCOL_CONNECTION_LOST'
@homarr/nextjs:dev: }
@homarr/nextjs:dev:  ⨯ uncaughtException:  [Error: Connection lost: The server closed the connection.] {
@homarr/nextjs:dev:   fatal: true,
@homarr/nextjs:dev:   code: 'PROTOCOL_CONNECTION_LOST'
@homarr/nextjs:dev: }
@homarr/websocket:dev:  ELIFECYCLE  Command failed with exit code 1.
@homarr/tasks:dev:  ELIFECYCLE  Command failed with exit code 1.
@homarr/tasks:dev: ERROR: command finished with error: command (C:\Dev\alparr-labs\homarr\apps\tasks) C:\Program Files\nodejs\pnpm.cmd run dev exited (1)
@homarr/tasks#dev: command (C:\Dev\alparr-labs\homarr\apps\tasks) C:\Program Files\nodejs\pnpm.cmd run dev exited (1)

 Tasks:    0 successful, 3 total
Cached:    0 cached, 3 total
  Time:    43.777s
Failed:    @homarr/tasks#dev

 ERROR  run failed: command  exited (1)
 ELIFECYCLE  Command failed with exit code 1.
```

After:
```
@homarr/tasks:dev: 2025-02-09T08:37:25.571Z info: The callback of 'mediaServer' cron job succeeded (before callback took 4 ms, callback took 15 ms)
@homarr/tasks:dev: 2025-02-09T08:37:25.571Z info: The callback of 'dnsHole' cron job succeeded (before callback took 4 ms, callback took 15 ms)
@homarr/tasks:dev: 2025-02-09T08:37:25.571Z info: The callback of 'downloads' cron job succeeded (before callback took 4 ms, callback took 15 ms)
@homarr/tasks:dev: 2025-02-09T08:37:25.572Z info: The callback of 'healthMonitoring' cron job succeeded (before callback took 3 ms, callback took 15 ms)
@homarr/nextjs:dev:  ✓ Compiled /[locale]/manage/users/[userId]/general in 2.7s
@homarr/nextjs:dev: (node:27636) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/nextjs:dev: 2025-02-09T08:37:28.298Z info: tRPC request from rsc by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /manage/users/x8mx6m1f56yfn390828spbs3/general 200 in 4601ms
@homarr/nextjs:dev:  GET /manifest.webmanifest 200 in 75ms
@homarr/tasks:dev: 2025-02-09T08:37:30.609Z error: Failed to run job 'mediaServer': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:30.610Z error: Failed to run job 'healthMonitoring': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:30.610Z error: Failed to run job 'dnsHole': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:30.610Z error: Failed to run job 'downloads': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:35.653Z error: Failed to run job 'mediaServer': Error
@homarr/tasks:dev: 2025-02-09T08:37:35.654Z error: Failed to run job 'downloads': Error
@homarr/tasks:dev: 2025-02-09T08:37:35.654Z error: Failed to run job 'dnsHole': Error
@homarr/tasks:dev: 2025-02-09T08:37:35.655Z error: Failed to run job 'healthMonitoring': Error
@homarr/tasks:dev: 2025-02-09T08:37:40.685Z error: Failed to run job 'mediaServer': Error
@homarr/tasks:dev: 2025-02-09T08:37:40.685Z error: Failed to run job 'downloads': Error
@homarr/tasks:dev: 2025-02-09T08:37:40.685Z error: Failed to run job 'dnsHole': Error
@homarr/tasks:dev: 2025-02-09T08:37:40.686Z error: Failed to run job 'healthMonitoring': Error
@homarr/nextjs:dev: 2025-02-09T08:37:45.014Z error: AdapterError: Read more at https://errors.authjs.dev#adaptererror
@homarr/nextjs:dev:   at acc.<computed> (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:1366:31)
@homarr/nextjs:dev:   at async Module.session (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:4300:30)
@homarr/nextjs:dev:   at async AuthInternal (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:4867:24)
@homarr/nextjs:dev:   at async Auth (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:5120:34)
@homarr/nextjs:dev:   at async handleAuth (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_next-auth_8ea0cb._.js:3717:29)
@homarr/nextjs:dev:   at async AppRouteRouteModule.do (C:\Dev\alparr-labs\homarr\node_modules\next\dist\compiled\next-server\app-route.runtime.dev.js:10:32847)
@homarr/nextjs:dev:   at async AppRouteRouteModule.handle (C:\Dev\alparr-labs\homarr\node_modules\next\dist\compiled\next-server\app-route.runtime.dev.js:10:39868)
@homarr/nextjs:dev:   at async doRender (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:1452:42)
@homarr/nextjs:dev:   at async responseGenerator (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:1822:28)
@homarr/nextjs:dev:   at async DevServer.renderToResponseWithComponentsImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:1832:28)
@homarr/nextjs:dev:   at async DevServer.renderPageComponent (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:2259:24)
@homarr/nextjs:dev:   at async DevServer.renderToResponseImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:2297:32)
@homarr/nextjs:dev:   at async DevServer.pipeImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:959:25)
@homarr/nextjs:dev:   at async NextNodeServer.handleCatchallRenderRequest (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\next-server.js:281:17)
@homarr/nextjs:dev:   at async DevServer.handleRequestImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:853:17)
@homarr/nextjs:dev:   at async C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\dev\next-dev-server.js:371:20
@homarr/nextjs:dev:   at async Span.traceAsyncFn (C:\Dev\alparr-labs\homarr\node_modules\next\dist\trace\trace.js:153:20)
@homarr/nextjs:dev:   at async DevServer.handleRequest (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\dev\next-dev-server.js:368:24)
@homarr/nextjs:dev:   at async invokeRender (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\router-server.js:230:21)
@homarr/nextjs:dev:   at async handleRequest (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\router-server.js:408:24)
@homarr/nextjs:dev:   at async requestHandlerImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\router-server.js:432:13)
@homarr/nextjs:dev:   at async Server.requestListener (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\start-server.js:146:13)
@homarr/nextjs:dev: The above error also had these properties on it:
@homarr/nextjs:dev: {
@homarr/nextjs:dev:   cause: {
@homarr/nextjs:dev:     err: [Error: ] {
@homarr/nextjs:dev:       code: 'ECONNREFUSED',
@homarr/nextjs:dev:       errno: undefined,
@homarr/nextjs:dev:       sql: undefined,
@homarr/nextjs:dev:       sqlState: undefined,
@homarr/nextjs:dev:       sqlMessage: undefined
@homarr/nextjs:dev:     }
@homarr/nextjs:dev:   },
@homarr/nextjs:dev:   name: 'AdapterError',
@homarr/nextjs:dev:   type: 'AdapterError',
@homarr/nextjs:dev:   kind: 'error'
@homarr/nextjs:dev: }
@homarr/nextjs:dev: 2025-02-09T08:37:45.092Z error: [object Object]
@homarr/nextjs:dev: The above error also had these properties on it:
@homarr/nextjs:dev: {
@homarr/nextjs:dev:   err: [Error: ] {
@homarr/nextjs:dev:     code: 'ECONNREFUSED',
@homarr/nextjs:dev:     errno: undefined,
@homarr/nextjs:dev:     sql: undefined,
@homarr/nextjs:dev:     sqlState: undefined,
@homarr/nextjs:dev:     sqlMessage: undefined
@homarr/nextjs:dev:   }
@homarr/nextjs:dev: }
@homarr/nextjs:dev: 2025-02-09T08:37:45.150Z error: SessionTokenError: Read more at https://errors.authjs.dev#sessiontokenerror
@homarr/nextjs:dev:   at Module.session (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:4358:22)
@homarr/nextjs:dev:   at async AuthInternal (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:4867:24)
@homarr/nextjs:dev:   at async Auth (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:5120:34)
@homarr/nextjs:dev:   at async handleAuth (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_next-auth_8ea0cb._.js:3717:29)
@homarr/nextjs:dev:   at async AppRouteRouteModule.do (C:\Dev\alparr-labs\homarr\node_modules\next\dist\compiled\next-server\app-route.runtime.dev.js:10:32847)
@homarr/nextjs:dev:   at async AppRouteRouteModule.handle (C:\Dev\alparr-labs\homarr\node_modules\next\dist\compiled\next-server\app-route.runtime.dev.js:10:39868)
@homarr/nextjs:dev:   at async doRender (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:1452:42)
@homarr/nextjs:dev:   at async responseGenerator (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:1822:28)
@homarr/nextjs:dev:   at async DevServer.renderToResponseWithComponentsImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:1832:28)
@homarr/nextjs:dev:   at async DevServer.renderPageComponent (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:2259:24)
@homarr/nextjs:dev:   at async DevServer.renderToResponseImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:2297:32)
@homarr/nextjs:dev:   at async DevServer.pipeImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:959:25)
@homarr/nextjs:dev:   at async NextNodeServer.handleCatchallRenderRequest (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\next-server.js:281:17)
@homarr/nextjs:dev:   at async DevServer.handleRequestImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:853:17)
@homarr/nextjs:dev:   at async C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\dev\next-dev-server.js:371:20
@homarr/nextjs:dev:   at async Span.traceAsyncFn (C:\Dev\alparr-labs\homarr\node_modules\next\dist\trace\trace.js:153:20)
@homarr/nextjs:dev:   at async DevServer.handleRequest (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\dev\next-dev-server.js:368:24)
@homarr/nextjs:dev:   at async invokeRender (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\router-server.js:230:21)
@homarr/nextjs:dev:   at async handleRequest (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\router-server.js:408:24)
@homarr/nextjs:dev:   at async requestHandlerImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\router-server.js:432:13)
@homarr/nextjs:dev:   at async Server.requestListener (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\start-server.js:146:13)
@homarr/nextjs:dev: The above error also had these properties on it:
@homarr/nextjs:dev: {
@homarr/nextjs:dev:   cause: {
@homarr/nextjs:dev:     err: [Error: ] {
@homarr/nextjs:dev:       code: 'ECONNREFUSED',
@homarr/nextjs:dev:       errno: undefined,
@homarr/nextjs:dev:       sql: undefined,
@homarr/nextjs:dev:       sqlState: undefined,
@homarr/nextjs:dev:       sqlMessage: undefined
@homarr/nextjs:dev:     }
@homarr/nextjs:dev:   },
@homarr/nextjs:dev:   name: 'SessionTokenError',
@homarr/nextjs:dev:   type: 'SessionTokenError',
@homarr/nextjs:dev:   kind: 'error'
@homarr/nextjs:dev: }
@homarr/nextjs:dev: 2025-02-09T08:37:45.214Z error: [object Object]
@homarr/nextjs:dev: The above error also had these properties on it:
@homarr/nextjs:dev: {
@homarr/nextjs:dev:   err: [Error: ] {
@homarr/nextjs:dev:     code: 'ECONNREFUSED',
@homarr/nextjs:dev:     errno: undefined,
@homarr/nextjs:dev:     sql: undefined,
@homarr/nextjs:dev:     sqlState: undefined,
@homarr/nextjs:dev:     sqlMessage: undefined
@homarr/nextjs:dev:   }
@homarr/nextjs:dev: }
@homarr/nextjs:dev: 2025-02-09T08:37:45.215Z info: tRPC request from server-fetch by user 'undefined (undefined)'
@homarr/nextjs:dev: 2025-02-09T08:37:45.226Z error: tRPC Error with query on 'serverSettings.getCulture': (INTERNAL_SERVER_ERROR) -
@homarr/nextjs:dev: Error:
@homarr/nextjs:dev:     at PromisePool.query (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_mysql2_58eb85._.js:11498:26)
@homarr/nextjs:dev:     at MySql2PreparedQuery.execute (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_drizzle-orm_5b168a._.js:12632:37)
@homarr/nextjs:dev:     at QueryPromise.execute (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_drizzle-orm_5b168a._.js:9867:31)
@homarr/nextjs:dev:     at QueryPromise.then (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_drizzle-orm_5b168a._.js:6677:21)
@homarr/nextjs:dev:     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
@homarr/nextjs:dev: Error
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 500 in 857ms
@homarr/nextjs:dev:  ⨯ Error [TRPCClientError]: 
@homarr/nextjs:dev:     at TRPCClientError.from (.next\server\edge\chunks\08b5e_4fcd8b._.js:92:20)
@homarr/nextjs:dev:     at <unknown> (.next\server\edge\chunks\08b5e_4fcd8b._.js:1098:216)
@homarr/tasks:dev: 2025-02-09T08:37:45.717Z error: Failed to run job 'mediaServer': Error
@homarr/tasks:dev: 2025-02-09T08:37:45.717Z error: Failed to run job 'downloads': Error
@homarr/tasks:dev: 2025-02-09T08:37:45.718Z error: Failed to run job 'dnsHole': Error
@homarr/tasks:dev: 2025-02-09T08:37:45.718Z error: Failed to run job 'healthMonitoring': Error
@homarr/nextjs:dev:  ○ Compiling /_error ...
@homarr/nextjs:dev: (node:34620) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/nextjs:dev:  ✓ Compiled /_error in 2.3s
@homarr/nextjs:dev:  GET /manage/users/x8mx6m1f56yfn390828spbs3/general 404 in 7ms
@homarr/websocket:dev: 2025-02-09T08:37:47.923Z info: ➖ Connection (1) 1001
@homarr/nextjs:dev:  ✓ Compiled /_not-found/page in 206ms
@homarr/tasks:dev: 2025-02-09T08:37:50.786Z error: Failed to run job 'mediaServer': Error
@homarr/tasks:dev: 2025-02-09T08:37:50.787Z error: Failed to run job 'downloads': Error
@homarr/tasks:dev: 2025-02-09T08:37:50.788Z error: Failed to run job 'dnsHole': Error
@homarr/tasks:dev: 2025-02-09T08:37:50.789Z error: Failed to run job 'healthMonitoring': Error
@homarr/nextjs:dev: 2025-02-09T08:37:55.265Z error: AdapterError: Read more at https://errors.authjs.dev#adaptererror
@homarr/nextjs:dev:   at acc.<computed> (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:1366:31)
@homarr/nextjs:dev:   at async Module.session (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:4300:30)
@homarr/nextjs:dev:   at async AuthInternal (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:4867:24)
@homarr/nextjs:dev:   at async Auth (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:5120:34)
@homarr/nextjs:dev:   at async handleAuth (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_next-auth_8ea0cb._.js:3717:29)
@homarr/nextjs:dev:   at async AppRouteRouteModule.do (C:\Dev\alparr-labs\homarr\node_modules\next\dist\compiled\next-server\app-route.runtime.dev.js:10:32847)
@homarr/nextjs:dev:   at async AppRouteRouteModule.handle (C:\Dev\alparr-labs\homarr\node_modules\next\dist\compiled\next-server\app-route.runtime.dev.js:10:39868)
@homarr/nextjs:dev:   at async doRender (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:1452:42)
@homarr/nextjs:dev:   at async responseGenerator (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:1822:28)
@homarr/nextjs:dev:   at async DevServer.renderToResponseWithComponentsImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:1832:28)
@homarr/nextjs:dev:   at async DevServer.renderPageComponent (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:2259:24)
@homarr/nextjs:dev:   at async DevServer.renderToResponseImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:2297:32)
@homarr/nextjs:dev:   at async DevServer.pipeImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:959:25)
@homarr/nextjs:dev:   at async NextNodeServer.handleCatchallRenderRequest (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\next-server.js:281:17)
@homarr/nextjs:dev:   at async DevServer.handleRequestImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:853:17)
@homarr/nextjs:dev:   at async C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\dev\next-dev-server.js:371:20
@homarr/nextjs:dev:   at async Span.traceAsyncFn (C:\Dev\alparr-labs\homarr\node_modules\next\dist\trace\trace.js:153:20)
@homarr/nextjs:dev:   at async DevServer.handleRequest (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\dev\next-dev-server.js:368:24)
@homarr/nextjs:dev:   at async invokeRender (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\router-server.js:230:21)
@homarr/nextjs:dev:   at async handleRequest (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\router-server.js:408:24)
@homarr/nextjs:dev:   at async requestHandlerImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\router-server.js:432:13)
@homarr/nextjs:dev:   at async Server.requestListener (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\start-server.js:146:13)
@homarr/nextjs:dev: The above error also had these properties on it:
@homarr/nextjs:dev: {
@homarr/nextjs:dev:   cause: {
@homarr/nextjs:dev:     err: [Error: Connection lost: The server closed the connection.] {
@homarr/nextjs:dev:       code: 'PROTOCOL_CONNECTION_LOST',
@homarr/nextjs:dev:       errno: undefined,
@homarr/nextjs:dev:       sql: undefined,
@homarr/nextjs:dev:       sqlState: undefined,
@homarr/nextjs:dev:       sqlMessage: undefined
@homarr/nextjs:dev:     }
@homarr/nextjs:dev:   },
@homarr/nextjs:dev:   name: 'AdapterError',
@homarr/nextjs:dev:   type: 'AdapterError',
@homarr/nextjs:dev:   kind: 'error'
@homarr/nextjs:dev: }
@homarr/nextjs:dev: 2025-02-09T08:37:55.322Z error: [object Object]
@homarr/nextjs:dev: The above error also had these properties on it:
@homarr/nextjs:dev: {
@homarr/nextjs:dev:   err: [Error: Connection lost: The server closed the connection.] {
@homarr/nextjs:dev:     code: 'PROTOCOL_CONNECTION_LOST',
@homarr/nextjs:dev:     errno: undefined,
@homarr/nextjs:dev:     sql: undefined,
@homarr/nextjs:dev:     sqlState: undefined,
@homarr/nextjs:dev:     sqlMessage: undefined
@homarr/nextjs:dev:   }
@homarr/nextjs:dev: }
@homarr/nextjs:dev: 2025-02-09T08:37:55.382Z error: SessionTokenError: Read more at https://errors.authjs.dev#sessiontokenerror
@homarr/nextjs:dev:   at Module.session (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:4358:22)
@homarr/nextjs:dev:   at async AuthInternal (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:4867:24)
@homarr/nextjs:dev:   at async Auth (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_68a7e0._.js:5120:34)
@homarr/nextjs:dev:   at async handleAuth (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_next-auth_8ea0cb._.js:3717:29)
@homarr/nextjs:dev:   at async AppRouteRouteModule.do (C:\Dev\alparr-labs\homarr\node_modules\next\dist\compiled\next-server\app-route.runtime.dev.js:10:32847)
@homarr/nextjs:dev:   at async AppRouteRouteModule.handle (C:\Dev\alparr-labs\homarr\node_modules\next\dist\compiled\next-server\app-route.runtime.dev.js:10:39868)
@homarr/nextjs:dev:   at async doRender (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:1452:42)
@homarr/nextjs:dev:   at async responseGenerator (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:1822:28)
@homarr/nextjs:dev:   at async DevServer.renderToResponseWithComponentsImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:1832:28)
@homarr/nextjs:dev:   at async DevServer.renderPageComponent (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:2259:24)
@homarr/nextjs:dev:   at async DevServer.renderToResponseImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:2297:32)
@homarr/nextjs:dev:   at async DevServer.pipeImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:959:25)
@homarr/nextjs:dev:   at async NextNodeServer.handleCatchallRenderRequest (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\next-server.js:281:17)
@homarr/nextjs:dev:   at async DevServer.handleRequestImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\base-server.js:853:17)
@homarr/nextjs:dev:   at async C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\dev\next-dev-server.js:371:20
@homarr/nextjs:dev:   at async Span.traceAsyncFn (C:\Dev\alparr-labs\homarr\node_modules\next\dist\trace\trace.js:153:20)
@homarr/nextjs:dev:   at async DevServer.handleRequest (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\dev\next-dev-server.js:368:24)
@homarr/nextjs:dev:   at async invokeRender (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\router-server.js:230:21)
@homarr/nextjs:dev:   at async handleRequest (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\router-server.js:408:24)
@homarr/nextjs:dev:   at async requestHandlerImpl (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\router-server.js:432:13)
@homarr/nextjs:dev:   at async Server.requestListener (C:\Dev\alparr-labs\homarr\node_modules\next\dist\server\lib\start-server.js:146:13)
@homarr/nextjs:dev: The above error also had these properties on it:
@homarr/nextjs:dev: {
@homarr/nextjs:dev:   cause: {
@homarr/nextjs:dev:     err: [Error: Connection lost: The server closed the connection.] {
@homarr/nextjs:dev:       code: 'PROTOCOL_CONNECTION_LOST',
@homarr/nextjs:dev:       errno: undefined,
@homarr/nextjs:dev:       sql: undefined,
@homarr/nextjs:dev:       sqlState: undefined,
@homarr/nextjs:dev:       sqlMessage: undefined
@homarr/nextjs:dev:     }
@homarr/nextjs:dev:   },
@homarr/nextjs:dev:   name: 'SessionTokenError',
@homarr/nextjs:dev:   type: 'SessionTokenError',
@homarr/nextjs:dev:   kind: 'error'
@homarr/nextjs:dev: }
@homarr/nextjs:dev: 2025-02-09T08:37:55.443Z error: [object Object]
@homarr/nextjs:dev: The above error also had these properties on it:
@homarr/nextjs:dev: {
@homarr/nextjs:dev:   err: [Error: Connection lost: The server closed the connection.] {
@homarr/nextjs:dev:     code: 'PROTOCOL_CONNECTION_LOST',
@homarr/nextjs:dev:     errno: undefined,
@homarr/nextjs:dev:     sql: undefined,
@homarr/nextjs:dev:     sqlState: undefined,
@homarr/nextjs:dev:     sqlMessage: undefined
@homarr/nextjs:dev:   }
@homarr/nextjs:dev: }
@homarr/nextjs:dev: 2025-02-09T08:37:55.443Z info: tRPC request from server-fetch by user 'undefined (undefined)'
@homarr/nextjs:dev: 2025-02-09T08:37:55.454Z error: tRPC Error with query on 'serverSettings.getCulture': (INTERNAL_SERVER_ERROR) - Connection lost: The server closed the connection.
@homarr/nextjs:dev: Error: Connection lost: The server closed the connection.
@homarr/nextjs:dev:     at PromisePool.query (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_mysql2_58eb85._.js:11498:26)
@homarr/nextjs:dev:     at MySql2PreparedQuery.execute (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_drizzle-orm_5b168a._.js:12632:37)
@homarr/nextjs:dev:     at QueryPromise.execute (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_drizzle-orm_5b168a._.js:9867:31)
@homarr/nextjs:dev:     at QueryPromise.then (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_drizzle-orm_5b168a._.js:6677:21)
@homarr/nextjs:dev: Error: Connection lost: The server closed the connection.
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 500 in 703ms
@homarr/nextjs:dev:  ⨯ Error [TRPCClientError]: Connection lost: The server closed the connection.
@homarr/nextjs:dev:     at TRPCClientError.from (.next\server\edge\chunks\08b5e_4fcd8b._.js:92:20)
@homarr/nextjs:dev:     at <unknown> (.next\server\edge\chunks\08b5e_4fcd8b._.js:1098:216)
@homarr/nextjs:dev:  GET /manage/users/x8mx6m1f56yfn390828spbs3/general 404 in 2ms
@homarr/tasks:dev: 2025-02-09T08:37:55.822Z error: Failed to run job 'downloads': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.823Z error: Failed to run job 'dnsHole': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.823Z error: Failed to run job 'mediaServer': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.824Z error: Failed to run job 'healthMonitoring': Error: Connection lost: The server closed the connection.
@homarr/nextjs:dev: (node:17148) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/nextjs:dev: 2025-02-09T08:37:58.793Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 400ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.247Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/onboard.currentStep?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 449ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.677Z info: tRPC request from rsc by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:     at PromisePool.query (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_mysql2_58eb85._.js:11498:26)
@homarr/nextjs:dev:     at MySql2PreparedQuery.execute (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_drizzle-orm_5b168a._.js:12632:37)
@homarr/nextjs:dev:     at QueryPromise.execute (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_drizzle-orm_5b168a._.js:9867:31)
@homarr/nextjs:dev:     at QueryPromise.then (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_drizzle-orm_5b168a._.js:6677:21)
@homarr/nextjs:dev: Error: Connection lost: The server closed the connection.
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 500 in 703ms
@homarr/nextjs:dev:  ⨯ Error [TRPCClientError]: Connection lost: The server closed the connection.
@homarr/nextjs:dev:     at TRPCClientError.from (.next\server\edge\chunks\08b5e_4fcd8b._.js:92:20)
@homarr/nextjs:dev:     at <unknown> (.next\server\edge\chunks\08b5e_4fcd8b._.js:1098:216)
@homarr/nextjs:dev:  GET /manage/users/x8mx6m1f56yfn390828spbs3/general 404 in 2ms
@homarr/tasks:dev: 2025-02-09T08:37:55.822Z error: Failed to run job 'downloads': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.823Z error: Failed to run job 'dnsHole': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.823Z error: Failed to run job 'mediaServer': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.824Z error: Failed to run job 'healthMonitoring': Error: Connection lost: The server closed the connection.
@homarr/nextjs:dev: (node:17148) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/nextjs:dev: 2025-02-09T08:37:58.793Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 400ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.247Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/onboard.currentStep?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 449ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.677Z info: tRPC request from rsc by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:     at MySql2PreparedQuery.execute (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_drizzle-orm_5b168a._.js:12632:37)
@homarr/nextjs:dev:     at QueryPromise.execute (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_drizzle-orm_5b168a._.js:9867:31)
@homarr/nextjs:dev:     at QueryPromise.then (C:\Dev\alparr-labs\homarr\apps\nextjs\.next\server\chunks\08b5e_drizzle-orm_5b168a._.js:6677:21)
@homarr/nextjs:dev: Error: Connection lost: The server closed the connection.
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 500 in 703ms
@homarr/nextjs:dev:  ⨯ Error [TRPCClientError]: Connection lost: The server closed the connection.
@homarr/nextjs:dev:     at TRPCClientError.from (.next\server\edge\chunks\08b5e_4fcd8b._.js:92:20)
@homarr/nextjs:dev:     at <unknown> (.next\server\edge\chunks\08b5e_4fcd8b._.js:1098:216)
@homarr/nextjs:dev:  GET /manage/users/x8mx6m1f56yfn390828spbs3/general 404 in 2ms
@homarr/tasks:dev: 2025-02-09T08:37:55.822Z error: Failed to run job 'downloads': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.823Z error: Failed to run job 'dnsHole': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.823Z error: Failed to run job 'mediaServer': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.824Z error: Failed to run job 'healthMonitoring': Error: Connection lost: The server closed the connection.
@homarr/nextjs:dev: (node:17148) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/nextjs:dev: 2025-02-09T08:37:58.793Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 400ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.247Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/onboard.currentStep?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 449ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.677Z info: tRPC request from rsc by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev: Error: Connection lost: The server closed the connection.
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 500 in 703ms
@homarr/nextjs:dev:  ⨯ Error [TRPCClientError]: Connection lost: The server closed the connection.
@homarr/nextjs:dev:     at TRPCClientError.from (.next\server\edge\chunks\08b5e_4fcd8b._.js:92:20)
@homarr/nextjs:dev:     at <unknown> (.next\server\edge\chunks\08b5e_4fcd8b._.js:1098:216)
@homarr/nextjs:dev:  GET /manage/users/x8mx6m1f56yfn390828spbs3/general 404 in 2ms
@homarr/tasks:dev: 2025-02-09T08:37:55.822Z error: Failed to run job 'downloads': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.823Z error: Failed to run job 'dnsHole': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.823Z error: Failed to run job 'mediaServer': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.824Z error: Failed to run job 'healthMonitoring': Error: Connection lost: The server closed the connection.
@homarr/nextjs:dev: (node:17148) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/nextjs:dev: 2025-02-09T08:37:58.793Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 400ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.247Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/onboard.currentStep?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 449ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.677Z info: tRPC request from rsc by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:     at TRPCClientError.from (.next\server\edge\chunks\08b5e_4fcd8b._.js:92:20)
@homarr/nextjs:dev:     at <unknown> (.next\server\edge\chunks\08b5e_4fcd8b._.js:1098:216)
@homarr/nextjs:dev:  GET /manage/users/x8mx6m1f56yfn390828spbs3/general 404 in 2ms
@homarr/tasks:dev: 2025-02-09T08:37:55.822Z error: Failed to run job 'downloads': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.823Z error: Failed to run job 'dnsHole': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.823Z error: Failed to run job 'mediaServer': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.824Z error: Failed to run job 'healthMonitoring': Error: Connection lost: The server closed the connection.
@homarr/nextjs:dev: (node:17148) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/nextjs:dev: 2025-02-09T08:37:58.793Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 400ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.247Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/onboard.currentStep?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 449ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.677Z info: tRPC request from rsc by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/tasks:dev: 2025-02-09T08:37:55.822Z error: Failed to run job 'downloads': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.823Z error: Failed to run job 'dnsHole': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.823Z error: Failed to run job 'mediaServer': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.824Z error: Failed to run job 'healthMonitoring': Error: Connection lost: The server closed the connection.
@homarr/nextjs:dev: (node:17148) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/nextjs:dev: 2025-02-09T08:37:58.793Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 400ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.247Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/onboard.currentStep?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 449ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.677Z info: tRPC request from rsc by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/tasks:dev: 2025-02-09T08:37:55.823Z error: Failed to run job 'mediaServer': Error: Connection lost: The server closed the connection.
@homarr/tasks:dev: 2025-02-09T08:37:55.824Z error: Failed to run job 'healthMonitoring': Error: Connection lost: The server closed the connection.
@homarr/nextjs:dev: (node:17148) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/nextjs:dev: 2025-02-09T08:37:58.793Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 400ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.247Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/onboard.currentStep?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 449ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.677Z info: tRPC request from rsc by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/tasks:dev: 2025-02-09T08:37:55.824Z error: Failed to run job 'healthMonitoring': Error: Connection lost: The server closed the connection.
@homarr/nextjs:dev: (node:17148) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/nextjs:dev: 2025-02-09T08:37:58.793Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 400ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.247Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/onboard.currentStep?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 449ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.677Z info: tRPC request from rsc by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/nextjs:dev: 2025-02-09T08:37:58.793Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/serverSettings.getCulture?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 400ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.247Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/onboard.currentStep?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 449ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.677Z info: tRPC request from rsc by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev: 2025-02-09T08:37:59.247Z info: tRPC request from server-fetch by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /api/trpc/onboard.currentStep?input=%7B%22json%22%3Anull%2C%22meta%22%3A%7B%22values%22%3A%5B%22undefined%22%5D%7D%7D 200 in 449ms
@homarr/nextjs:dev: 2025-02-09T08:37:59.677Z info: tRPC request from rsc by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev: 2025-02-09T08:37:59.677Z info: tRPC request from rsc by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev:  GET /manage/users/x8mx6m1f56yfn390828spbs3/general 200 in 689ms
@homarr/nextjs:dev:  GET /manage/users/x8mx6m1f56yfn390828spbs3/general 200 in 689ms
@homarr/websocket:dev: 2025-02-09T08:38:00.043Z info: ➕ Connection (2) GET /websockets
@homarr/websocket:dev: 2025-02-09T08:38:00.059Z info: tRPC request from unknown by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev: (node:29700) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/websocket:dev: 2025-02-09T08:38:00.043Z info: ➕ Connection (2) GET /websockets
@homarr/websocket:dev: 2025-02-09T08:38:00.059Z info: tRPC request from unknown by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev: (node:29700) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/websocket:dev: 2025-02-09T08:38:00.059Z info: tRPC request from unknown by user 'meierluk (x8mx6m1f56yfn390828spbs3)'
@homarr/nextjs:dev: (node:29700) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/nextjs:dev: (node:29700) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/nextjs:dev:  GET /manifest.webmanifest 200 in 356ms
@homarr/nextjs:dev: (Use `node --trace-deprecation ...` to show where the warning was created)
@homarr/nextjs:dev:  GET /manifest.webmanifest 200 in 356ms
@homarr/nextjs:dev:  GET /manifest.webmanifest 200 in 356ms
@homarr/tasks:dev: 2025-02-09T08:38:00.910Z info: The callback of 'ping' cron job succeeded (before callback took 7 ms, callback took 62 ms)
@homarr/tasks:dev: 2025-02-09T08:38:00.913Z info: The callback of 'smartHomeEntityState' cron job succeeded (before callback took 7 ms, callback took 65 ms)
@homarr/tasks:dev: 2025-02-09T08:38:00.913Z info: The callback of 'mediaServer' cron job succeeded (before callback took 7 ms, callback took 65 ms)
@homarr/tasks:dev: 2025-02-09T08:38:00.914Z info: The callback of 'mediaOrganizer' cron job succeeded (before callback took 7 ms, callback took 66 ms)
@homarr/tasks:dev: 2025-02-09T08:38:00.914Z info: The callback of 'downloads' cron job succeeded (before callback took 6 ms, callback took 66 ms)
@homarr/tasks:dev: 2025-02-09T08:38:00.914Z info: The callback of 'dnsHole' cron job succeeded (before callback took 6 ms, callback took 66 ms)
@homarr/tasks:dev: 2025-02-09T08:38:00.915Z info: The callback of 'mediaRequestList' cron job succeeded (before callback took 12 ms, callback took 66 ms)
@homarr/tasks:dev: 2025-02-09T08:38:00.916Z info: The callback of 'mediaRequestStats' cron job succeeded (before callback took 6 ms, callback took 68 ms)
@homarr/tasks:dev: 2025-02-09T08:38:00.917Z info: The callback of 'healthMonitoring' cron job succeeded (before callback took 12 ms, callback took 69 ms)
```