### PR TITLE
fix(docker-widget): memory usage wrong

### DIFF
--- a/packages/request-handler/src/docker.ts
+++ b/packages/request-handler/src/docker.ts
@@ -47,7 +47,7 @@ async function getContainersWithStatsAsync() {
     const instance = dockerInstances.find(({ host }) => host === container.instance)?.instance;
     if (!instance) return null;
 
-    const stats = await instance.getContainer(container.Id).stats({ stream: false });
+    const stats = await instance.getContainer(container.Id).stats({ stream: false, "one-shot": true });
 
     return {
       id: container.Id,
@@ -60,7 +60,8 @@ async function getContainersWithStatsAsync() {
           return icon.name.toLowerCase().includes(extractedImage.toLowerCase());
         })?.url ?? null,
       cpuUsage: calculateCpuUsage(stats),
-      memoryUsage: stats.memory_stats.usage,
+      // memory usage by default includes cache, which should not be shown as it is also not shown with docker stats command
+      memoryUsage: stats.memory_stats.usage - stats.memory_stats.stats.cache,
       image: container.Image,
       ports: container.Ports,
     };


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Closes #3231

The `one-shot` improves performance. As we don't need the previous cpu stats we can use it.
Tested it and confirmed it is working by running `docker stats` and dockerode `getContainer.stats`