### PR TITLE
fix(calendar): missing badge for sonarr series

### DIFF
--- a/packages/integrations/src/media-organizer/sonarr/sonarr-integration.ts
+++ b/packages/integrations/src/media-organizer/sonarr/sonarr-integration.ts
@@ -47,6 +47,10 @@ export class SonarrIntegration extends Integration implements ICalendarIntegrati
           ? {
               src: imageSrc,
               aspectRatio: { width: 7, height: 12 },
+              badge: {
+                color: "red",
+                content: `S${event.seasonNumber}/E${event.episodeNumber}`,
+              },
             }
           : null,
         location: null,

--- a/packages/integrations/src/mock/data/calendar.ts
+++ b/packages/integrations/src/mock/data/calendar.ts
@@ -69,7 +69,7 @@ const seriesRelease = (start: Date, end: Date): CalendarEvent => ({
     src: "https://image.tmdb.org/t/p/original/sWgBv7LV2PRoQgkxwlibdGXKz1S.jpg",
     aspectRatio: { width: 7, height: 12 },
     badge: {
-      content: "S1:E1",
+      content: "S1/E1",
       color: "red",
     },
   },


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

This bug was introduced in #3980 by not adding the badge for Sonarr back
Closes #4148 