### PR TITLE
fix: some integrations handle parse errors wrong

### DIFF
--- a/packages/integrations/src/base/integration.ts
+++ b/packages/integrations/src/base/integration.ts
@@ -8,8 +8,6 @@ import { removeTrailingSlash } from "@homarr/common";
 import type { IntegrationSecretKind } from "@homarr/definitions";
 
 import { HandleIntegrationErrors } from "./errors/decorator";
-import { integrationFetchHttpErrorHandler } from "./errors/http";
-import { integrationJsonParseErrorHandler, integrationZodParseErrorHandler } from "./errors/parse";
 import { TestConnectionError } from "./test-connection/test-connection-error";
 import type { TestingResult } from "./test-connection/test-connection-service";
 import { TestConnectionService } from "./test-connection/test-connection-service";
@@ -32,11 +30,7 @@ export interface IntegrationTestingInput {
   };
 }
 
-@HandleIntegrationErrors([
-  integrationZodParseErrorHandler,
-  integrationJsonParseErrorHandler,
-  integrationFetchHttpErrorHandler,
-])
+@HandleIntegrationErrors([])
 export abstract class Integration {
   constructor(protected integration: IntegrationInput) {}
 

--- a/packages/integrations/src/opnsense/opnsense-integration.ts
+++ b/packages/integrations/src/opnsense/opnsense-integration.ts
@@ -2,7 +2,6 @@ import { fetchWithTrustedCertificatesAsync } from "@homarr/certificates/server";
 import { ParseError, ResponseError } from "@homarr/common/server";
 import { createChannelEventHistory } from "@homarr/redis";
 
-import { HandleIntegrationErrors } from "../base/errors/decorator";
 import type { IntegrationTestingInput } from "../base/integration";
 import { Integration } from "../base/integration";
 import { TestConnectionError } from "../base/test-connection/test-connection-error";
@@ -22,7 +21,6 @@ import {
   opnsenseSystemSummarySchema,
 } from "./opnsense-types";
 
-@HandleIntegrationErrors([])
 export class OPNsenseIntegration extends Integration implements FirewallSummaryIntegration {
   protected async testingAsync(input: IntegrationTestingInput): Promise<TestingResult> {
     const response = await input.fetchAsync(this.url("/api/diagnostics/system/system_information"), {


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Pretty simple bug, the decorator does not run for methods of subclasses when there is a decorator on the subclass themself. Therefore I had to add the default ones to the decorator directly, so zod and json error are handled also for decorator of axios or similar.