### PR TITLE
Update de-CH.json

### DIFF
--- a/packages/translation/src/lang/de-CH.json
+++ b/packages/translation/src/lang/de-CH.json
@@ -2639,7 +2639,7 @@
         "notification": {
           "success": {
             "title": "Änderungen erfolgreich angewendet",
-            "message": "Das Board wurde erfolgreich dupliziert"
+            "message": "Das Board wurde erfolgreich gespeichert"
           },
           "error": {
             "title": "Änderungen konnten nicht angewendet werden",


### PR DESCRIPTION
The correct translation is "gespeichert" (equals "saved") and NOT "dupliziert" (equals "duplicated").

I think this was mistakenly copied from line 2630

<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [X] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [X] Pull request targets `dev` branch
- [X] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [X] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).
