### PR TITLE
fix(cookie): parsing of header not working with percentage char

### DIFF
--- a/packages/common/src/cookie.ts
+++ b/packages/common/src/cookie.ts
@@ -1,22 +1,8 @@
 import type { CookieSerializeOptions } from "cookie";
-import { serialize } from "cookie";
+import { parse, serialize } from "cookie";
 
 export function parseCookies(cookieString: string) {
-  const list: Record<string, string> = {};
-  const cookieHeader = cookieString;
-  if (!cookieHeader) return list;
-
-  cookieHeader.split(";").forEach(function (cookie) {
-    const items = cookie.split("=");
-    let name = items.shift();
-    name = name?.trim();
-    if (!name) return;
-    const value = items.join("=").trim();
-    if (!value) return;
-    list[name] = decodeURIComponent(value);
-  });
-
-  return list;
+  return parse(cookieString);
 }
 
 export function setClientCookie(name: string, value: string, options: CookieSerializeOptions = {}) {


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Error the user got `error: URI malformed`, because of our usage of `decodeURIComponent` where any non uri encoded character with `%` throws an error. So something like `%!` -> Error, but `%20` -> `<space>`

Relevant conversation: https://discordapp.com/channels/972958686051962910/1366882564870111343/1367166436484714496 and below messages