### PR TITLE
feat(releases-widget): show project description when release description is missing

### DIFF
--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -2309,6 +2309,7 @@
       "openProjectPage": "Open Project Page",
       "openReleasePage": "Open Release Page",
       "releaseDescription": "Release Description",
+      "projectDescription": "Project Description",
       "created": "Created",
       "error": {
         "label": "Error",

--- a/packages/widgets/src/releases/component.tsx
+++ b/packages/widgets/src/releases/component.tsx
@@ -572,11 +572,14 @@ const ExpandedDisplay = ({ repository, hasIconColor }: ExtendedDisplayProps) => 
             </Text>
           </>
         )}
-        {repository.releaseDescription && (
+        {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing*/}
+        {(repository.releaseDescription || repository.projectDescription) && (
           <>
             <Divider className="releases-repository-expanded-description-divider" my={10} mx="30%" />
             <Title className="releases-repository-expanded-description-title" order={4} ta="center">
-              {t("releaseDescription")}
+              {repository.releaseDescription && repository.releaseDescription !== ""
+                ? t("releaseDescription")
+                : t("projectDescription")}
             </Title>
             <Text
               className={combineClasses("releases-repository-expanded-description-text", classes.releasesDescription)}
@@ -584,7 +587,8 @@ const ExpandedDisplay = ({ repository, hasIconColor }: ExtendedDisplayProps) => 
               size="xs"
               ff="monospace"
             >
-              <ReactMarkdown skipHtml>{repository.releaseDescription}</ReactMarkdown>
+              {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing*/}
+              <ReactMarkdown skipHtml>{repository.releaseDescription || repository.projectDescription}</ReactMarkdown>
             </Text>
           </>
         )}


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

---

This will show the project description if available, when expanding the release information and only if the release description is missing