### PR TITLE
feat(logs): improve logs by logging errors with causes and metadata

### DIFF
--- a/apps/nextjs/src/app/api/[...trpc]/route.ts
+++ b/apps/nextjs/src/app/api/[...trpc]/route.ts
@@ -26,6 +26,9 @@ const handlerAsync = async (req: NextRequest) => {
     endpoint: "/",
     router: appRouter,
     createContext: () => createTRPCContext({ session, headers: req.headers }),
+    onError({ error, path, type }) {
+      logger.error(new Error(`tRPC Error with ${type} on '${path}'`, { cause: error.cause }));
+    },
   });
 };
 

--- a/apps/nextjs/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/nextjs/src/app/api/trpc/[trpc]/route.ts
@@ -31,9 +31,7 @@ const handler = auth(async (req) => {
     req,
     createContext: () => createTRPCContext({ session: req.auth, headers: req.headers }),
     onError({ error, path, type }) {
-      logger.error(
-        `tRPC Error with ${type} on '${path}': (${error.code}) - ${error.message}\n${error.stack}\n${error.cause}`,
-      );
+      logger.error(new Error(`tRPC Error with ${type} on '${path}'`, { cause: error.cause }));
     },
   });
 

--- a/packages/api/src/router/integration/integration-test-connection.ts
+++ b/packages/api/src/router/integration/integration-test-connection.ts
@@ -1,5 +1,3 @@
-import { formatError } from "pretty-print-error";
-
 import { decryptSecret } from "@homarr/common/server";
 import type { Integration } from "@homarr/db/schema";
 import type { IntegrationKind, IntegrationSecretKind } from "@homarr/definitions";
@@ -41,7 +39,10 @@ export const testConnectionAsync = async (
         };
       } catch (error) {
         logger.warn(
-          `Failed to decrypt secret from database integration="${integration.name}" secretKind="${secret.kind}"\n${formatError(error)}`,
+          new Error(
+            `Failed to decrypt secret from database integration="${integration.name}" secretKind="${secret.kind}"`,
+            { cause: error },
+          ),
         );
         return null;
       }

--- a/packages/api/src/router/update-checker.ts
+++ b/packages/api/src/router/update-checker.ts
@@ -10,7 +10,7 @@ export const updateCheckerRouter = createTRPCRouter({
       const data = await handler.getCachedOrUpdatedDataAsync({});
       return data.data.availableUpdates;
     } catch (error) {
-      logger.error(new Error(`Failed to get available updates`, { cause: error }));
+      logger.error(new Error("Failed to get available updates", { cause: error }));
       return undefined; // We return undefined to not show the indicator in the UI
     }
   }),

--- a/packages/api/src/router/update-checker.ts
+++ b/packages/api/src/router/update-checker.ts
@@ -1,5 +1,3 @@
-import { formatError } from "pretty-print-error";
-
 import { logger } from "@homarr/log";
 import { updateCheckerRequestHandler } from "@homarr/request-handler/update-checker";
 
@@ -12,7 +10,7 @@ export const updateCheckerRouter = createTRPCRouter({
       const data = await handler.getCachedOrUpdatedDataAsync({});
       return data.data.availableUpdates;
     } catch (error) {
-      logger.error(`Failed to get available updates\n${formatError(error)}`);
+      logger.error(new Error(`Failed to get available updates`, { cause: error }));
       return undefined; // We return undefined to not show the indicator in the UI
     }
   }),

--- a/packages/auth/configuration.ts
+++ b/packages/auth/configuration.ts
@@ -2,7 +2,6 @@ import type { ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapte
 import { cookies } from "next/headers";
 import NextAuth from "next-auth";
 import Credentials from "next-auth/providers/credentials";
-import { formatError } from "pretty-print-error";
 
 import { db } from "@homarr/db";
 import type { SupportedAuthProvider } from "@homarr/definitions";
@@ -36,8 +35,7 @@ export const createConfiguration = (
           return;
         }
 
-        logger.error(formatError(error));
-        logger.error(formatError(error.cause));
+        logger.error(error);
       },
     },
     trustHost: true,

--- a/packages/log/src/error.ts
+++ b/packages/log/src/error.ts
@@ -1,0 +1,50 @@
+import { formatMetadata } from "./metadata";
+
+/**
+ * Formats the cause of an error in the format
+ * @example caused by Error: {message}
+ * {stack-trace}
+ * @param cause next cause in the chain
+ * @param iteration current iteration of the function
+ * @returns formatted and stacked causes
+ */
+export const formatErrorCause = (cause: unknown, iteration = 0): string => {
+  // Prevent infinite recursion
+  if (iteration > 5) {
+    return "";
+  }
+
+  if (cause instanceof Error) {
+    if (!cause.cause) {
+      return `\ncaused by ${formatErrorTitle(cause)}\n${formatErrorStack(cause.stack)}`;
+    }
+
+    return `\ncaused by ${formatErrorTitle(cause)}\n${formatErrorStack(cause.stack)}${formatErrorCause(cause.cause, iteration + 1)}`;
+  }
+
+  return `\ncaused by ${cause as string}`;
+};
+
+const ignoredErrorProperties = ["stack", "message", "name", "cause"];
+
+/**
+ * Formats the title of an error
+ * @example {name}: {message} {metadata}
+ * @param error error to format title from
+ * @returns formatted error title
+ */
+export const formatErrorTitle = (error: Error) => {
+  const title = error.message.length === 0 ? error.name : `${error.name}: ${error.message}`;
+  const metadata = formatMetadata(error, ignoredErrorProperties);
+
+  return `${title} ${metadata}`;
+};
+
+/**
+ * Formats the stack trance of an error
+ * We remove the first line as it contains the error name and message
+ * @param stack stack trace
+ * @returns formatted stack trace
+ */
+export const formatErrorStack = (stack: string | undefined) => (stack ? removeFirstLine(stack) : "");
+const removeFirstLine = (stack: string) => stack.split("\n").slice(1).join("\n");

--- a/packages/log/src/metadata.ts
+++ b/packages/log/src/metadata.ts
@@ -1,0 +1,8 @@
+export const formatMetadata = (metadata: Record<string, unknown> | Error, ignoreKeys?: string[]) => {
+  const filteredMetadata = Object.keys(metadata)
+    .filter((key) => !ignoreKeys?.includes(key))
+    .map((key) => ({ key, value: metadata[key as keyof typeof metadata] }))
+    .filter(({ value }) => typeof value !== "object" && typeof value !== "function");
+
+  return filteredMetadata.map(({ key, value }) => `${key}="${value as string}"`).join(" ");
+};

--- a/packages/ping/src/index.ts
+++ b/packages/ping/src/index.ts
@@ -1,16 +1,16 @@
-import { formatError } from "pretty-print-error";
 import type { fetch } from "undici";
 
 import { fetchWithTrustedCertificatesAsync } from "@homarr/certificates/server";
+import { extractErrorMessage } from "@homarr/common";
 import { logger } from "@homarr/log";
 
 export const sendPingRequestAsync = async (url: string) => {
   try {
     return await fetchWithTimeoutAndCertificates(url).then((response) => ({ statusCode: response.status }));
   } catch (error) {
-    logger.error("packages/ping/src/index.ts:", formatError(error));
+    logger.error(new Error(`Failed to send ping request to "${url}"`, { cause: error }));
     return {
-      error: formatError(error),
+      error: extractErrorMessage(error),
     };
   }
 };

--- a/packages/request-handler/src/lib/cached-request-integration-job-handler.ts
+++ b/packages/request-handler/src/lib/cached-request-integration-job-handler.ts
@@ -1,4 +1,3 @@
-import { formatError } from "pretty-print-error";
 import SuperJSON from "superjson";
 
 import { hashObjectBase64, Stopwatch } from "@homarr/common";
@@ -107,7 +106,9 @@ export const createRequestIntegrationJobHandler = <
         );
       } catch (error) {
         logger.error(
-          `Failed to run integration job integration=${integrationId} inputHash='${inputHash}' error=${formatError(error)}`,
+          new Error(`Failed to run integration job integration=${integrationId} inputHash='${inputHash}'`, {
+            cause: error,
+          }),
         );
       }
     }


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

This is how it looks like for a failed integration job:

```
2025-03-26T19:59:15.799Z error: Failed to run integration job integration=c9twazvm8d6zbnkgy78792f5 inputHash='W3t9XQ=='
    at <anonymous> (C:\Dev\alparr-labs\homarr\packages\request-handler\src\lib\cached-request-integration-job-handler.ts:109:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async catchingCallbackAsync (C:\Dev\alparr-labs\homarr\packages\cron-jobs-core\src\creator.ts:38:9)
caused by TypeError: fetch failed
    at fetch (C:\Dev\alparr-labs\homarr\packages\certificates\node_modules\undici\index.js:120:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async EmbyIntegration.getCurrentSessionsAsync (C:\Dev\alparr-labs\homarr\packages\integrations\src\emby\emby-integration.ts:52:22)
    at async Object.requestAsync (C:\Dev\alparr-labs\homarr\packages\request-handler\src\media-server.ts:16:12)
    at async Object.requestAsync (C:\Dev\alparr-labs\homarr\packages\request-handler\src\lib\cached-integration-request-handler.ts:34:18)
    at async requestNewDataAsync (C:\Dev\alparr-labs\homarr\packages\request-handler\src\lib\cached-request-handler.ts:28:26)
    at async Object.getCachedOrUpdatedDataAsync (C:\Dev\alparr-labs\homarr\packages\request-handler\src\lib\cached-request-handler.ts:40:20)
    at async <anonymous> (C:\Dev\alparr-labs\homarr\packages\request-handler\src\lib\cached-request-integration-job-handler.ts:103:9)
    at async catchingCallbackAsync (C:\Dev\alparr-labs\homarr\packages\cron-jobs-core\src\creator.ts:38:9)
caused by AggregateError code="ECONNREFUSED"
    at internalConnectMultiple (node:net:1121:18)
    at afterConnectMultiple (node:net:1688:7)
```