### PR TITLE
fix(releases-widget): reduced padding for `ul` in release description

### DIFF
--- a/packages/widgets/src/releases/component.module.scss
+++ b/packages/widgets/src/releases/component.module.scss
@@ -28,3 +28,7 @@
 .releasesRepositoryExpanded {
   background-color: var(--mantine-color-default-hover);
 }
+
+.releasesDescription > ul {
+  padding-inline-start: 15px;
+}

--- a/packages/widgets/src/releases/component.tsx
+++ b/packages/widgets/src/releases/component.tsx
@@ -391,7 +391,7 @@ const ExpandedDisplay = ({ repository, hasIconColor }: ExtendedDisplayProps) => 
             <Title order={4} ta="center">
               {t("releaseDescription")}
             </Title>
-            <Text component="div" size="xs" ff="monospace">
+            <Text component="div" size="xs" ff="monospace" className={classes.releasesDescription}>
               <ReactMarkdown skipHtml>{repository.releaseDescription}</ReactMarkdown>
             </Text>
           </>


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Reduced the padding for `ul` in the description from `40px` (default) to `15px`. Works well on the tested repositories.

![image](https://github.com/user-attachments/assets/d84f779e-c544-4a9b-a2e1-0bfd43187cbb)
![image](https://github.com/user-attachments/assets/767eaba2-52da-40f5-bf43-c91ed1b31705)

fixes #3069
