### PR TITLE
Update minecraft component.tsx to format player counts to 0 decimal places

### DIFF
--- a/packages/widgets/src/minecraft/server-status/component.tsx
+++ b/packages/widgets/src/minecraft/server-status/component.tsx
@@ -54,7 +54,7 @@ export default function MinecraftServerStatusWidget({ options }: WidgetComponent
           <Group gap={5} c="gray.6" align="center">
             <IconUsersGroup size="1rem" />
             <Text size="md">
-              {formatNumber(data.players.online, 1)} / {formatNumber(data.players.max, 1)}
+              {formatNumber(data.players.online, 0)} / {formatNumber(data.players.max, 0)}
             </Text>
           </Group>
         </>


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [ ] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [ ] Pull request targets `dev` branch
- [ ] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [ ] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Simple update to remove decimal places in player counts for minecraft server status widget. Unable to test build currently but this simple format change seems logical given it represents whole player counts.