### PR TITLE
feat(widget): add restriction callback to restrict visibility and modification of widget kinds

### DIFF
--- a/apps/nextjs/src/components/board/items/item-menu.tsx
+++ b/apps/nextjs/src/components/board/items/item-menu.tsx
@@ -3,6 +3,8 @@ import { ActionIcon, Menu } from "@mantine/core";
 import { IconCopy, IconDotsVertical, IconLayoutKanban, IconPencil, IconTrash } from "@tabler/icons-react";
 
 import { clientApi } from "@homarr/api/client";
+import { useSession } from "@homarr/auth/client";
+import { isWidgetRestricted } from "@homarr/auth/shared";
 import { useEditMode } from "@homarr/boards/edit-mode";
 import { useConfirmModal, useModalAction } from "@homarr/modals";
 import { useSettings } from "@homarr/settings";
@@ -37,6 +39,7 @@ export const BoardItemMenu = ({
   const currentDefinition = useMemo(() => widgetImports[item.kind].definition, [item.kind]);
   const { gridstack } = useSectionContext().refs;
   const settings = useSettings();
+  const { data: session } = useSession();
 
   // Reset error boundary on next render if item has been edited
   useEffect(() => {
@@ -90,6 +93,16 @@ export const BoardItemMenu = ({
       },
     });
   };
+
+  if (
+    isWidgetRestricted({
+      definition: currentDefinition,
+      user: session?.user ?? null,
+      check: (level) => level !== "none",
+    })
+  ) {
+    return null;
+  }
 
   return (
     <Menu withinPortal withArrow position="right-start" arrowPosition="center">

--- a/apps/nextjs/src/components/board/items/restricted.tsx
+++ b/apps/nextjs/src/components/board/items/restricted.tsx
@@ -1,0 +1,26 @@
+import { Center, Group, Stack, Text } from "@mantine/core";
+import { IconShield } from "@tabler/icons-react";
+
+import type { WidgetKind } from "@homarr/definitions";
+import { useScopedI18n } from "@homarr/translation/client";
+
+interface RestrictedWidgetProps {
+  kind: WidgetKind;
+}
+
+export const RestrictedWidgetContent = ({ kind }: RestrictedWidgetProps) => {
+  const tCurrentWidget = useScopedI18n(`widget.${kind}`);
+  const tCommonWidget = useScopedI18n("widget.common");
+
+  return (
+    <Center h="100%">
+      <Stack ta="center" gap="xs" align="center">
+        <Group gap="sm">
+          <IconShield size={16} />
+          <Text fw="bold">{tCommonWidget("restricted.title")}</Text>
+        </Group>
+        <Text>{tCommonWidget("restricted.description", { name: tCurrentWidget("name") })}</Text>
+      </Stack>
+    </Center>
+  );
+};

--- a/packages/api/src/router/board.ts
+++ b/packages/api/src/router/board.ts
@@ -2,7 +2,7 @@ import { TRPCError } from "@trpc/server";
 import superjson from "superjson";
 import { z } from "zod";
 
-import { constructBoardPermissions } from "@homarr/auth/shared";
+import { constructBoardPermissions, isWidgetRestricted } from "@homarr/auth/shared";
 import type { DeviceType } from "@homarr/common/server";
 import type { Database, InferInsertModel, InferSelectModel, SQL } from "@homarr/db";
 import { and, asc, createId, eq, handleTransactionsAsync, inArray, isNull, like, not, or, sql } from "@homarr/db";
@@ -40,6 +40,7 @@ import { oldmarrConfigSchema } from "@homarr/old-schema";
 import type { BoardItemAdvancedOptions } from "@homarr/validation";
 import { sectionSchema, sharedItemSchema, validation, zodUnionFromArray } from "@homarr/validation";
 
+import { widgetImports } from "../../../widgets/src";
 import { createTRPCRouter, permissionRequiredProcedure, protectedProcedure, publicProcedure } from "../trpc";
 import { throwIfActionForbiddenAsync } from "./board/board-access";
 import { generateResponsiveGridFor } from "./board/grid-algorithm";
@@ -310,6 +311,13 @@ export const boardRouter = createTRPCRouter({
       }
 
       const { sections: boardSections, items: boardItems, layouts: boardLayouts, ...boardProps } = board;
+      const allowedBoardItems = boardItems.filter((item) => {
+        return !isWidgetRestricted({
+          definition: widgetImports[item.kind].definition,
+          user: ctx.session.user,
+          check: (level) => level !== "none",
+        });
+      });
 
       const newBoardId = createId();
 
@@ -357,8 +365,8 @@ export const boardRouter = createTRPCRouter({
           ),
       );
 
-      const itemMap = new Map<string, string>(boardItems.map((item) => [item.id, createId()]));
-      const itemsToInsert: InferInsertModel<typeof items>[] = boardItems.map(
+      const itemMap = new Map<string, string>(allowedBoardItems.map((item) => [item.id, createId()]));
+      const itemsToInsert: InferInsertModel<typeof items>[] = allowedBoardItems.map(
         ({ integrations: _, layouts: _layouts, ...item }) => ({
           ...item,
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -367,7 +375,7 @@ export const boardRouter = createTRPCRouter({
         }),
       );
 
-      const itemLayoutsToInsert: InferInsertModel<typeof itemLayouts>[] = boardItems.flatMap((item) =>
+      const itemLayoutsToInsert: InferInsertModel<typeof itemLayouts>[] = allowedBoardItems.flatMap((item) =>
         item.layouts.map(
           (layoutSection): InferInsertModel<typeof itemLayouts> => ({
             ...layoutSection,
@@ -400,7 +408,7 @@ export const boardRouter = createTRPCRouter({
             )
             .then((result) => result.map((row) => row.id));
 
-      const itemIntegrationsToInsert = boardItems.flatMap((item) =>
+      const itemIntegrationsToInsert = allowedBoardItems.flatMap((item) =>
         item.integrations
           // Restrict integrations to only those the user has access to
           .filter(({ integrationId }) => integrationIdsWithAccess.includes(integrationId) || hasAccessForAll)
@@ -730,105 +738,140 @@ export const boardRouter = createTRPCRouter({
 
     const dbBoard = await getFullBoardWithWhereAsync(ctx.db, eq(boards.id, input.id), ctx.session.user.id);
 
+    const addedSections = filterAddedItems(input.sections, dbBoard.sections);
+    const sectionsToInsert = addedSections.map(
+      (section): InferInsertModel<typeof sections> => ({
+        id: section.id,
+        kind: section.kind,
+        yOffset: section.kind !== "dynamic" ? section.yOffset : null,
+        xOffset: section.kind === "dynamic" ? null : 0,
+        options: section.kind === "dynamic" ? superjson.stringify(section.options) : emptySuperJSON,
+        name: "name" in section ? section.name : null,
+        boardId: dbBoard.id,
+      }),
+    );
+
+    const sectionLayoutsToInsert = addedSections
+      .filter((section) => section.kind === "dynamic")
+      .flatMap((section) =>
+        section.layouts.map(
+          (sectionLayout): InferInsertModel<typeof sectionLayouts> => ({
+            layoutId: sectionLayout.layoutId,
+            sectionId: section.id,
+            parentSectionId: sectionLayout.parentSectionId,
+            height: sectionLayout.height,
+            width: sectionLayout.width,
+            xOffset: sectionLayout.xOffset,
+            yOffset: sectionLayout.yOffset,
+          }),
+        ),
+      );
+
+    const addedItems = filterAddedItems(input.items, dbBoard.items).filter((item) => {
+      return !isWidgetRestricted({
+        definition: widgetImports[item.kind].definition,
+        user: ctx.session.user,
+        check: (level) => level !== "none",
+      });
+    });
+    const itemsToInsert = addedItems.map(
+      (item): InferInsertModel<typeof items> => ({
+        id: item.id,
+        kind: item.kind,
+        options: superjson.stringify(item.options),
+        advancedOptions: superjson.stringify(item.advancedOptions),
+        boardId: dbBoard.id,
+      }),
+    );
+
+    const itemLayoutsToInsert = addedItems.flatMap((item) =>
+      item.layouts.map(
+        (layoutSection): InferInsertModel<typeof itemLayouts> => ({
+          layoutId: layoutSection.layoutId,
+          sectionId: layoutSection.sectionId,
+          itemId: item.id,
+          height: layoutSection.height,
+          width: layoutSection.width,
+          xOffset: layoutSection.xOffset,
+          yOffset: layoutSection.yOffset,
+        }),
+      ),
+    );
+
+    const inputIntegrationRelations = input.items.flatMap(({ integrationIds, id: itemId }) =>
+      integrationIds.map((integrationId) => ({
+        integrationId,
+        itemId,
+      })),
+    );
+    const dbIntegrationRelations = dbBoard.items.flatMap(({ integrationIds, id: itemId }) =>
+      integrationIds.map((integrationId) => ({
+        integrationId,
+        itemId,
+      })),
+    );
+    const addedIntegrationRelations = inputIntegrationRelations.filter(
+      (inputRelation) =>
+        !dbIntegrationRelations.some(
+          (dbRelation) =>
+            dbRelation.itemId === inputRelation.itemId && dbRelation.integrationId === inputRelation.integrationId,
+        ),
+    );
+    const integrationItemsToInsert = addedIntegrationRelations.map((relation) => ({
+      itemId: relation.itemId,
+      integrationId: relation.integrationId,
+    }));
+
+    const updatedItems = filterUpdatedItems(input.items, dbBoard.items).filter((item) => {
+      return !isWidgetRestricted({
+        definition: widgetImports[item.kind].definition,
+        user: ctx.session.user,
+        check: (level) => level !== "none",
+      });
+    });
+    const updatedSections = filterUpdatedItems(input.sections, dbBoard.sections);
+
+    const removedIntegrationRelations = dbIntegrationRelations.filter(
+      (dbRelation) =>
+        !inputIntegrationRelations.some(
+          (inputRelation) =>
+            dbRelation.itemId === inputRelation.itemId && dbRelation.integrationId === inputRelation.integrationId,
+        ),
+    );
+
+    const removedItems = filterRemovedItems(input.items, dbBoard.items).filter((item) => {
+      return !isWidgetRestricted({
+        definition: widgetImports[item.kind].definition,
+        user: ctx.session.user,
+        check: (level) => level !== "none",
+      });
+    });
+    const itemIdsToRemove = removedItems.map((item) => item.id);
+
+    const removedSections = filterRemovedItems(input.sections, dbBoard.sections);
+    const sectionIdsToRemove = removedSections.map((section) => section.id);
+
     await handleTransactionsAsync(ctx.db, {
       async handleAsync(db, schema) {
         await db.transaction(async (transaction) => {
-          const addedSections = filterAddedItems(input.sections, dbBoard.sections);
-
-          if (addedSections.length > 0) {
-            await transaction.insert(schema.sections).values(
-              addedSections.map((section) => ({
-                id: section.id,
-                kind: section.kind,
-                yOffset: section.kind !== "dynamic" ? section.yOffset : null,
-                xOffset: section.kind === "dynamic" ? null : 0,
-                options: section.kind === "dynamic" ? superjson.stringify(section.options) : emptySuperJSON,
-                name: "name" in section ? section.name : null,
-                boardId: dbBoard.id,
-              })),
-            );
-
-            if (addedSections.some((section) => section.kind === "dynamic")) {
-              await transaction.insert(schema.sectionLayouts).values(
-                addedSections
-                  .filter((section) => section.kind === "dynamic")
-                  .flatMap((section) =>
-                    section.layouts.map(
-                      (sectionLayout): InferInsertModel<typeof schema.sectionLayouts> => ({
-                        layoutId: sectionLayout.layoutId,
-                        sectionId: section.id,
-                        parentSectionId: sectionLayout.parentSectionId,
-                        height: sectionLayout.height,
-                        width: sectionLayout.width,
-                        xOffset: sectionLayout.xOffset,
-                        yOffset: sectionLayout.yOffset,
-                      }),
-                    ),
-                  ),
-              );
-            }
+          if (sectionsToInsert.length > 0) {
+            await transaction.insert(schema.sections).values(sectionsToInsert);
           }
 
-          const addedItems = filterAddedItems(input.items, dbBoard.items);
-
-          if (addedItems.length > 0) {
-            await transaction.insert(schema.items).values(
-              addedItems.map((item) => ({
-                id: item.id,
-                kind: item.kind,
-                options: superjson.stringify(item.options),
-                advancedOptions: superjson.stringify(item.advancedOptions),
-                boardId: dbBoard.id,
-              })),
-            );
-            await transaction.insert(schema.itemLayouts).values(
-              addedItems.flatMap((item) =>
-                item.layouts.map(
-                  (layoutSection): InferInsertModel<typeof schema.itemLayouts> => ({
-                    layoutId: layoutSection.layoutId,
-                    sectionId: layoutSection.sectionId,
-                    itemId: item.id,
-                    height: layoutSection.height,
-                    width: layoutSection.width,
-                    xOffset: layoutSection.xOffset,
-                    yOffset: layoutSection.yOffset,
-                  }),
-                ),
-              ),
-            );
+          if (sectionLayoutsToInsert.length > 0) {
+            await transaction.insert(schema.sectionLayouts).values(sectionLayoutsToInsert);
           }
 
-          const inputIntegrationRelations = input.items.flatMap(({ integrationIds, id: itemId }) =>
-            integrationIds.map((integrationId) => ({
-              integrationId,
-              itemId,
-            })),
-          );
-          const dbIntegrationRelations = dbBoard.items.flatMap(({ integrationIds, id: itemId }) =>
-            integrationIds.map((integrationId) => ({
-              integrationId,
-              itemId,
-            })),
-          );
-          const addedIntegrationRelations = inputIntegrationRelations.filter(
-            (inputRelation) =>
-              !dbIntegrationRelations.some(
-                (dbRelation) =>
-                  dbRelation.itemId === inputRelation.itemId &&
-                  dbRelation.integrationId === inputRelation.integrationId,
-              ),
-          );
-
-          if (addedIntegrationRelations.length > 0) {
-            await transaction.insert(schema.integrationItems).values(
-              addedIntegrationRelations.map((relation) => ({
-                itemId: relation.itemId,
-                integrationId: relation.integrationId,
-              })),
-            );
+          if (itemsToInsert.length > 0) {
+            await transaction.insert(schema.items).values(itemsToInsert);
+          }
+          if (itemLayoutsToInsert.length > 0) {
+            await transaction.insert(schema.itemLayouts).values(itemLayoutsToInsert);
           }
 
-          const updatedItems = filterUpdatedItems(input.items, dbBoard.items);
+          if (integrationItemsToInsert.length > 0) {
+            await transaction.insert(schema.integrationItems).values(integrationItemsToInsert);
+          }
 
           for (const item of updatedItems) {
             await transaction
@@ -858,8 +901,6 @@ export const boardRouter = createTRPCRouter({
                 );
             }
           }
-
-          const updatedSections = filterUpdatedItems(input.sections, dbBoard.sections);
 
           for (const section of updatedSections) {
             const prev = dbBoard.sections.find((dbSection) => dbSection.id === section.id);
@@ -894,15 +935,6 @@ export const boardRouter = createTRPCRouter({
             }
           }
 
-          const removedIntegrationRelations = dbIntegrationRelations.filter(
-            (dbRelation) =>
-              !inputIntegrationRelations.some(
-                (inputRelation) =>
-                  dbRelation.itemId === inputRelation.itemId &&
-                  dbRelation.integrationId === inputRelation.integrationId,
-              ),
-          );
-
           for (const relation of removedIntegrationRelations) {
             await transaction
               .delete(schema.integrationItems)
@@ -914,134 +946,36 @@ export const boardRouter = createTRPCRouter({
               );
           }
 
-          const removedItems = filterRemovedItems(input.items, dbBoard.items);
-
-          const itemIds = removedItems.map((item) => item.id);
-          if (itemIds.length > 0) {
-            await transaction.delete(schema.items).where(inArray(schema.items.id, itemIds));
+          if (itemIdsToRemove.length > 0) {
+            await transaction.delete(schema.items).where(inArray(schema.items.id, itemIdsToRemove));
           }
 
-          const removedSections = filterRemovedItems(input.sections, dbBoard.sections);
-          const sectionIds = removedSections.map((section) => section.id);
-
-          if (sectionIds.length > 0) {
-            await transaction.delete(schema.sections).where(inArray(schema.sections.id, sectionIds));
+          if (sectionIdsToRemove.length > 0) {
+            await transaction.delete(schema.sections).where(inArray(schema.sections.id, sectionIdsToRemove));
           }
         });
       },
       handleSync(db) {
         db.transaction((transaction) => {
-          const addedSections = filterAddedItems(input.sections, dbBoard.sections);
-
-          if (addedSections.length > 0) {
-            transaction
-              .insert(sections)
-              .values(
-                addedSections.map((section) => ({
-                  id: section.id,
-                  kind: section.kind,
-                  yOffset: section.kind !== "dynamic" ? section.yOffset : null,
-                  xOffset: section.kind === "dynamic" ? null : 0,
-                  options: section.kind === "dynamic" ? superjson.stringify(section.options) : emptySuperJSON,
-                  name: "name" in section ? section.name : null,
-                  boardId: dbBoard.id,
-                })),
-              )
-              .run();
-
-            if (addedSections.some((section) => section.kind === "dynamic")) {
-              transaction
-                .insert(sectionLayouts)
-                .values(
-                  addedSections
-                    .filter((section) => section.kind === "dynamic")
-                    .flatMap((section) =>
-                      section.layouts.map(
-                        (sectionLayout): InferInsertModel<typeof sectionLayouts> => ({
-                          layoutId: sectionLayout.layoutId,
-                          sectionId: section.id,
-                          parentSectionId: sectionLayout.parentSectionId,
-                          height: sectionLayout.height,
-                          width: sectionLayout.width,
-                          xOffset: sectionLayout.xOffset,
-                          yOffset: sectionLayout.yOffset,
-                        }),
-                      ),
-                    ),
-                )
-                .run();
-            }
+          if (sectionsToInsert.length > 0) {
+            transaction.insert(sections).values(sectionsToInsert).run();
           }
 
-          const addedItems = filterAddedItems(input.items, dbBoard.items);
-
-          if (addedItems.length > 0) {
-            transaction
-              .insert(items)
-              .values(
-                addedItems.map((item) => ({
-                  id: item.id,
-                  kind: item.kind,
-                  options: superjson.stringify(item.options),
-                  advancedOptions: superjson.stringify(item.advancedOptions),
-                  boardId: dbBoard.id,
-                })),
-              )
-              .run();
-            transaction
-              .insert(itemLayouts)
-              .values(
-                addedItems.flatMap((item) =>
-                  item.layouts.map(
-                    (layoutSection): InferInsertModel<typeof itemLayouts> => ({
-                      layoutId: layoutSection.layoutId,
-                      sectionId: layoutSection.sectionId,
-                      itemId: item.id,
-                      height: layoutSection.height,
-                      width: layoutSection.width,
-                      xOffset: layoutSection.xOffset,
-                      yOffset: layoutSection.yOffset,
-                    }),
-                  ),
-                ),
-              )
-              .run();
+          if (sectionLayoutsToInsert.length > 0) {
+            transaction.insert(sectionLayouts).values(sectionLayoutsToInsert).run();
           }
 
-          const inputIntegrationRelations = input.items.flatMap(({ integrationIds, id: itemId }) =>
-            integrationIds.map((integrationId) => ({
-              integrationId,
-              itemId,
-            })),
-          );
-          const dbIntegrationRelations = dbBoard.items.flatMap(({ integrationIds, id: itemId }) =>
-            integrationIds.map((integrationId) => ({
-              integrationId,
-              itemId,
-            })),
-          );
-          const addedIntegrationRelations = inputIntegrationRelations.filter(
-            (inputRelation) =>
-              !dbIntegrationRelations.some(
-                (dbRelation) =>
-                  dbRelation.itemId === inputRelation.itemId &&
-                  dbRelation.integrationId === inputRelation.integrationId,
-              ),
-          );
-
-          if (addedIntegrationRelations.length > 0) {
-            transaction
-              .insert(integrationItems)
-              .values(
-                addedIntegrationRelations.map((relation) => ({
-                  itemId: relation.itemId,
-                  integrationId: relation.integrationId,
-                })),
-              )
-              .run();
+          if (itemsToInsert.length > 0) {
+            transaction.insert(items).values(itemsToInsert).run();
           }
 
-          const updatedItems = filterUpdatedItems(input.items, dbBoard.items);
+          if (itemLayoutsToInsert.length > 0) {
+            transaction.insert(itemLayouts).values(itemLayoutsToInsert).run();
+          }
+
+          if (integrationItemsToInsert.length > 0) {
+            transaction.insert(integrationItems).values(integrationItemsToInsert).run();
+          }
 
           for (const item of updatedItems) {
             transaction
@@ -1068,8 +1002,6 @@ export const boardRouter = createTRPCRouter({
                 .run();
             }
           }
-
-          const updatedSections = filterUpdatedItems(input.sections, dbBoard.sections);
 
           for (const section of updatedSections) {
             const prev = dbBoard.sections.find((dbSection) => dbSection.id === section.id);
@@ -1103,15 +1035,6 @@ export const boardRouter = createTRPCRouter({
             }
           }
 
-          const removedIntegrationRelations = dbIntegrationRelations.filter(
-            (dbRelation) =>
-              !inputIntegrationRelations.some(
-                (inputRelation) =>
-                  dbRelation.itemId === inputRelation.itemId &&
-                  dbRelation.integrationId === inputRelation.integrationId,
-              ),
-          );
-
           for (const relation of removedIntegrationRelations) {
             transaction
               .delete(integrationItems)
@@ -1124,18 +1047,12 @@ export const boardRouter = createTRPCRouter({
               .run();
           }
 
-          const removedItems = filterRemovedItems(input.items, dbBoard.items);
-
-          const itemIds = removedItems.map((item) => item.id);
-          if (itemIds.length > 0) {
-            transaction.delete(items).where(inArray(items.id, itemIds)).run();
+          if (itemIdsToRemove.length > 0) {
+            transaction.delete(items).where(inArray(items.id, itemIdsToRemove)).run();
           }
 
-          const removedSections = filterRemovedItems(input.sections, dbBoard.sections);
-          const sectionIds = removedSections.map((section) => section.id);
-
-          if (sectionIds.length > 0) {
-            transaction.delete(sections).where(inArray(sections.id, sectionIds)).run();
+          if (sectionIdsToRemove.length > 0) {
+            transaction.delete(sections).where(inArray(sections.id, sectionIdsToRemove)).run();
           }
         });
       },

--- a/packages/auth/permissions/index.ts
+++ b/packages/auth/permissions/index.ts
@@ -1,2 +1,3 @@
 export * from "./board-permissions";
 export * from "./integration-permissions";
+export * from "./widget-restriction";

--- a/packages/auth/permissions/widget-restriction.ts
+++ b/packages/auth/permissions/widget-restriction.ts
@@ -1,0 +1,14 @@
+import type { Session } from "next-auth";
+
+import type { WidgetDefinition } from "../../widgets/src";
+import type { RestrictionLevel } from "../../widgets/src/definition";
+
+export const isWidgetRestricted = <TDefinition extends WidgetDefinition>(props: {
+  definition: TDefinition;
+  user: Session["user"] | null;
+  check: (level: RestrictionLevel) => boolean;
+}) => {
+  if (!("restrict" in props.definition)) return false;
+  if (props.definition.restrict === undefined) return false;
+  return props.check(props.definition.restrict({ user: props.user ?? null }));
+};

--- a/packages/old-import/package.json
+++ b/packages/old-import/package.json
@@ -26,6 +26,7 @@
   },
   "prettier": "@homarr/prettier-config",
   "dependencies": {
+    "@homarr/auth": "workspace:^0.1.0",
     "@homarr/common": "workspace:^0.1.0",
     "@homarr/db": "workspace:^0.1.0",
     "@homarr/definitions": "workspace:^0.1.0",

--- a/packages/old-import/src/import/collections/board-collection.ts
+++ b/packages/old-import/src/import/collections/board-collection.ts
@@ -1,9 +1,12 @@
+import type { Session } from "@homarr/auth";
+import { isWidgetRestricted } from "@homarr/auth/shared";
 import { createId } from "@homarr/db";
 import { createDbInsertCollectionForTransaction } from "@homarr/db/collection";
 import { logger } from "@homarr/log";
 import type { BoardSize } from "@homarr/old-schema";
 import { boardSizes, getBoardSizeName } from "@homarr/old-schema";
 
+import { widgetImports } from "../../../../widgets/src";
 import { fixSectionIssues } from "../../fix-section-issues";
 import { mapBoard } from "../../mappers/map-board";
 import { mapBreakpoint } from "../../mappers/map-breakpoint";
@@ -17,6 +20,7 @@ import type { InitialOldmarrImportSettings } from "../../settings";
 export const createBoardInsertCollection = (
   { preparedApps, preparedBoards }: Omit<ReturnType<typeof prepareMultipleImports>, "preparedIntegrations">,
   settings: InitialOldmarrImportSettings,
+  session: Session | null,
 ) => {
   const insertCollection = createDbInsertCollectionForTransaction([
     "apps",
@@ -105,10 +109,18 @@ export const createBoardInsertCollection = (
       layoutMapping,
       mappedBoard.id,
     );
-    preparedItems.forEach(({ layouts, ...item }) => {
-      insertCollection.items.push(item);
-      insertCollection.itemLayouts.push(...layouts);
-    });
+    preparedItems
+      .filter((item) => {
+        return !isWidgetRestricted({
+          definition: widgetImports[item.kind].definition,
+          user: session?.user ?? null,
+          check: (level) => level !== "none",
+        });
+      })
+      .forEach(({ layouts, ...item }) => {
+        insertCollection.items.push(item);
+        insertCollection.itemLayouts.push(...layouts);
+      });
     logger.debug(`Added items to board insert collection count=${insertCollection.items.length}`);
   });
 

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -1721,7 +1721,11 @@
         "noIntegration": "No integration selected",
         "noData": "No integration data available"
       },
-      "option": {}
+      "option": {},
+      "restricted": {
+        "title": "Restricted",
+        "description": "You don't have access to the {name} widget."
+      }
     },
     "video": {
       "name": "Video Stream",

--- a/packages/widgets/src/definition.ts
+++ b/packages/widgets/src/definition.ts
@@ -1,6 +1,7 @@
 import type { LoaderComponent } from "next/dynamic";
 import type { DefaultErrorData } from "@trpc/server/unstable-core-do-not-import";
 
+import type { Session } from "@homarr/auth";
 import type { IntegrationKind, WidgetKind } from "@homarr/definitions";
 import type { ServerSettings } from "@homarr/server-settings";
 import type { SettingsContextProps } from "@homarr/settings";
@@ -43,7 +44,22 @@ export interface WidgetDefinition {
       }
     >
   >;
+  /**
+   * Callback that returns wheter or not the widget should be available to the user.
+   * The widget will not be available in the widget picker and saving with a new one of this kind will not be possible.
+   *
+   * @param props contain user information
+   * @returns restriction type
+   */
+  restrict?: (props: { user: Session["user"] | null }) => RestrictionLevel;
 }
+
+/**
+ * none: The widget is fully available to the user.
+ * select: The widget is available to the user but not in the widget picker.
+ * all: The widget is not available to the user. As replacement a message will be shown at the widgets position.
+ */
+export type RestrictionLevel = "none" | "select" | "all";
 
 export interface WidgetProps<TKind extends WidgetKind> {
   options: inferOptionsFromCreator<WidgetOptionsRecordOf<TKind>>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1506,6 +1506,9 @@ importers:
 
   packages/old-import:
     dependencies:
+      '@homarr/auth':
+        specifier: workspace:^0.1.0
+        version: link:../auth
       '@homarr/common':
         specifier: workspace:^0.1.0
         version: link:../common


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Example usage:

```ts
export const { definition, componentLoader } = createWidgetDefinition("dockerContainers", {
	...otherProps,
	restrict({ user }) {
    	return user?.permissions.includes("admin") ? "none" : "all";
  	},
}).withDynamicImport(() => import("./component"));
```

**Available restriction levels:**
- **none:** The widget is fully available to the user.
- **select:** The widget is available to the user but not in the widget picker.
- **all:** The widget is not available to the user. As replacement a message will be shown at the widgets position.

**Widgets when restricted:**
![image](https://github.com/user-attachments/assets/e0b3ea1d-92f5-47aa-b28d-bbb1a5eec798)

Part of #2288 