### PR TITLE
feat: add API support for Tdarr

### DIFF
--- a/packages/api/src/router/integration/integration-test-connection.ts
+++ b/packages/api/src/router/integration/integration-test-connection.ts
@@ -101,6 +101,18 @@ const getSecretKindOption = (kind: IntegrationKind, sourcedSecrets: SourcedInteg
   );
 
   if (onlyFormSecretsKindOptions.length >= 1) {
+    // If the first option is no secret it would always be selected even if we want to have a secret
+    if (
+      onlyFormSecretsKindOptions.length >= 2 &&
+      onlyFormSecretsKindOptions.some((secretKinds) => secretKinds.length === 0)
+    ) {
+      return (
+        // Will never be undefined because of the check above
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        onlyFormSecretsKindOptions.find((secretKinds) => secretKinds.length >= 1) ?? onlyFormSecretsKindOptions[0]!
+      );
+    }
+
     // Will never be undefined because of the check above
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return onlyFormSecretsKindOptions[0]!;

--- a/packages/definitions/src/integration.ts
+++ b/packages/definitions/src/integration.ts
@@ -142,26 +142,26 @@ export const integrationDefs = {
   dashDot: {
     name: "Dash.",
     secretKinds: [[]],
-    category: ["healthMonitoring"],
     iconUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/png/dashdot.png",
+    category: ["healthMonitoring"],
   },
   tdarr: {
     name: "Tdarr",
-    secretKinds: [[]],
-    category: ["mediaTranscoding"],
+    secretKinds: [[], ["apiKey"]],
     iconUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/png/tdarr.png",
+    category: ["mediaTranscoding"],
   },
   proxmox: {
     name: "Proxmox",
     secretKinds: [["username", "tokenId", "apiKey", "realm"]],
-    category: ["healthMonitoring"],
     iconUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/proxmox.svg",
+    category: ["healthMonitoring"],
   },
   nextcloud: {
     name: "Nextcloud",
     secretKinds: [["username", "password"]],
-    category: ["calendar"],
     iconUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/nextcloud.svg",
+    category: ["calendar"],
   },
   unifiController: {
     name: "Unifi Controller",

--- a/packages/integrations/src/media-transcoding/tdarr-integration.ts
+++ b/packages/integrations/src/media-transcoding/tdarr-integration.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 import { fetchWithTrustedCertificatesAsync } from "@homarr/certificates/server";
 
 import { Integration } from "../base/integration";
@@ -10,20 +8,41 @@ import { getNodesResponseSchema, getStatisticsSchema, getStatusTableSchema } fro
 
 export class TdarrIntegration extends Integration {
   public async testConnectionAsync(): Promise<void> {
-    const url = this.url("/api/v2/status");
-    const response = await fetchWithTrustedCertificatesAsync(url);
-    if (response.status !== 200) {
-      throw new Error(`Unexpected status code: ${response.status}`);
-    }
-
-    await z.object({ status: z.string() }).parseAsync(await response.json());
+    await super.handleTestConnectionResponseAsync({
+      queryFunctionAsync: async () => {
+        return await fetchWithTrustedCertificatesAsync(this.url("/api/v2/status"), {
+          headers: {
+            accept: "application/json",
+            "X-Api-Key": super.hasSecretValue("apiKey") ? super.getSecretValue("apiKey") : "",
+          },
+        });
+      },
+    });
+    // await super.handleTestConnectionResponseAsync({
+    //   queryFunctionAsync: async () => {
+    //     return await fetchWithTrustedCertificatesAsync(this.url("/api/v2/is-server-alive"), {
+    //       method: "POST",
+    //       headers: {
+    //         accept: "application/json",
+    //         "X-Api-Key": super.hasSecretValue("apiKey") ? super.getSecretValue("apiKey") : "",
+    //       },
+    //     });
+    //   },
+    // });
   }
 
   public async getStatisticsAsync(): Promise<TdarrStatistics> {
     const url = this.url("/api/v2/stats/get-pies");
+
+    const headerParams = {
+      accept: "application/json",
+      "Content-Type": "application/json",
+      ...(super.hasSecretValue("apiKey") ? { "X-Api-Key": super.getSecretValue("apiKey") } : {}),
+    };
+
     const response = await fetchWithTrustedCertificatesAsync(url, {
       method: "POST",
-      headers: { accept: "application/json", "Content-Type": "application/json" },
+      headers: headerParams,
       body: JSON.stringify({
         data: {
           libraryId: "", // empty string to get all libraries
@@ -62,9 +81,13 @@ export class TdarrIntegration extends Integration {
 
   public async getWorkersAsync(): Promise<TdarrWorker[]> {
     const url = this.url("/api/v2/get-nodes");
+    const headerParams = {
+      "Content-Type": "application/json",
+      ...(super.hasSecretValue("apiKey") ? { "X-Api-Key": super.getSecretValue("apiKey") } : {}),
+    };
     const response = await fetchWithTrustedCertificatesAsync(url, {
       method: "GET",
-      headers: { "content-type": "application/json" },
+      headers: headerParams,
     });
 
     const nodesData = await getNodesResponseSchema.parseAsync(await response.json());
@@ -102,9 +125,13 @@ export class TdarrIntegration extends Integration {
 
   private async getTranscodingQueueAsync(firstItemIndex: number, pageSize: number) {
     const url = this.url("/api/v2/client/status-tables");
+    const headerParams = {
+      "Content-Type": "application/json",
+      ...(super.hasSecretValue("apiKey") ? { "X-Api-Key": super.getSecretValue("apiKey") } : {}),
+    };
     const response = await fetchWithTrustedCertificatesAsync(url, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: headerParams,
       body: JSON.stringify({
         data: {
           start: firstItemIndex,
@@ -137,9 +164,13 @@ export class TdarrIntegration extends Integration {
 
   private async getHealthCheckDataAsync(firstItemIndex: number, pageSize: number, totalQueueCount: number) {
     const url = this.url("/api/v2/client/status-tables");
+    const headerParams = {
+      "Content-Type": "application/json",
+      ...(super.hasSecretValue("apiKey") ? { "X-Api-Key": super.getSecretValue("apiKey") } : {}),
+    };
     const response = await fetchWithTrustedCertificatesAsync(url, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: headerParams,
       body: JSON.stringify({
         data: {
           start: Math.max(firstItemIndex - totalQueueCount, 0),
@@ -170,4 +201,6 @@ export class TdarrIntegration extends Integration {
       totalCount: healthCheckData.totalCount,
     };
   }
+
+
 }

--- a/packages/integrations/src/media-transcoding/tdarr-integration.ts
+++ b/packages/integrations/src/media-transcoding/tdarr-integration.ts
@@ -7,7 +7,6 @@ import type { TdarrWorker } from "../interfaces/media-transcoding/workers";
 import { getNodesResponseSchema, getStatisticsSchema, getStatusTableSchema } from "./tdarr-validation-schemas";
 
 export class TdarrIntegration extends Integration {
-  // This skips the test connection as no API key is required for the status endpoint
   public async testConnectionAsync(): Promise<void> {
     await super.handleTestConnectionResponseAsync({
       queryFunctionAsync: async () => {

--- a/packages/integrations/src/media-transcoding/tdarr-integration.ts
+++ b/packages/integrations/src/media-transcoding/tdarr-integration.ts
@@ -11,7 +11,8 @@ export class TdarrIntegration extends Integration {
   public async testConnectionAsync(): Promise<void> {
     await super.handleTestConnectionResponseAsync({
       queryFunctionAsync: async () => {
-        return await fetchWithTrustedCertificatesAsync(this.url("/api/v2/status"), {
+        return await fetchWithTrustedCertificatesAsync(this.url("/api/v2/is-server-alive"), {
+          method: "POST",
           headers: {
             accept: "application/json",
             "X-Api-Key": super.hasSecretValue("apiKey") ? super.getSecretValue("apiKey") : "",
@@ -19,20 +20,6 @@ export class TdarrIntegration extends Integration {
         });
       },
     });
-
-    // This is the correct endpoint to test the connection, but it requires an API key -> value cannot be read
-
-    // await super.handleTestConnectionResponseAsync({
-    //   queryFunctionAsync: async () => {
-    //     return await fetchWithTrustedCertificatesAsync(this.url("/api/v2/is-server-alive"), {
-    //       method: "POST",
-    //       headers: {
-    //         accept: "application/json",
-    //         "X-Api-Key": super.hasSecretValue("apiKey") ? super.getSecretValue("apiKey") : "",
-    //       },
-    //     });
-    //   },
-    // });
   }
 
   public async getStatisticsAsync(): Promise<TdarrStatistics> {

--- a/packages/integrations/src/media-transcoding/tdarr-integration.ts
+++ b/packages/integrations/src/media-transcoding/tdarr-integration.ts
@@ -7,6 +7,7 @@ import type { TdarrWorker } from "../interfaces/media-transcoding/workers";
 import { getNodesResponseSchema, getStatisticsSchema, getStatusTableSchema } from "./tdarr-validation-schemas";
 
 export class TdarrIntegration extends Integration {
+  // This skips the test connection as no API key is required for the status endpoint
   public async testConnectionAsync(): Promise<void> {
     await super.handleTestConnectionResponseAsync({
       queryFunctionAsync: async () => {
@@ -18,6 +19,9 @@ export class TdarrIntegration extends Integration {
         });
       },
     });
+
+    // This is the correct endpoint to test the connection, but it requires an API key -> value cannot be read
+
     // await super.handleTestConnectionResponseAsync({
     //   queryFunctionAsync: async () => {
     //     return await fetchWithTrustedCertificatesAsync(this.url("/api/v2/is-server-alive"), {
@@ -201,6 +205,4 @@ export class TdarrIntegration extends Integration {
       totalCount: healthCheckData.totalCount,
     };
   }
-
-
 }


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

This is a draft PR

The API key support is fully integrated and optional during integration creation. 

The missing component is the `testConnectionAsync` function. I am running into some kind of code executing order issue. When the function is ran during integration testing, the `super.hasSecretValue("apiKey")` will return false. But whenever I skip the function and run the integration on the dashboard the API key works for Tdarr.

I found that the issue is created by using `secretKinds: [[], ["apiKey]` in `packages\definitions\src\integration.ts` to set optional secrets (this way I can make use of the existing implementation for optional features, aria2 uses this as well)

I am unsure why, as the objects sent to the backend in the `apps\nextjs\src\app\[locale]\manage\integrations\new\_integration-new-form.tsx` are identical when using `secretKinds: [[], ["apiKey"]` or `[["apiKey"]`

It would be great if someone could take over this PR, I feel like my experience is not enough to solve the final problem. 

fixes: https://github.com/homarr-labs/homarr/issues/2646
fixes: https://github.com/homarr-labs/homarr/issues/2819
![image](https://github.com/user-attachments/assets/b428242f-b614-425e-9b0e-c413fc9f44c1)