### PR TITLE
fix: await params for board metadata

### DIFF
--- a/apps/nextjs/src/app/[locale]/boards/(content)/_creator.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_creator.tsx
@@ -41,9 +41,9 @@ export const createBoardContentPage = <TParams extends Record<string, unknown>>(
         </IntegrationProvider>
       );
     },
-    generateMetadataAsync: async ({ params }: { params: TParams }): Promise<Metadata> => {
+    generateMetadataAsync: async ({ params }: { params: Promise<TParams> }): Promise<Metadata> => {
       try {
-        const board = await getInitialBoard(params);
+        const board = await getInitialBoard(await params);
         const t = await getI18n();
 
         return {


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Fixes the following issue:

```
@homarr/nextjs:dev: Error: Route "/[locale]/boards/[name]" used `params.name`. `params` should be awaited before using its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis
@homarr/nextjs:dev:     at getInitialBoardAsync (file://C%3A/Dev/alparr-labs/homarr/apps/nextjs/apps/nextjs/src/app/%5Blocale%5D/boards/%28content%29/%5Bname%5D/%28board%29/_definition.tsx:6:31)
@homarr/nextjs:dev:     at Module.generateMetadataAsync (file://C%3A/Dev/alparr-labs/homarr/apps/nextjs/apps/nextjs/src/app/%5Blocale%5D/boards/%28content%29/_creator.tsx:46:28)
@homarr/nextjs:dev:   4 |
@homarr/nextjs:dev:   5 | export default createBoardContentPage<{ locale: string; name: string }>({
@homarr/nextjs:dev: > 6 |   async getInitialBoardAsync({ name }) {
@homarr/nextjs:dev:     |                               ^
@homarr/nextjs:dev:   7 |     return await api.board.getBoardByName({ name });
@homarr/nextjs:dev:   8 |   },
@homarr/nextjs:dev:   9 | });
```