### PR TITLE
feat(middleware): implement onboarding step cache

### DIFF
--- a/apps/nextjs/src/middleware.ts
+++ b/apps/nextjs/src/middleware.ts
@@ -1,6 +1,6 @@
-import { createTRPCClient, httpLink } from "@trpc/client";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { createTRPCClient, httpLink } from "@trpc/client";
 import SuperJSON from "superjson";
 
 import type { AppRouter } from "@homarr/api";
@@ -13,8 +13,8 @@ const onboardingStatusCache = new Map<string, string>();
 const cultureCache = new Map<string, { defaultLocale: string }>();
 
 export async function middleware(request: NextRequest) {
-  const csrfToken = request.cookies.get('authjs.csrf-token')?.value;
-  
+  const csrfToken = request.cookies.get("authjs.csrf-token")?.value;
+
   // fetch api does not work because window is not defined and we need to construct the url from the headers
   // In next 15 we will be able to use node apis and such the db directly
   let culture;


### PR DESCRIPTION
This solution is very simplistic and does not rely on redis on purpose.
This is so that it saves another "round-trip" at every single request

This choice is because the middleware should be the fastest possible im my opinion 

## Decision taken 
- [ ] Keep using `let` to define a variable that lives in the middleware (kept alive by nextjs since we are not deploying our API to functions) 
- [ ] Switch to using redis to cache this value (increases round trip time but it should still be faster than trpc) 


## Tests 
Reduced the time between each page switch by about 45ms on my machine