### PR TITLE
fix(iframe-widget): permission selection not applying to any origin

### DIFF
--- a/packages/widgets/src/iframe/component.tsx
+++ b/packages/widgets/src/iframe/component.tsx
@@ -27,7 +27,7 @@ export default function IFrameWidget({ options, isEditMode }: WidgetComponentPro
         className={classes.iframe}
         src={embedUrl}
         title="widget iframe"
-        allow={allowedPermissions.join(" ")}
+        allow={allowedPermissions}
         scrolling={allowScrolling ? "yes" : "no"}
         sandbox={sandboxFlags.join(" ")}
       >
@@ -77,9 +77,13 @@ const UnsupportedProtocol = () => {
 const getAllowedPermissions = (
   permissions: Omit<WidgetComponentProps<"iframe">["options"], "embedUrl" | "allowScrolling">,
 ) => {
-  return objectEntries(permissions)
-    .filter(([_key, value]) => value)
-    .map(([key]) => permissionMapping[key]);
+  return (
+    objectEntries(permissions)
+      .filter(([_key, value]) => value)
+      // * means it applies to all origins
+      .map(([key]) => `${permissionMapping[key]} *`)
+      .join("; ")
+  );
 };
 
 const getSandboxFlags = (


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Previously all permissions were denied as the origin selection was missing

Closes #4109