### PR TITLE
fix(releases-widget): unable to change provider if previous is deleted

### DIFF
--- a/packages/widgets/src/_inputs/widget-multiReleasesRepositories-input.tsx
+++ b/packages/widgets/src/_inputs/widget-multiReleasesRepositories-input.tsx
@@ -368,7 +368,7 @@ const RepositoryEditModal = createModal<RepositoryEditProps>(({ innerProps, acti
             value={tempRepository.providerIntegrationId ? [tempRepository.providerIntegrationId] : []}
             error={formErrors[`${innerProps.fieldPath}.providerIntegrationId`] as string}
             onChange={(value) => {
-              handleChange({ providerIntegrationId: value.length > 0 ? value[0] : undefined });
+              handleChange({ providerIntegrationId: value.length > 0 ? value.pop() : undefined });
             }}
           />
         </div>


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).
 
This fixes a small bug, when if a provider integrations gets deleted and was preivously set against a repository release, the user will not be able to change the provider (as it would keep picking the old provider). Also improves usability because currently the user has to manually unpick a give provider to be able to pick another.

