### PR TITLE
fix(adguard-integration): parse error with protection_disabled_duration field

### DIFF
--- a/packages/integrations/src/adguard-home/adguard-home-types.ts
+++ b/packages/integrations/src/adguard-home/adguard-home-types.ts
@@ -23,7 +23,6 @@ export const statusResponseSchema = z.object({
   dns_addresses: z.array(z.string()),
   dns_port: z.number().positive(),
   http_port: z.number().positive(),
-  protection_disabled_duration: z.number(),
   protection_enabled: z.boolean(),
   dhcp_available: z.boolean(),
   running: z.boolean(),


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Closes #3909
The field is not used anywhere and so it doesn't make sense to be part of the parse