### PR TITLE
fix(old-import): default logo and favicon not replaced

### DIFF
--- a/packages/old-import/src/mappers/map-board.ts
+++ b/packages/old-import/src/mappers/map-board.ts
@@ -14,12 +14,40 @@ export const mapBoard = (preparedBoard: PreparedBoard): InferInsertModel<typeof 
   backgroundImageUrl: preparedBoard.config.settings.customization.backgroundImageUrl,
   backgroundImageRepeat: preparedBoard.config.settings.customization.backgroundImageRepeat,
   backgroundImageSize: preparedBoard.config.settings.customization.backgroundImageSize,
-  faviconImageUrl: preparedBoard.config.settings.customization.faviconUrl,
+  faviconImageUrl: mapFavicon(preparedBoard.config.settings.customization.faviconUrl),
   isPublic: preparedBoard.config.settings.access.allowGuests,
-  logoImageUrl: preparedBoard.config.settings.customization.logoImageUrl,
+  logoImageUrl: mapLogo(preparedBoard.config.settings.customization.logoImageUrl),
   pageTitle: preparedBoard.config.settings.customization.pageTitle,
   metaTitle: preparedBoard.config.settings.customization.metaTitle,
   opacity: preparedBoard.config.settings.customization.appOpacity,
   primaryColor: mapColor(preparedBoard.config.settings.customization.colors.primary, "#fa5252"),
   secondaryColor: mapColor(preparedBoard.config.settings.customization.colors.secondary, "#fd7e14"),
 });
+
+const defaultOldmarrLogoPath = "/imgs/logo/logo.png";
+
+const mapLogo = (logo: string | null | undefined) => {
+  if (!logo) {
+    return null;
+  }
+
+  if (logo.trim() === defaultOldmarrLogoPath) {
+    return null; // We fallback to default logo when null
+  }
+
+  return logo;
+};
+
+const defaultOldmarrFaviconPath = "/imgs/favicon/favicon-squared.png";
+
+const mapFavicon = (favicon: string | null | undefined) => {
+  if (!favicon) {
+    return null;
+  }
+
+  if (favicon.trim() === defaultOldmarrFaviconPath) {
+    return null; // We fallback to default favicon when null
+  }
+
+  return favicon;
+};


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Closes #2246

From
![image](https://github.com/user-attachments/assets/53944ab8-3a3e-4e1c-9d03-44f18be2c56c)


To
![image](https://github.com/user-attachments/assets/cf79caaa-95e3-41c9-91dc-c488d381472e)
