### PR TITLE
fix: calculate available space correctly and filter unmounted drives

### DIFF
--- a/packages/integrations/src/dashdot/dashdot-integration.ts
+++ b/packages/integrations/src/dashdot/dashdot-integration.ts
@@ -30,13 +30,15 @@ export class DashDotIntegration extends Integration {
       cpuUtilization: cpuLoad.sumLoad,
       memUsed: `${memoryLoad.loadInBytes}`,
       memAvailable: `${info.maxAvailableMemoryBytes - memoryLoad.loadInBytes}`,
-      fileSystem: info.storage.map((storage, index) => ({
-        deviceName: `Storage ${index + 1}: (${storage.disks.map((disk) => disk.device).join(", ")})`,
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        used: humanFileSize(storageLoad[index]!),
-        available: `${storage.size}`,
-        percentage: storageLoad[index] ? (storageLoad[index] / storage.size) * 100 : 0,
-      })),
+      fileSystem: info.storage
+        .filter((_, index) => storageLoad[index] !== -1) // filter out undermoutned drives, they display as -1 in the load API
+        .map((storage, index) => ({
+          deviceName: `Storage ${index + 1}: (${storage.disks.map((disk) => disk.device).join(", ")})`,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          used: humanFileSize(storageLoad[index]!),
+          available: storageLoad[index] ? `${storage.size - storageLoad[index]}` : `${storage.size}`,
+          percentage: storageLoad[index] ? (storageLoad[index] / storage.size) * 100 : 0,
+        })),
       cpuModelName: info.cpuModel === "" ? `Unknown Model (${info.cpuBrand})` : `${info.cpuModel} (${info.cpuBrand})`,
       cpuTemp: cpuLoad.averageTemperature,
       availablePkgUpdates: 0,


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

I've tested this with an unmounted drive and they are being filtered out now. However, the info you get back from the dashdot API is very limited, so the whole function of mapping indexes from the /load/storage endpoint to the /info endpoint might not always be correct. But this was already there before, I only applied a filter to remove the unmounted drives and fix the available storage to display the correct info

fixes: https://github.com/homarr-labs/homarr/issues/2141
fixes: https://github.com/homarr-labs/homarr/issues/2140
![image](https://github.com/user-attachments/assets/339cdb95-bf93-4df0-be10-84e250c2c860)
![image](https://github.com/user-attachments/assets/2e8e6a3d-754e-414c-bac0-bdc07f801b50)

