### PR TITLE
fix(calendar): some timezones result in offset of one day

### DIFF
--- a/packages/widgets/src/calendar/component.tsx
+++ b/packages/widgets/src/calendar/component.tsx
@@ -124,8 +124,12 @@ const CalendarBase = ({ isEditMode, events, month, setMonth, options }: Calendar
             )?.date,
           }))
           .filter((event): event is CalendarEvent => Boolean(event.date));
+
         return (
           <CalendarDay
+            // new Date() does not work here, because for timezones like UTC-7 it will
+            // show one day earlier (probably due to the time being set to 00:00)
+            // see https://github.com/homarr-labs/homarr/pull/3120
             date={dayjs(tileDate).toDate()}
             events={eventsForDate}
             disabled={isEditMode || eventsForDate.length === 0}

--- a/packages/widgets/src/calendar/component.tsx
+++ b/packages/widgets/src/calendar/component.tsx
@@ -126,7 +126,7 @@ const CalendarBase = ({ isEditMode, events, month, setMonth, options }: Calendar
           .filter((event): event is CalendarEvent => Boolean(event.date));
         return (
           <CalendarDay
-            date={new Date(tileDate)}
+            date={dayjs(tileDate).toDate()}
             events={eventsForDate}
             disabled={isEditMode || eventsForDate.length === 0}
             rootWidth={width}


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

I've tried it out locally and set my timezone to -10 where I got an offset of one day. Then I've tried a few things out and analysed the input for the day component. Finally I landed at that simple solution and tried it out again with +14, +1 and -12. Now it works as expected. Was caused by the changes of mantine v8 where we now get the date in the format `yyyy-mm-dd`.

Closes #3102