### PR TITLE
fix(minecraft-status): wrong api path for bedrock

### DIFF
--- a/packages/request-handler/src/minecraft-server-status.ts
+++ b/packages/request-handler/src/minecraft-server-status.ts
@@ -9,7 +9,7 @@ export const minecraftServerStatusRequestHandler = createCachedWidgetRequestHand
   queryKey: "minecraftServerStatusApiResult",
   widgetKind: "minecraftServerStatus",
   async requestAsync(input: { domain: string; isBedrockServer: boolean }) {
-    const path = `/3/${input.isBedrockServer ? "bedrock/" : ""}${input.domain}`;
+    const path = `${input.isBedrockServer ? "/bedrock" : ""}/3/${input.domain}`;
 
     const response = await fetchWithTimeout(`https://api.mcsrvstat.us${path}`);
     return responseSchema.parse(await response.json());

--- a/packages/widgets/src/minecraft/server-status/component.tsx
+++ b/packages/widgets/src/minecraft/server-status/component.tsx
@@ -36,7 +36,7 @@ export default function MinecraftServerStatusWidget({ options }: WidgetComponent
     >
       <Group gap="xs" wrap="nowrap" align="center">
         <Tooltip label={data.online ? tStatus("online") : tStatus("offline")}>
-          <Box w="md" h="md" bg={data.online ? "teal" : "red"} style={{ borderRadius: "100%" }}></Box>
+          <Box miw="md" h="md" bg={data.online ? "teal" : "red"} style={{ borderRadius: "100%" }}></Box>
         </Tooltip>
         <Text size="md" fw="bold">
           {title}
@@ -44,11 +44,13 @@ export default function MinecraftServerStatusWidget({ options }: WidgetComponent
       </Group>
       {data.online && (
         <>
-          <img
-            style={{ flex: 1, transform: "scale(0.8)", objectFit: "contain" }}
-            alt={`minecraft icon ${options.domain}`}
-            src={data.icon}
-          />
+          {!options.isBedrockServer && (
+            <img
+              style={{ flex: 1, transform: "scale(0.8)", objectFit: "contain" }}
+              alt={`minecraft icon ${options.domain}`}
+              src={data.icon}
+            />
+          )}
           <Group gap={5} c="gray.6" align="center">
             <IconUsersGroup size="1rem" />
             <Text size="md">


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

![image](https://github.com/user-attachments/assets/17e9d610-4bea-4f08-88cc-862c37b787fe)
Closes https://www.reddit.com/r/homarr/comments/1j6ujgg/minecraft_bedrock_error/?rdt=58902