### PR TITLE
fix(visual): check for creator board permission is wrong

### DIFF
--- a/packages/auth/permissions/board-permissions.ts
+++ b/packages/auth/permissions/board-permissions.ts
@@ -23,21 +23,22 @@ export type BoardPermissionsProps = (
 
 export const constructBoardPermissions = (board: BoardPermissionsProps, session: Session | null) => {
   const creatorId = "creator" in board ? board.creator?.id : board.creatorId;
+  const isCreator = session !== null && session.user.id === creatorId;
 
   return {
     hasFullAccess:
-      session?.user.id === creatorId ||
+      isCreator ||
       board.userPermissions.some(({ permission }) => permission === "full") ||
       board.groupPermissions.some(({ permission }) => permission === "full") ||
       (session?.user.permissions.includes("board-full-all") ?? false),
     hasChangeAccess:
-      session?.user.id === creatorId ||
+      isCreator ||
       board.userPermissions.some(({ permission }) => permission === "modify" || permission === "full") ||
       board.groupPermissions.some(({ permission }) => permission === "modify" || permission === "full") ||
       (session?.user.permissions.includes("board-modify-all") ?? false) ||
       (session?.user.permissions.includes("board-full-all") ?? false),
     hasViewAccess:
-      session?.user.id === creatorId ||
+      isCreator ||
       board.userPermissions.length >= 1 ||
       board.groupPermissions.length >= 1 ||
       board.isPublic ||

--- a/packages/auth/permissions/test/board-permissions.spec.ts
+++ b/packages/auth/permissions/test/board-permissions.spec.ts
@@ -286,4 +286,22 @@ describe("constructBoardPermissions", () => {
     expect(result.hasChangeAccess).toBe(false);
     expect(result.hasViewAccess).toBe(true);
   });
+  test("should return all false when creator is null and session is null", () => {
+    // Arrange
+    const board = {
+      creator: null,
+      userPermissions: [],
+      groupPermissions: [],
+      isPublic: false,
+    };
+    const session = null;
+
+    // Act
+    const result = constructBoardPermissions(board, session);
+
+    // Assert
+    expect(result.hasFullAccess).toBe(false);
+    expect(result.hasChangeAccess).toBe(false);
+    expect(result.hasViewAccess).toBe(false);
+  });
 });


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (``pnpm build``, autofix with ``pnpm format:fix``)
- [x] Pull request targets ``dev`` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. ``x``, ``y``, ``i`` or any abbrevation)

Closes #2671

This could have been pretty bad! If we for example included the creator in this query, it would have been possible to bypass the view check for non public boards without an owner (so most likely imported ones) when opening them without being logged in:

```
const board = await db.query.boards.findFirst({
    where: boardWhere,
    columns: {
      id: true,
      creatorId: true,
      isPublic: true,
    },
    with: {
      userPermissions: {
        where: eq(boardUserPermissions.userId, session?.user.id ?? ""),
      },
      groupPermissions: {
        where: inArray(boardGroupPermissions.groupId, groupsOfCurrentUser.map((group) => group.groupId).concat("")),
      },
    },
  });
```

I've checked all paths where the createBoardPermissions method was used and luckily none of them results in an unauthorized access. The only thing is, that some visual things are wrong.

Usages of throwIfActionForbiddenAsync would never fall into this because of the creator not included / all except two where used anyway with protected routers (so session is never undefined and rather null `Thank you ===`)

Previously:
![image](https://github.com/user-attachments/assets/004497d7-31ca-4667-88a3-0c232b2967cc)

Now:
![image](https://github.com/user-attachments/assets/4e0ba5e3-02c7-4aaa-9847-8790991befe9)
