### PR TITLE
fix(groups): saving permissions with none activated causes error

### DIFF
--- a/packages/api/src/router/group.ts
+++ b/packages/api/src/router/group.ts
@@ -277,12 +277,14 @@ export const groupRouter = createTRPCRouter({
 
       await ctx.db.delete(groupPermissions).where(eq(groupPermissions.groupId, input.groupId));
 
-      await ctx.db.insert(groupPermissions).values(
-        input.permissions.map((permission) => ({
-          groupId: input.groupId,
-          permission,
-        })),
-      );
+      if (input.permissions.length > 0) {
+        await ctx.db.insert(groupPermissions).values(
+          input.permissions.map((permission) => ({
+            groupId: input.groupId,
+            permission,
+          })),
+        );
+      }
     }),
   transferOwnership: permissionRequiredProcedure
     .requiresPermission("admin")


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

```
@homarr/nextjs:dev: 2025-08-02T13:41:39.390Z error: tRPC Error with mutation on 'group.savePermissions'
@homarr/nextjs:dev:     at Object.onError (webpack-internal:///(rsc)/./src/app/api/trpc/[trpc]/route.ts:43:67)
@homarr/nextjs:dev:     at Object.onError (webpack-internal:///(rsc)/../../node_modules/@trpc/server/dist/adapters/fetch/index.mjs:40:125)
@homarr/nextjs:dev:     at eval (webpack-internal:///(rsc)/../../node_modules/@trpc/server/dist/resolveResponse-CzlbRpCI.mjs:1969:90)
@homarr/nextjs:dev:     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
@homarr/nextjs:dev:     at async eval (webpack-internal:///(rsc)/../../node_modules/@trpc/server/dist/resolveResponse-CzlbRpCI.mjs:2085:30)
@homarr/nextjs:dev: caused by Error: values() must be called with at least one value
@homarr/nextjs:dev:     at SQLiteInsertBuilder.values (webpack-internal:///(rsc)/../../node_modules/drizzle-orm/sqlite-core/query-builders/insert.js:33:13)
@homarr/nextjs:dev:     at eval (webpack-internal:///(rsc)/../../packages/api/src/router/group.ts:241:94)
@homarr/nextjs:dev:     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
@homarr/nextjs:dev:     at async resolveMiddleware (webpack-internal:///(rsc)/../../node_modules/@trpc/server/dist/initTRPC-IT_6ZYJd.mjs:237:17)
@homarr/nextjs:dev:     at async callRecursive (webpack-internal:///(rsc)/../../node_modules/@trpc/server/dist/initTRPC-IT_6ZYJd.mjs:272:18)
@homarr/nextjs:dev:     at async callRecursive (webpack-internal:///(rsc)/../../node_modules/@trpc/server/dist/initTRPC-IT_6ZYJd.mjs:272:18)
@homarr/nextjs:dev:     at async callRecursive (webpack-internal:///(rsc)/../../node_modules/@trpc/server/dist/initTRPC-IT_6ZYJd.mjs:272:18)
@homarr/nextjs:dev:     at async callRecursive (webpack-internal:///(rsc)/../../node_modules/@trpc/server/dist/initTRPC-IT_6ZYJd.mjs:272:18)
@homarr/nextjs:dev:     at async procedure (webpack-internal:///(rsc)/../../node_modules/@trpc/server/dist/initTRPC-IT_6ZYJd.mjs:297:18)
@homarr/nextjs:dev:     at async eval (webpack-internal:///(rsc)/../../node_modules/@trpc/server/dist/resolveResponse-CzlbRpCI.mjs:1957:18)
@homarr/nextjs:dev:     at async eval (webpack-internal:///(rsc)/../../node_modules/@trpc/server/dist/resolveResponse-CzlbRpCI.mjs:2085:30)
```