### PR TITLE
fix(api): page is crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
       "vite@>=5.0.0 <=5.4.18": ">=7.1.4"
     },
     "patchedDependencies": {
-      "@types/node-unifi": "patches/@types__node-unifi.patch"
+      "@types/node-unifi": "patches/@types__node-unifi.patch",
+      "trpc-to-openapi": "patches/trpc-to-openapi.patch"
     },
     "allowUnusedPatches": true,
     "ignoredBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ patchedDependencies:
   '@types/node-unifi':
     hash: 5e6ae51e2a17a7f9729bfa30b0eb3d0842a5810ac6db47603ab4a6efa1ed84c5
     path: patches/@types__node-unifi.patch
+  trpc-to-openapi:
+    hash: 2ca3c16af0fcca0c736697ad4fe553a14f794524fa9ce0d5c3e8ee4aea76090c
+    path: patches/trpc-to-openapi.patch
 
 importers:
 
@@ -651,7 +654,7 @@ importers:
         version: 2.2.2
       trpc-to-openapi:
         specifier: ^3.0.1
-        version: 3.0.1(@trpc/server@11.5.0(typescript@5.9.2))(zod-openapi@5.3.0(zod@4.1.5))(zod@4.1.5)
+        version: 3.0.1(patch_hash=2ca3c16af0fcca0c736697ad4fe553a14f794524fa9ce0d5c3e8ee4aea76090c)(@trpc/server@11.5.0(typescript@5.9.2))(zod-openapi@5.3.0(zod@4.1.5))(zod@4.1.5)
       zod:
         specifier: ^4.1.5
         version: 4.1.5
@@ -19406,7 +19409,7 @@ snapshots:
 
   trough@2.2.0: {}
 
-  trpc-to-openapi@3.0.1(@trpc/server@11.5.0(typescript@5.9.2))(zod-openapi@5.3.0(zod@4.1.5))(zod@4.1.5):
+  trpc-to-openapi@3.0.1(patch_hash=2ca3c16af0fcca0c736697ad4fe553a14f794524fa9ce0d5c3e8ee4aea76090c)(@trpc/server@11.5.0(typescript@5.9.2))(zod-openapi@5.3.0(zod@4.1.5))(zod@4.1.5):
     dependencies:
       '@trpc/server': 11.5.0(typescript@5.9.2)
       co-body: 6.2.0


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Closes #4037 and parts of #4028 

This issue was already fixed in #3920, however in https://github.com/homarr-labs/homarr/commit/fb6b5e88ff3a5e85d06885aed1f2a99788e04f2c it added an additional `patchedDependencies` do to a merge issue and therefore caused the `trpc-to-openapi` patch to be removed from the `package.json` and `pnpm-lock.yaml`. It then removed the first `patchedDependencies` (which contained both deps) in https://github.com/homarr-labs/homarr/commit/2ac96a11b770828fbef9153fbe73a8e3be0e05bd#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519