### PR TITLE
feat(logs): improve error logs with stacked causes

### DIFF
--- a/packages/log/src/index.ts
+++ b/packages/log/src/index.ts
@@ -4,8 +4,41 @@ import winston, { format, transports } from "winston";
 import { env } from "./env";
 import { RedisTransport } from "./redis-transport";
 
-const logMessageFormat = format.printf(({ level, message, timestamp }) => {
-  return `${timestamp as string} ${level}: ${message as string}`;
+/**
+ * Formats the cause of an error in the format
+ * @example caused by Error: {message}
+ * {stack-trace}
+ * @param cause next cause in the chain
+ * @param iteration current iteration of the function
+ * @returns formatted and stacked causes
+ */
+const formatCause = (cause: unknown, iteration = 0): string => {
+  // Prevent infinite recursion
+  if (iteration > 5) {
+    return "";
+  }
+
+  if (cause instanceof Error) {
+    if (!cause.cause) {
+      return `\ncaused by ${cause.stack}`;
+    }
+
+    return `\ncaused by ${cause.stack}${formatCause(cause.cause, iteration + 1)}`;
+  }
+
+  return `\ncaused by ${cause as string}`;
+};
+
+const logMessageFormat = format.printf(({ level, message, timestamp, cause, stack }) => {
+  if (!cause && !stack) {
+    return `${timestamp as string} ${level}: ${message as string}`;
+  }
+
+  if (!cause) {
+    return `${timestamp as string} ${level}: ${message as string}\n${stack as string}`;
+  }
+
+  return `${timestamp as string} ${level}: ${message as string}\n${stack as string}${formatCause(cause)}`;
 });
 
 const logTransports: Transport[] = [new transports.Console()];
@@ -16,7 +49,12 @@ if (!(Boolean(process.env.CI) || Boolean(process.env.DISABLE_REDIS_LOGS))) {
 }
 
 const logger = winston.createLogger({
-  format: format.combine(format.colorize(), format.timestamp(), logMessageFormat),
+  format: format.combine(
+    format.colorize(),
+    format.timestamp(),
+    format.errors({ stack: true, cause: true }),
+    logMessageFormat,
+  ),
   transports: logTransports,
   level: env.LOG_LEVEL,
 });


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Logs now look like the following when the logged value is an error:
![image](https://github.com/user-attachments/assets/9f39ac4a-7312-40c9-b010-09e1459a4bb2)

This means in general all error logs should be logged as error like:
`logger.error(new Error(`Failed to parse something`, { cause: catchedError }))`
This way it will show the stack trace with the current log statements location and all the below errors