### PR TITLE
fix: add orphaned status for containers with invalid stats

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/tools/docker/docker-table.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/tools/docker/docker-table.tsx
@@ -76,6 +76,7 @@ const createColumns = (
     accessorKey: "ports",
     header: t("docker.field.ports.label"),
     Cell({ cell }) {
+      if (!cell.row.original.ports.length) return null;
       return (
         <OverflowBadge overflowCount={1} data={cell.row.original.ports.map((port) => port.PrivatePort.toString())} />
       );


### PR DESCRIPTION
Setting homarr up for the first time, I got a `Cannot read properties of undefined (reading online_cpus)` error when accessing manage -> tools -> docker.

In my case it was an issue of orphaned running containers where online_cpus were null.
I achieved this feat by removing services from a docker-compose stack while the containers were still running and later restarting the compose stack. 

Having exited containers exist should not stop a user from using the Docker tool.

- Display exited containers in 
- Prevent 'Cannot read properties of undefined (reading online_cpus)' error
- Fixed exited status container error in docker-table (⨯ TypeError: Cannot read properties of null (reading 'map')

<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).
