### PR TITLE
feat: set home board when creating first board

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/boards/_components/create-board-button.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/boards/_components/create-board-button.tsx
@@ -3,18 +3,39 @@
 import { Affix, Button, Menu } from "@mantine/core";
 import { IconCategoryPlus, IconChevronDown, IconFileImport } from "@tabler/icons-react";
 
+import { clientApi } from "@homarr/api/client";
+import { revalidatePathActionAsync } from "@homarr/common/client";
 import { useModalAction } from "@homarr/modals";
 import { AddBoardModal, ImportBoardModal } from "@homarr/modals-collection";
 import { useI18n } from "@homarr/translation/client";
 
 export const CreateBoardButton = () => {
   const t = useI18n();
+  const { data: boards } = clientApi.board.getAllBoards.useQuery();
+  const { mutate: setHomeBoard } = clientApi.board.setHomeBoard.useMutation({
+    onSuccess: async () => {
+      await revalidatePathActionAsync("/manage/boards");
+    },
+  });
+
   const { openModal: openAddModal } = useModalAction(AddBoardModal);
   const { openModal: openImportModal } = useModalAction(ImportBoardModal);
 
+  const handleOpenAddModal = () => {
+    const hasHomeBoard = boards?.some((board) => board.isHome) ?? false;
+
+    openAddModal({
+      onSuccess: (boardId) => {
+        if (!hasHomeBoard && boardId) {
+          setHomeBoard({ id: boardId });
+        }
+      },
+    });
+  };
+
   const buttonGroupContent = (
     <>
-      <Button leftSection={<IconCategoryPlus size="1rem" />} onClick={openAddModal}>
+      <Button leftSection={<IconCategoryPlus size="1rem" />} onClick={handleOpenAddModal}>
         {t("management.page.board.action.new.label")}
       </Button>
       <Menu position="bottom-end">

--- a/packages/api/src/router/board.ts
+++ b/packages/api/src/router/board.ts
@@ -275,6 +275,8 @@ export const boardRouter = createTRPCRouter({
       });
 
       await createBoardCollection.insertAllAsync(ctx.db);
+
+      return { boardId };
     }),
   duplicateBoard: permissionRequiredProcedure
     .requiresPermission("board-create")
@@ -1081,8 +1083,7 @@ export const boardRouter = createTRPCRouter({
                 options: section.kind === "dynamic" ? superjson.stringify(section.options) : emptySuperJSON,
                 name: prev?.kind === "category" && "name" in section ? section.name : null,
               })
-              .where(eq(sections.id, section.id))
-              .run();
+              .where(eq(sections.id, section.id));
 
             if (section.kind !== "dynamic") continue;
 
@@ -1098,8 +1099,7 @@ export const boardRouter = createTRPCRouter({
                 })
                 .where(
                   and(eq(sectionLayouts.sectionId, section.id), eq(sectionLayouts.layoutId, sectionLayout.layoutId)),
-                )
-                .run();
+                );
             }
           }
 


### PR DESCRIPTION
Closes https://github.com/homarr-labs/homarr/issues/2680 


Auto-assigns a home board to a user when they create their first board 