### PR TITLE
chore: adjust codeowners for renovate managed files to no owner instead of homarr-labs/none

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,8 +2,8 @@
 * @homarr-labs/maintainers
 
 # Exempt Renovate‑managed files (no owners)
-package.json          @homarr-labs/none
-package-lock.json     @homarr-labs/none
-pnpm-lock.yaml        @homarr-labs/none
-Dockerfile            @homarr-labs/none
-docker-compose.yml    @homarr-labs/none
+package.json
+package-lock.json
+pnpm-lock.yaml
+Dockerfile
+docker-compose.yml


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

After this the team @homarr-labs/none can be removed