### PR TITLE
fix(releases-widget): validation preventing removal of a previously added icon

### DIFF
--- a/packages/widgets/src/_inputs/widget-multiReleasesRepositories-input.tsx
+++ b/packages/widgets/src/_inputs/widget-multiReleasesRepositories-input.tsx
@@ -276,7 +276,7 @@ const ReleaseEditModal = createModal<ReleaseEditProps>(({ innerProps, actions })
         <IconPicker
           withAsterisk={false}
           value={tempRepository.iconUrl}
-          onChange={(url) => handleChange({ iconUrl: url })}
+          onChange={(url) => handleChange({ iconUrl: url === "" ? undefined : url })}
           error={formErrors[`${innerProps.fieldPath}.iconUrl`] as string}
         />
       </Group>

--- a/packages/widgets/src/_inputs/widget-multiReleasesRepositories-input.tsx
+++ b/packages/widgets/src/_inputs/widget-multiReleasesRepositories-input.tsx
@@ -275,7 +275,7 @@ const ReleaseEditModal = createModal<ReleaseEditProps>(({ innerProps, actions })
 
         <IconPicker
           withAsterisk={false}
-          value={tempRepository.iconUrl}
+          value={tempRepository.iconUrl ?? ""}
           onChange={(url) => handleChange({ iconUrl: url === "" ? undefined : url })}
           error={formErrors[`${innerProps.fieldPath}.iconUrl`] as string}
         />


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

---

Fixes small issue when a user tries to remove a previously added icon