### PR TITLE
fix(docker): stats not working

### DIFF
--- a/packages/request-handler/src/docker.ts
+++ b/packages/request-handler/src/docker.ts
@@ -3,7 +3,6 @@ import type { ContainerInfo, ContainerStats } from "dockerode";
 
 import { db, like, or } from "@homarr/db";
 import { icons } from "@homarr/db/schema";
-import { logger } from "@homarr/log";
 
 import type { ContainerState } from "../../docker/src";
 import { DockerSingleton } from "../../docker/src";
@@ -44,14 +43,11 @@ async function getContainersWithStatsAsync() {
         })
       : [];
 
-  const logs: { name: string; stats: unknown }[] = [];
   const containerStatsPromises = containers.map(async (container) => {
     const instance = dockerInstances.find(({ host }) => host === container.instance)?.instance;
     if (!instance) return null;
 
     const stats = await instance.getContainer(container.Id).stats({ stream: false, "one-shot": true });
-
-    logs.push({ name: container.Names[0] ?? "unknown", stats });
 
     return {
       id: container.Id,
@@ -81,11 +77,7 @@ async function getContainersWithStatsAsync() {
     };
   });
 
-  const result = (await Promise.all(containerStatsPromises)).filter((container) => container !== null);
-
-  logger.warn(JSON.stringify(logs));
-
-  return result;
+  return (await Promise.all(containerStatsPromises)).filter((container) => container !== null);
 }
 
 function calculateCpuUsage(stats: ContainerStats): number {


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

In some environments the cache stats property is not available which causes it to crash.
Also the cpu usage calculation results in `NaN`

From official docker documentation:

```
On Linux, the Docker CLI reports memory usage by subtracting cache usage from the total memory usage. The API does not perform such a calculation but rather provides the total memory usage and the amount from the cache so that clients can use the data as needed. The cache usage is defined as the value of total_inactive_file field in the memory.stat file on cgroup v1 hosts.

On Docker 19.03 and older, the cache usage was defined as the value of cache field. On cgroup v2 hosts, the cache usage is defined as the value of inactive_file field.
```

See https://docs.docker.com/reference/cli/docker/container/stats

Closes #4305