### PR TITLE
fix(bookmarks): wrong widget icon

### DIFF
--- a/packages/widgets/src/bookmarks/index.tsx
+++ b/packages/widgets/src/bookmarks/index.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, Avatar, Group, Stack, Text } from "@mantine/core";
-import { IconClock, IconX } from "@tabler/icons-react";
+import { IconBookmark, IconX } from "@tabler/icons-react";
 
 import type { RouterOutputs } from "@homarr/api";
 import { clientApi } from "@homarr/api/client";
@@ -9,7 +9,7 @@ import { optionsBuilder } from "../options";
 import { BookmarkAddButton } from "./add-button";
 
 export const { definition, componentLoader } = createWidgetDefinition("bookmarks", {
-  icon: IconClock,
+  icon: IconBookmark,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       title: factory.text(),


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

https://github.com/ajnart/homarr/blob/cd78714da99e73cfdb13bd87f5474cb83756f157/src/widgets/bookmark/BookmarkWidgetTile.tsx#L51