### PR TITLE
feat: add default search engines seeding / set homarr docs as global server search engine

### DIFF
--- a/packages/db/migrations/seed.ts
+++ b/packages/db/migrations/seed.ts
@@ -101,20 +101,11 @@ const seedDefaultSearchEnginesAsync = async (db: Database) => {
   // Set Homarr docs as the default search engine in server settings
   const searchSettings = await getServerSettingByKeyAsync(db, "search");
 
-  if (searchSettings) {
-    if (!searchSettings.defaultSearchEngineId) {
-      await updateServerSettingByKeyAsync(db, "search", {
-        ...searchSettings,
-        defaultSearchEngineId: homarrId,
-      });
-      console.log("Set Homarr docs as the default search engine");
-    }
-  } else {
-    await updateServerSettingByKeyAsync(db, "search", {
-      defaultSearchEngineId: homarrId,
-    });
-    console.log("Created search settings with Homarr docs as the default search engine");
-  }
+  await updateServerSettingByKeyAsync(db, "search", {
+    ...searchSettings,
+    defaultSearchEngineId: homarrId,
+  });
+  console.log("Set Homarr docs as the default search engine");
 };
 
 const seedServerSettingsAsync = async (db: Database) => {

--- a/packages/db/migrations/seed.ts
+++ b/packages/db/migrations/seed.ts
@@ -1,5 +1,5 @@
 import { objectKeys } from "@homarr/common";
-import { everyoneGroup } from "@homarr/definitions";
+import { createDocumentationLink, everyoneGroup } from "@homarr/definitions";
 import { defaultServerSettings, defaultServerSettingsKeys } from "@homarr/server-settings";
 
 import type { Database } from "..";
@@ -88,8 +88,7 @@ const seedDefaultSearchEnginesAsync = async (db: Database) => {
       iconUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/homarr.svg",
       short: "docs",
       description: "Search the Homarr documentation",
-      // eslint-disable-next-line no-restricted-syntax
-      urlTemplate: "https://homarr.dev/search?q=%s",
+      urlTemplate: createDocumentationLink("search", undefined, { q: "%s" }),
       type: "generic" as const,
       integrationId: null,
     },

--- a/packages/db/migrations/seed.ts
+++ b/packages/db/migrations/seed.ts
@@ -88,6 +88,7 @@ const seedDefaultSearchEnginesAsync = async (db: Database) => {
       iconUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/homarr.svg",
       short: "docs",
       description: "Search the Homarr documentation",
+      // eslint-disable-next-line no-restricted-syntax
       urlTemplate: "https://homarr.dev/search?q=%s",
       type: "generic" as const,
       integrationId: null,

--- a/packages/db/migrations/seed.ts
+++ b/packages/db/migrations/seed.ts
@@ -88,7 +88,7 @@ const seedDefaultSearchEnginesAsync = async (db: Database) => {
       iconUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/homarr.svg",
       short: "docs",
       description: "Search the Homarr documentation",
-      urlTemplate: createDocumentationLink("search", undefined, { q: "%s" }),
+      urlTemplate: createDocumentationLink("/search", undefined, { q: "%s" }),
       type: "generic" as const,
       integrationId: null,
     },

--- a/packages/db/migrations/seed.ts
+++ b/packages/db/migrations/seed.ts
@@ -4,15 +4,16 @@ import { objectKeys } from "@homarr/common";
 import { everyoneGroup } from "@homarr/definitions";
 import { defaultServerSettings, defaultServerSettingsKeys } from "@homarr/server-settings";
 
-import { createId, eq } from "..";
 import type { Database } from "..";
-import { onboarding, serverSettings } from "../schema";
+import { createId, eq } from "..";
+import { onboarding, searchEngines, serverSettings } from "../schema";
 import { groups } from "../schema/mysql";
 
 export const seedDataAsync = async (db: Database) => {
   await seedEveryoneGroupAsync(db);
   await seedOnboardingAsync(db);
   await seedServerSettingsAsync(db);
+  await seedDefaultSearchEnginesAsync(db);
 };
 
 const seedEveryoneGroupAsync = async (db: Database) => {
@@ -46,6 +47,51 @@ const seedOnboardingAsync = async (db: Database) => {
     step: "start",
   });
   console.log("Created onboarding step through seed");
+};
+
+const seedDefaultSearchEnginesAsync = async (db: Database) => {
+  const existingSearchEngines = await db.query.searchEngines.findMany();
+  
+  if (existingSearchEngines.length > 0) {
+    console.log("Skipping seeding of default search engines as some already exists");
+    return;
+  }
+
+  const defaultSearchEngines = [
+    {
+      id: createId(),
+      name: "Google",
+      iconUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/google.svg",
+      short: "g",
+      description: "Search the web with Google",
+      urlTemplate: "https://www.google.com/search?q=%s",
+      type: "generic" as const,
+      integrationId: null,
+    },
+    {
+      id: createId(),
+      name: "YouTube",
+      iconUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/youtube.svg",
+      short: "yt",
+      description: "Search for videos on YouTube",
+      urlTemplate: "https://www.youtube.com/results?search_query=%s",
+      type: "generic" as const,
+      integrationId: null,
+    },
+    {
+      id: createId(),
+      name: "Homarr Docs",
+      iconUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/homarr.svg",
+      short: "docs",
+      description: "Search the Homarr documentation",
+      urlTemplate: "https://homarr.dev/search?q=%s",
+      type: "generic" as const,
+      integrationId: null,
+    },
+  ];
+
+  await db.insert(searchEngines).values(defaultSearchEngines);
+  console.log(`Created ${defaultSearchEngines.length} default search engines through seeding process`);
 };
 
 const seedServerSettingsAsync = async (db: Database) => {

--- a/packages/db/queries/server-setting.ts
+++ b/packages/db/queries/server-setting.ts
@@ -51,7 +51,11 @@ export const updateServerSettingByKeyAsync = async <TKey extends keyof ServerSet
     .where(eq(serverSettings.settingKey, key));
 };
 
-export const insertServerSettingByKeyAsync = async <TKey extends keyof ServerSettings>(db: Database, key: TKey, value: ServerSettings[TKey]) => {
+export const insertServerSettingByKeyAsync = async <TKey extends keyof ServerSettings>(
+  db: Database,
+  key: TKey,
+  value: ServerSettings[TKey],
+) => {
   await db.insert(serverSettings).values({
     settingKey: key,
     value: SuperJSON.stringify(value),

--- a/packages/db/queries/server-setting.ts
+++ b/packages/db/queries/server-setting.ts
@@ -50,3 +50,10 @@ export const updateServerSettingByKeyAsync = async <TKey extends keyof ServerSet
     })
     .where(eq(serverSettings.settingKey, key));
 };
+
+export const insertServerSettingByKeyAsync = async <TKey extends keyof ServerSettings>(db: Database, key: TKey, value: ServerSettings[TKey]) => {
+  await db.insert(serverSettings).values({
+    settingKey: key,
+    value: SuperJSON.stringify(value),
+  });
+};

--- a/packages/definitions/src/docs/index.ts
+++ b/packages/definitions/src/docs/index.ts
@@ -3,5 +3,12 @@ import type { HomarrDocumentationPath } from "./homarr-docs-sitemap";
 const documentationBaseUrl = "https://homarr.dev";
 
 // Please use the method so the path can be checked!
-export const createDocumentationLink = (path: HomarrDocumentationPath, hashTag?: `#${string}`) =>
-  `${documentationBaseUrl}${path}${hashTag ?? ""}`;
+export const createDocumentationLink = (
+  path: HomarrDocumentationPath,
+  hashTag?: `#${string}`,
+  queryParams?: Record<string, string>,
+) => {
+  const url = `${documentationBaseUrl}${path}`;
+  const params = queryParams ? `?${new URLSearchParams(queryParams)}` : "";
+  return `${url}${params}${hashTag ?? ""}`;
+};

--- a/packages/definitions/src/test/docs.spec.ts
+++ b/packages/definitions/src/test/docs.spec.ts
@@ -1,0 +1,47 @@
+/* eslint-disable no-restricted-syntax */
+import { describe, expect, test } from "vitest";
+
+import { createDocumentationLink } from "../docs";
+import type { HomarrDocumentationPath } from "../docs/homarr-docs-sitemap";
+
+describe("createDocumentationLink should generate correct URLs", () => {
+  test.each([
+    ["/docs/getting-started", undefined, undefined, "https://homarr.dev/docs/getting-started"],
+    ["/blog", undefined, undefined, "https://homarr.dev/blog"],
+    ["/docs/widgets/weather", "#configuration", undefined, "https://homarr.dev/docs/widgets/weather#configuration"],
+    [
+      "/docs/advanced/environment-variables",
+      undefined,
+      { lang: "en" },
+      "https://homarr.dev/docs/advanced/environment-variables?lang=en",
+    ],
+    [
+      "/docs/widgets/bookmarks",
+      "#sorting",
+      { lang: "fr", theme: "dark" },
+      "https://homarr.dev/docs/widgets/bookmarks?lang=fr&theme=dark#sorting",
+    ],
+  ] satisfies [HomarrDocumentationPath, `#${string}` | undefined, Record<string, string> | undefined, string][])(
+    "should create correct URL for path %s with hash %s and params %o",
+    (path, hashTag, queryParams, expected) => {
+      expect(createDocumentationLink(path, hashTag, queryParams)).toBe(expected);
+    },
+  );
+});
+
+describe("createDocumentationLink parameter validation", () => {
+  test("should work with only path parameter", () => {
+    const result = createDocumentationLink("/docs/getting-started");
+    expect(result).toBe("https://homarr.dev/docs/getting-started");
+  });
+
+  test("should work with path and hashtag", () => {
+    const result = createDocumentationLink("/docs/getting-started", "#installation");
+    expect(result).toBe("https://homarr.dev/docs/getting-started#installation");
+  });
+
+  test("should work with path and query params", () => {
+    const result = createDocumentationLink("/docs/getting-started", undefined, { version: "1.0" });
+    expect(result).toBe("https://homarr.dev/docs/getting-started?version=1.0");
+  });
+});


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

Added the following search engines as default during the seeding process. Feel free to directly edit the code if you'd want to use another one than Google / add more search engines. 
I also set Homarr docs as the default search engine 

<img width="624" alt="image" src="https://github.com/user-attachments/assets/5b6feb56-f034-42e7-a08a-3af8bf882058" />

