### PR TITLE
fix(releases-widget): improve ui for smaller widgets

### DIFF
--- a/packages/widgets/src/releases/component.tsx
+++ b/packages/widgets/src/releases/component.tsx
@@ -152,7 +152,7 @@ export default function ReleasesWidget({ options }: WidgetComponentProps<"releas
                 }}
               />
 
-              <Group gap={5} justify="space-between" style={{ flex: 1}}>
+              <Group gap={5} justify="space-between" style={{ flex: 1 }}>
                 <Text size="xs">{repository.identifier}</Text>
 
                 <Tooltip label={repository.latestRelease ?? t("not-found")}>
@@ -162,7 +162,7 @@ export default function ReleasesWidget({ options }: WidgetComponentProps<"releas
                 </Tooltip>
               </Group>
 
-              <Group gap={5} >
+              <Group gap={5}>
                 <Text
                   size="xs"
                   c={repository.isNewRelease ? "primaryColor" : repository.isStaleRelease ? "secondaryColor" : "dimmed"}

--- a/packages/widgets/src/releases/component.tsx
+++ b/packages/widgets/src/releases/component.tsx
@@ -141,7 +141,6 @@ export default function ReleasesWidget({ options }: WidgetComponentProps<"releas
                 [classes.active ?? ""]: isActive,
               })}
               p="xs"
-              wrap="nowrap"
               onClick={() => toggleExpandedRepository(repository.identifier)}
             >
               <MaskedOrNormalImage
@@ -153,7 +152,7 @@ export default function ReleasesWidget({ options }: WidgetComponentProps<"releas
                 }}
               />
 
-              <Group gap={5} justify="space-between" style={{ flex: 1, minWidth: 0 }} wrap="nowrap">
+              <Group gap={5} justify="space-between" style={{ flex: 1}}>
                 <Text size="xs">{repository.identifier}</Text>
 
                 <Tooltip label={repository.latestRelease ?? t("not-found")}>
@@ -163,7 +162,7 @@ export default function ReleasesWidget({ options }: WidgetComponentProps<"releas
                 </Tooltip>
               </Group>
 
-              <Group gap={5} wrap="nowrap">
+              <Group gap={5} >
                 <Text
                   size="xs"
                   c={repository.isNewRelease ? "primaryColor" : repository.isStaleRelease ? "secondaryColor" : "dimmed"}


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

This will improve the UI on samller widgets.

Might be good to wait for #2891 because there's some file overlap, I can merge after if needed.

https://github.com/user-attachments/assets/b3d1aad0-c6b8-4f36-baf8-0aaaff0353cd

fixes: #2953 
