### PR TITLE
feat(icon-color): add icon color clear button

### DIFF
--- a/apps/nextjs/src/app/[locale]/boards/[name]/settings/_appereance.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/[name]/settings/_appereance.tsx
@@ -17,6 +17,7 @@ import {
   useMantineTheme,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import { IconX } from "@tabler/icons-react";
 
 import { useZodForm } from "@homarr/form";
 import { useI18n } from "@homarr/translation/client";
@@ -102,12 +103,23 @@ export const ColorSettingsContent = ({ board }: Props) => {
             </InputWrapper>
           </Grid.Col>
           <Grid.Col span={{ sm: 12, md: 6 }}>
-            <ColorInput
-              label={t("board.field.iconColor.label")}
-              format="hex"
-              swatches={Object.values(theme.colors).map((color) => color[6])}
-              {...form.getInputProps("iconColor")}
-            />
+            <Group align="end">
+              <ColorInput
+                label={t("board.field.iconColor.label")}
+                format="hex"
+                swatches={Object.values(theme.colors).map((color) => color[6])}
+                flex={1}
+                {...form.getInputProps("iconColor")}
+              />
+              <Button
+                variant="subtle"
+                leftSection={<IconX />}
+                onClick={() => form.setFieldValue("iconColor", "")}
+                disabled={!form.values.iconColor}
+              >
+                {t("board.field.clearColor.label")}
+              </Button>
+            </Group>
             <Select
               label={t("board.field.itemRadius.label")}
               description={t("board.field.itemRadius.description")}

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -2556,6 +2556,9 @@
       "iconColor": {
         "label": "Icon color"
       },
+      "clearColor": {
+        "label": "Clear color"
+      },
       "customCss": {
         "label": "Custom css for this board",
         "description": "Further, customize your dashboard using CSS, only recommended for experienced users",


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

This adds a button to clear the icon color. Should make it more user friendly to remove the color. 
Let me know if it needs any adjustments.

<img width="1108" height="726" alt="image" src="https://github.com/user-attachments/assets/07aef361-24f7-454a-90c6-316cc9285e84" />

fixes #3530