### PR TITLE
fix(nextcloud): integration ignores trusted certificates

### DIFF
--- a/packages/common/src/errors/http/handlers/node-fetch-http-error-handler.ts
+++ b/packages/common/src/errors/http/handlers/node-fetch-http-error-handler.ts
@@ -1,0 +1,44 @@
+import { FetchError } from "node-fetch";
+
+import { logger } from "@homarr/log";
+
+import { RequestError } from "../request-error";
+import type { AnyRequestError } from "../request-error";
+import type { ResponseError } from "../response-error";
+import { matchErrorCode } from "./fetch-http-error-handler";
+import { HttpErrorHandler } from "./http-error-handler";
+
+/**
+ * node-fetch was a defacto standard to use fetch in nodejs.
+ *
+ * It is for example used within the cross-fetch package which is used in tsdav.
+ */
+export class NodeFetchHttpErrorHandler extends HttpErrorHandler {
+  constructor(private type = "node-fetch") {
+    super();
+  }
+
+  handleRequestError(error: unknown): AnyRequestError | undefined {
+    if (!(error instanceof FetchError)) return undefined;
+    if (error.code === undefined) return undefined;
+
+    logger.debug(`Received ${this.type} request error`, {
+      code: error.code,
+      message: error.message,
+    });
+
+    const requestErrorInput = matchErrorCode(error.code);
+    if (!requestErrorInput) return undefined;
+
+    return new RequestError(requestErrorInput, {
+      cause: error,
+    });
+  }
+
+  /**
+   * Response errors do not exist for fetch as it does not throw errors for non successful responses.
+   */
+  handleResponseError(_: unknown): ResponseError | undefined {
+    return undefined;
+  }
+}

--- a/packages/common/src/errors/http/handlers/tsdav-http-error-handler.ts
+++ b/packages/common/src/errors/http/handlers/tsdav-http-error-handler.ts
@@ -2,12 +2,12 @@ import { logger } from "@homarr/log";
 
 import type { AnyRequestError } from "../request-error";
 import { ResponseError } from "../response-error";
-import { FetchHttpErrorHandler } from "./fetch-http-error-handler";
 import { HttpErrorHandler } from "./http-error-handler";
+import { NodeFetchHttpErrorHandler } from "./node-fetch-http-error-handler";
 
 export class TsdavHttpErrorHandler extends HttpErrorHandler {
   handleRequestError(error: unknown): AnyRequestError | undefined {
-    return new FetchHttpErrorHandler("tsdav").handleRequestError(error);
+    return new NodeFetchHttpErrorHandler("tsdav").handleRequestError(error);
   }
 
   handleResponseError(error: unknown): ResponseError | undefined {
@@ -16,7 +16,7 @@ export class TsdavHttpErrorHandler extends HttpErrorHandler {
     // https://github.com/natelindev/tsdav/blob/bf33f04b1884694d685ee6f2b43fe9354b12d167/src/account.ts#L86
     if (error.message !== "Invalid credentials") return undefined;
 
-    logger.debug("Received Tsdav response error", {
+    logger.debug("Received tsdav response error", {
       status: 401,
     });
 


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Resolves an issue posted on discord: https://discord.com/channels/972958686051962910/1407391751995392130/1407413152441962591

It was not using the dispatcher previously as the used fetch was not `undici` and rather `node-fetch` which has an agent property and expects that agent to be of the same type as `node:https`. I've tried it out locally with a small script that ran against my pi-hole instance (without having trusted this certificate) and it worked:

```
2025-08-19T19:34:34.257Z debug: Testing connection
2025-08-19T19:34:34.263Z debug: Executed SQL query: select "hostname", "thumbprint", "certificate" from "trusted_certificate_hostname" "trustedCertificateHostnames"
2025-08-19T19:34:34.359Z debug: Received tsdav request error request to https://localhost:6407/ failed, reason: self-signed certificate in certificate chain
2025-08-19T19:34:34.359Z debug: Testing connection failed
2025-08-19T19:34:34.360Z debug: Fetching certificate
2025-08-19T19:34:34.366Z debug: Fetched certificate
{
  "success": false,
  "error": {
    "type": "certificate",
    "data": {
      "requestError": {
        "type": "certificate",
        "reason": "untrusted",
        "code": "SELF_SIGNED_CERT_IN_CHAIN",
        "name": "RequestError"
      },
      "certificate": "-----BEGIN CERTIFICATE-----\nMIIB4DCCAWagAwIBAgIPOTU5Mjg4ODgxMDY1NTE5MAoGCCqGSM49BAMCMDExEDAO\nBgNVBAMMB3BpLmhvbGUxEDAOBgNVBAoMB1BpLWhvbGUxCzAJBgNVBAYTAkRFMCAX\nDTI1MDYxMzIwNTA1N1oYDzIwNTUwNjEzMjA1MDU3WjASMRAwDgYDVQQDDAdwaS5o\nb2xlMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEfZ4jmCgwyRklmzd+m7D4vHTsQttq\n4In3/fthHvAB/DRaCNrMrUNU5AtvasyaM+TnK151pX7BdwCNf7crSmZDUPxZ+LD+\n95D6rFJLjNZbm6yxAXyV4cOD0uaVLxSxioO6o2EwXzAdBgNVHQ4EFgQUM1/83fkO\nDoYWdNcrQLw5/vuRPf8wHwYDVR0jBBgwFoAU6az1bLOzmOa7JoSXdpCGE31j38Iw\nCQYDVR0TBAIwADASBgNVHREECzAJggdwaS5ob2xlMAoGCCqGSM49BAMCA2gAMGUC\nMH27pHCVq8LoVlArvjc2a/Z6Wlioz6W2Bdbvc/RjSl1FR7N5rBSS8UcNaszZ9Cx8\nygIxAPqgVTvTdIVTsrA+30T0ZQB51cuy+ClGvaJ/h7p9bZKzdKoauXdXx5ULjtBM\n296KgA==\n-----END CERTIFICATE-----\n"
    },
    "name": "TestConnectionError"
  }
}
```