### PR TITLE
fix: Recalculate time ago on re-render

### DIFF
--- a/packages/common/src/hooks.ts
+++ b/packages/common/src/hooks.ts
@@ -11,13 +11,17 @@ const calculateTimeAgo = (timestamp: Date) => {
 };
 
 export const useTimeAgo = (timestamp: Date, updateFrequency = 1000) => {
-  const [timeAgo, setTimeAgo] = useState(calculateTimeAgo(timestamp));
+  const [timeAgo, setTimeAgo] = useState(() => calculateTimeAgo(timestamp));
+
+  useEffect(() => {
+    setTimeAgo(calculateTimeAgo(timestamp));
+  }, [timestamp]);
 
   useEffect(() => {
     const intervalId = setInterval(() => setTimeAgo(calculateTimeAgo(timestamp)), updateFrequency);
 
     return () => clearInterval(intervalId); // clear interval on hook unmount
-  }, [timestamp]);
+  }, [timestamp, updateFrequency]);
 
   return timeAgo;
 };


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

### Checklist

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

### Description

Fixes:
- #4091 
- Unnecessary recalculations of "time ago"

When you set an aggressive enough Notification Updater frequency, your notification timestamps get stuck in their initial state. The parent `<NotificationsWidget />` component subscribes to notification updates, so it will necessarily re-render at least as frequently as your Notification Updater configuration. This means the `useTimeAgo` hook will always clear the update interval before it performs the update in these scenarios.