### PR TITLE
feat(integrations): add support for self-signed-cert-in-chain request error

### DIFF
--- a/packages/api/src/router/integration/map-test-connection-error.ts
+++ b/packages/api/src/router/integration/map-test-connection-error.ts
@@ -36,6 +36,7 @@ const mapError = (error: Error): MappedError => {
 export interface MappedCertificate {
   isSelfSigned: boolean;
   issuer: string;
+  issuerCertificate?: MappedCertificate;
   subject: string;
   serialNumber: string;
   validFrom: Date;
@@ -47,6 +48,7 @@ export interface MappedCertificate {
 const mapCertificate = (certificate: X509Certificate, code: RequestErrorCode): MappedCertificate => ({
   isSelfSigned: certificate.ca || code === "DEPTH_ZERO_SELF_SIGNED_CERT",
   issuer: certificate.issuer,
+  issuerCertificate: certificate.issuerCertificate ? mapCertificate(certificate.issuerCertificate, code) : undefined,
   subject: certificate.subject,
   serialNumber: certificate.serialNumber,
   validFrom: certificate.validFromDate,

--- a/packages/common/src/errors/http/request-error.ts
+++ b/packages/common/src/errors/http/request-error.ts
@@ -36,7 +36,12 @@ export const requestErrorMap = {
     expired: ["CERT_HAS_EXPIRED"],
     hostnameMismatch: ["ERR_TLS_CERT_ALTNAME_INVALID", "CERT_COMMON_NAME_INVALID"],
     notYetValid: ["CERT_NOT_YET_VALID"],
-    untrusted: ["DEPTH_ZERO_SELF_SIGNED_CERT", "UNABLE_TO_VERIFY_LEAF_SIGNATURE", "UNABLE_TO_GET_ISSUER_CERT_LOCALLY"],
+    untrusted: [
+      "DEPTH_ZERO_SELF_SIGNED_CERT",
+      "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+      "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+      "SELF_SIGNED_CERT_IN_CHAIN",
+    ],
   },
   connection: {
     hostUnreachable: "EHOSTUNREACH",


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Related: https://discourse.pi-hole.net/t/include-ca-certificate-in-self-signed/79629
Pi-hole version 6.2+ now automatically adds the ca certificate to the returned peer certificate. So we can extract that one to trust. Sadly it only works for people that let the certificate be regenerated or that install a new pi-hole service