### PR TITLE
fix(invites): creation with custom expiration not working

### DIFF
--- a/packages/modals-collection/src/invites/invite-create-modal.tsx
+++ b/packages/modals-collection/src/invites/invite-create-modal.tsx
@@ -13,7 +13,7 @@ import { InviteCopyModal } from "./invite-copy-modal";
 dayjs.extend(relativeTime);
 
 interface FormType {
-  expirationDate: Date;
+  expirationDate: string;
 }
 
 export const InviteCreateModal = createModal<void>(({ actions }) => {
@@ -28,18 +28,23 @@ export const InviteCreateModal = createModal<void>(({ actions }) => {
 
   const form = useForm<FormType>({
     initialValues: {
-      expirationDate: dayjs().add(4, "hours").toDate(),
+      expirationDate: dayjs().add(4, "hours").toDate().toISOString(),
     },
   });
 
   const handleSubmit = (values: FormType) => {
-    mutate(values, {
-      onSuccess: (result) => {
-        void utils.invite.getAll.invalidate();
-        actions.closeModal();
-        openModal(result);
+    mutate(
+      {
+        expirationDate: new Date(values.expirationDate),
       },
-    });
+      {
+        onSuccess: (result) => {
+          void utils.invite.getAll.invalidate();
+          actions.closeModal();
+          openModal(result);
+        },
+      },
+    );
   };
 
   return (


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Closes #4666
Regression of #3022 due to change of date pickers from `Date` values to `string` values
Checked for other usages of Date / Time pickers, but there are none:

<img width="455" height="533" alt="image" src="https://github.com/user-attachments/assets/b77adb42-6ecd-4a35-9a44-96a192acf75d" />
