### PR TITLE
fix: Search multiple docker hub pages for releases

### DIFF
--- a/packages/integrations/src/codeberg/codeberg-integration.ts
+++ b/packages/integrations/src/codeberg/codeberg-integration.ts
@@ -94,10 +94,7 @@ export class CodebergIntegration extends Integration implements ReleasesProvider
 
     const details = await this.getDetailsAsync(owner, name);
 
-    return {
-      ...details,
-      ...latestRelease,
-    };
+    return { ...details, ...latestRelease };
   }
 
   protected async getDetailsAsync(owner: string, name: string): Promise<DetailsProviderResponse | undefined> {

--- a/packages/integrations/src/github/github-integration.ts
+++ b/packages/integrations/src/github/github-integration.ts
@@ -63,10 +63,7 @@ export class GithubIntegration extends Integration implements ReleasesProviderIn
     const api = this.getApi();
 
     try {
-      const releasesResponse = await api.rest.repos.listReleases({
-        owner,
-        repo: name,
-      });
+      const releasesResponse = await api.rest.repos.listReleases({ owner, repo: name });
 
       if (releasesResponse.data.length === 0) {
         localLogger.warn(`No releases found, for ${owner}/${name} with Github integration`, {
@@ -93,10 +90,7 @@ export class GithubIntegration extends Integration implements ReleasesProviderIn
 
       const details = await this.getDetailsAsync(api, owner, name);
 
-      return {
-        ...details,
-        ...latestRelease,
-      };
+      return { ...details, ...latestRelease };
     } catch (error) {
       const errorMessage = error instanceof OctokitRequestError ? error.message : String(error);
       localLogger.warn(`Failed to get releases for ${owner}\\${name} with Github integration`, {

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -47,7 +47,7 @@ export type {
   TdarrStatistics,
   TdarrWorker,
 } from "./interfaces/media-transcoding/media-transcoding-types";
-export type { ReleasesResponse } from "./interfaces/releases-providers/releases-providers-types";
+export type { ReleasesResponse, DetailedRelease } from "./interfaces/releases-providers/releases-providers-types";
 export type { Notification } from "./interfaces/notifications/notification-types";
 
 // Schemas

--- a/packages/integrations/src/interfaces/releases-providers/releases-providers-types.ts
+++ b/packages/integrations/src/interfaces/releases-providers/releases-providers-types.ts
@@ -1,5 +1,16 @@
 import type { TranslationObject } from "@homarr/translation";
 
+export interface ParsedIdentifier {
+  owner: string;
+  name: string;
+}
+
+export interface ReleasesRepository {
+  id: string;
+  identifier: string;
+  versionRegex?: string;
+}
+
 export interface DetailsProviderResponse {
   projectUrl?: string;
   projectDescription?: string;
@@ -12,42 +23,17 @@ export interface DetailsProviderResponse {
 }
 
 export interface ReleaseProviderResponse {
-  latestRelease: string;
-  latestReleaseAt: Date;
+  latestRelease: string; // fix me
+  latestReleaseAt: Date; // fix me
   releaseUrl?: string;
   releaseDescription?: string;
   isPreRelease?: boolean;
-}
-
-export interface ReleasesRepository {
-  id: string;
-  identifier: string;
-  versionRegex?: string;
 }
 
 type ReleasesErrorKeys = keyof TranslationObject["widget"]["releases"]["error"]["messages"];
 
-export interface ReleasesResponse {
-  id: string;
-  latestRelease?: string;
-  latestReleaseAt?: Date;
-  releaseUrl?: string;
-  releaseDescription?: string;
-  isPreRelease?: boolean;
-  projectUrl?: string;
-  projectDescription?: string;
-  isFork?: boolean;
-  isArchived?: boolean;
-  createdAt?: Date;
-  starsCount?: number;
-  openIssues?: number;
-  forksCount?: number;
+export type ErrorResponse = { code: ReleasesErrorKeys } | { message: string };
 
-  error?:
-    | {
-        code: ReleasesErrorKeys;
-      }
-    | {
-        message: string;
-      };
-}
+export type DetailedRelease = DetailsProviderResponse & ReleaseProviderResponse;
+
+export type ReleasesResponse = { id: string } & (DetailedRelease | { error: ErrorResponse });

--- a/packages/integrations/src/interfaces/releases-providers/releases-providers-types.ts
+++ b/packages/integrations/src/interfaces/releases-providers/releases-providers-types.ts
@@ -23,8 +23,8 @@ export interface DetailsProviderResponse {
 }
 
 export interface ReleaseProviderResponse {
-  latestRelease: string; // fix me
-  latestReleaseAt: Date; // fix me
+  latestRelease: string;
+  latestReleaseAt: Date;
   releaseUrl?: string;
   releaseDescription?: string;
   isPreRelease?: boolean;

--- a/packages/integrations/src/linuxserverio/linuxserverio-integration.ts
+++ b/packages/integrations/src/linuxserverio/linuxserverio-integration.ts
@@ -43,7 +43,7 @@ export class LinuxServerIOIntegration extends Integration implements ReleasesPro
   public async getLatestMatchingReleaseAsync(
     identifier: ParsedIdentifier,
   ): Promise<DetailedRelease | ErrorResponse | null> {
-    const { owner, name } = identifier;
+    const { name } = identifier;
 
     const releasesResponse = await fetchWithTrustedCertificatesAsync(this.url("/api/v1/images"));
     if (!releasesResponse.ok) {
@@ -59,7 +59,6 @@ export class LinuxServerIOIntegration extends Integration implements ReleasesPro
     const release = data.data.repositories.linuxserver.find((repo) => repo.name === name);
     if (!release) {
       localLogger.warn(`Repository ${name} not found on provider, with LinuxServerIO integration`, {
-        owner,
         name,
       });
       return null;

--- a/packages/integrations/src/linuxserverio/linuxserverio-integration.ts
+++ b/packages/integrations/src/linuxserverio/linuxserverio-integration.ts
@@ -6,7 +6,11 @@ import { Integration } from "../base/integration";
 import { TestConnectionError } from "../base/test-connection/test-connection-error";
 import type { TestingResult } from "../base/test-connection/test-connection-service";
 import type { ReleasesProviderIntegration } from "../interfaces/releases-providers/releases-providers-integration";
-import type { ReleasesRepository, ReleasesResponse } from "../interfaces/releases-providers/releases-providers-types";
+import type {
+  DetailedRelease,
+  ErrorResponse,
+  ParsedIdentifier,
+} from "../interfaces/releases-providers/releases-providers-types";
 import { releasesResponseSchema } from "./linuxserverio-schemas";
 
 const localLogger = logger.child({ module: "LinuxServerIOsIntegration" });
@@ -24,65 +28,52 @@ export class LinuxServerIOIntegration extends Integration implements ReleasesPro
     };
   }
 
-  public async getLatestMatchingReleaseAsync(repository: ReleasesRepository): Promise<ReleasesResponse> {
-    const [owner, name] = repository.identifier.split("/");
+  public parseIdentifier(identifier: string): ParsedIdentifier | null {
+    const [owner, name] = identifier.split("/");
     if (!owner || !name) {
       localLogger.warn(
-        `Invalid identifier format. Expected 'owner/name', for ${repository.identifier} with LinuxServerIO integration`,
-        {
-          identifier: repository.identifier,
-        },
+        `Invalid identifier format. Expected 'owner/name', for ${identifier} with LinuxServerIO integration`,
+        { identifier },
       );
-      return {
-        id: repository.id,
-        error: { code: "invalidIdentifier" },
-      };
+      return null;
     }
+    return { owner, name };
+  }
+
+  public async getLatestMatchingReleaseAsync(
+    identifier: ParsedIdentifier,
+  ): Promise<DetailedRelease | ErrorResponse | null> {
+    const { owner, name } = identifier;
 
     const releasesResponse = await fetchWithTrustedCertificatesAsync(this.url("/api/v1/images"));
-
     if (!releasesResponse.ok) {
-      return {
-        id: repository.id,
-        error: { message: releasesResponse.statusText },
-      };
+      return { message: releasesResponse.statusText };
     }
 
     const releasesResponseJson: unknown = await releasesResponse.json();
     const { data, success, error } = releasesResponseSchema.safeParse(releasesResponseJson);
-
     if (!success) {
-      return {
-        id: repository.id,
-        error: {
-          message: error.message,
-        },
-      };
-    } else {
-      const release = data.data.repositories.linuxserver.find((repo) => repo.name === name);
-      if (!release) {
-        localLogger.warn(`Repository ${name} not found on provider, with LinuxServerIO integration`, {
-          owner,
-          name,
-        });
-
-        return {
-          id: repository.id,
-          error: { code: "noReleasesFound" },
-        };
-      }
-
-      return {
-        id: repository.id,
-        latestRelease: release.version,
-        latestReleaseAt: release.version_timestamp,
-        releaseDescription: release.changelog?.shift()?.desc,
-        projectUrl: release.github_url,
-        projectDescription: release.description,
-        isArchived: release.deprecated,
-        createdAt: release.initial_date ? new Date(release.initial_date) : undefined,
-        starsCount: release.stars,
-      };
+      return { message: error.message };
     }
+
+    const release = data.data.repositories.linuxserver.find((repo) => repo.name === name);
+    if (!release) {
+      localLogger.warn(`Repository ${name} not found on provider, with LinuxServerIO integration`, {
+        owner,
+        name,
+      });
+      return null;
+    }
+
+    return {
+      latestRelease: release.version,
+      latestReleaseAt: release.version_timestamp,
+      releaseDescription: release.changelog?.shift()?.desc,
+      projectUrl: release.github_url,
+      projectDescription: release.description,
+      isArchived: release.deprecated,
+      createdAt: release.initial_date ? new Date(release.initial_date) : undefined,
+      starsCount: release.stars,
+    };
   }
 }

--- a/packages/integrations/src/npm/npm-integration.ts
+++ b/packages/integrations/src/npm/npm-integration.ts
@@ -54,9 +54,7 @@ export class NPMIntegration extends Integration implements ReleasesProviderInteg
       releaseUrl: `https://www.npmjs.com/package/${encodeURIComponent(data.name)}/v/${encodeURIComponent(tag.latestRelease)}`,
       releaseDescription: data.versions[tag.latestRelease]?.description ?? "",
     }));
-    const latestRelease = getLatestRelease(formattedReleases, versionRegex);
-    if (!latestRelease) return null;
 
-    return latestRelease;
+    return getLatestRelease(formattedReleases, versionRegex);
   }
 }

--- a/packages/widgets/src/releases/component.tsx
+++ b/packages/widgets/src/releases/component.tsx
@@ -137,7 +137,7 @@ export default function ReleasesWidget({ options }: WidgetComponentProps<"releas
       })
       .filter(
         (repository) =>
-          !("error" in repository) ||
+          "error" in repository ||
           !options.showOnlyHighlighted ||
           repository.isNewRelease ||
           repository.isStaleRelease,

--- a/packages/widgets/src/releases/component.tsx
+++ b/packages/widgets/src/releases/component.tsx
@@ -125,26 +125,26 @@ export default function ReleasesWidget({ options }: WidgetComponentProps<"releas
           ...repository,
           ...response,
           isNewRelease:
-            relativeDateOptions.newReleaseWithin !== "" && response.latestReleaseAt
+            relativeDateOptions.newReleaseWithin !== "" && "latestReleaseAt" in response
               ? isDateWithin(response.latestReleaseAt, relativeDateOptions.newReleaseWithin)
               : false,
           isStaleRelease:
-            relativeDateOptions.staleReleaseWithin !== "" && response.latestReleaseAt
+            relativeDateOptions.staleReleaseWithin !== "" && "latestReleaseAt" in response
               ? !isDateWithin(response.latestReleaseAt, relativeDateOptions.staleReleaseWithin)
               : false,
-          viewed: releasesViewedList[repository.id] === response.latestRelease,
+          viewed: "latestRelease" in response && releasesViewedList[repository.id] === response.latestRelease,
         };
       })
       .filter(
         (repository) =>
-          repository.error !== undefined ||
+          !("error" in repository) ||
           !options.showOnlyHighlighted ||
           repository.isNewRelease ||
           repository.isStaleRelease,
       )
       .sort((repoA, repoB) => {
-        if (repoA.latestReleaseAt === undefined) return -1;
-        if (repoB.latestReleaseAt === undefined) return 1;
+        if (!("latestReleaseAt" in repoA) || !repoA.latestReleaseAt) return -1;
+        if (!("latestReleaseAt" in repoB) || !repoB.latestReleaseAt) return 1;
         return repoA.latestReleaseAt > repoB.latestReleaseAt ? -1 : 1;
       }) as ReleasesRepositoryResponse[];
 


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

### Checklist

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

### Description

Primarily adds functionality to search multiple pages on docker hub. Pages will be fetched one by one until we either find a matching release or search through "enough" pages and give up. Five pages was chosen in the current implementation, but it can be easily changed (e.g. I think `3` is a fine value too).

Additionally, the related code was refactored to reduce coupling and use types more effectively. 

#### Decoupling
Regarding the reduction of coupling, the core call structure of fetching the latest release looks like this:
```
-> releaseRequestHandler
    -> instanceA.getLatestMatchingReleaseAsync
    -> instanceB.getLatestMatchingReleaseAsync
    ...
    -> instanceN.getLatestMatchingReleaseAsync
        -> getLatestRelease
```
Currently, every instance of `getLatestMatchingReleaseAsync` and  `getLatestRelease` are maintaining a return structure and juggling codes on behalf of `releaseRequestHandler`. This makes it harder to make changes to this flow and keep behavior consistent across integrations (e.g. when is an error [an error](https://github.com/homarr-labs/homarr/blob/2e56d9a6c760e90896bc543fe84287284a48474c/packages/integrations/src/github-container-registry/github-container-registry-integration.ts#L96-L99) and when is it ["noReleasesFound"](https://github.com/homarr-labs/homarr/blob/2e56d9a6c760e90896bc543fe84287284a48474c/packages/integrations/src/gitlab/gitlab-integration.ts#L86-L89)?)

The change here keeps the behavior the same, but it centralizes the construction of the final response and some of the repeated handling logic in the top-level `releaseRequestHandler`. It's simpler to align everything now (e.g. an error is always an error) if there is desire for that. 

#### Typing improvements
Regarding the typing, the main characters [here](https://github.com/homarr-labs/homarr/blob/dev/packages/integrations/src/interfaces/releases-providers/releases-providers-types.ts) have been changed to reflect how the app behaves. For example, in the current model, a `ReleasesResponse` of `{ id: "id"}` would not raise any type errors, but is clearly invalid. I believe this flexibility was created because when there is an error, none of the release fields are there, so they're "optional"; similarly, when there is a release, the error field is not there and so it is also "optional". However, you can capture this "either release details or error" behavior accurately with types.