### PR TITLE
fix(video-widget): hls videos not working

### DIFF
--- a/apps/nextjs/next.config.ts
+++ b/apps/nextjs/next.config.ts
@@ -42,9 +42,11 @@ const nextConfig: NextConfig = {
         headers: [
           {
             key: "Content-Security-Policy",
+            // worker-src / media-src with blob: is necessary for video.js, see https://github.com/homarr-labs/homarr/issues/3912 and https://stackoverflow.com/questions/65792855/problem-with-video-js-and-content-security-policy-csp
             value: `
               default-src 'self';
               script-src * 'unsafe-inline' 'unsafe-eval';
+              worker-src * blob:;
               base-uri 'self';
               connect-src *;
               style-src * 'unsafe-inline'; 
@@ -53,7 +55,7 @@ const nextConfig: NextConfig = {
               form-action 'self';
               img-src * data:;
               font-src * data:;
-              media-src * data:;
+              media-src * data: blob:;
             `
               .replace(/\s{2,}/g, " ")
               .trim(),

--- a/packages/widgets/src/video/component.tsx
+++ b/packages/widgets/src/video/component.tsx
@@ -119,8 +119,3 @@ const Feed = ({ options }: Pick<WidgetComponentProps<"video">, "options">) => {
     </Group>
   );
 };
-
-/*
-<video className={combineClasses("video-js", classes.video)} ref={videoRef}>
-        <source src={options.feedUrl} />
-      </video>*/


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Closes #3912 

I've tried it out with https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8 as hls stream and it worked:
<img width="1267" height="457" alt="image" src="https://github.com/user-attachments/assets/3599afe1-4172-4fa1-bc89-309455bd4e68" />
