### PR TITLE
fix: improve run script

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -22,6 +22,7 @@ export CRON_JOB_API_KEY=$(openssl rand -base64 32)
 # 1. Replace the HOSTNAME in the nginx template file
 # 2. Create the nginx configuration file from the template
 # 3. Start the nginx server
+export HOSTNAME
 envsubst '${HOSTNAME}' < /etc/nginx/templates/nginx.conf > /etc/nginx/nginx.conf
 # Start services in the background and store their PIDs
 nginx -g 'daemon off;' &


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

As discussed with @manuel-rw a little PR to adress a missing shebang on bash script and fix a warning when $REDIS_IS_EXTERNAL is unset.

```bash
Dec 08 20:45:00 homarr run.sh[8797]: /opt/homarr/run.sh: line 30: [: =: unary operator expected
```

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Closes #4466