### PR TITLE
perf(memory): use lazy trpc routers

### DIFF
--- a/packages/api/src/root.ts
+++ b/packages/api/src/root.ts
@@ -1,54 +1,32 @@
-import { apiKeysRouter } from "./router/apiKeys";
-import { appRouter as innerAppRouter } from "./router/app";
-import { boardRouter } from "./router/board";
-import { certificateRouter } from "./router/certificates/certificate-router";
-import { cronJobsRouter } from "./router/cron-jobs";
-import { dockerRouter } from "./router/docker/docker-router";
-import { groupRouter } from "./router/group";
-import { homeRouter } from "./router/home";
-import { iconsRouter } from "./router/icons";
-import { importRouter } from "./router/import/import-router";
-import { infoRouter } from "./router/info";
-import { integrationRouter } from "./router/integration/integration-router";
-import { inviteRouter } from "./router/invite";
-import { kubernetesRouter } from "./router/kubernetes/router/kubernetes-router";
-import { locationRouter } from "./router/location";
-import { logRouter } from "./router/log";
-import { mediaRouter } from "./router/medias/media-router";
-import { onboardRouter } from "./router/onboard/onboard-router";
-import { searchEngineRouter } from "./router/search-engine/search-engine-router";
-import { sectionRouter } from "./router/section/section-router";
-import { serverSettingsRouter } from "./router/serverSettings";
-import { updateCheckerRouter } from "./router/update-checker";
-import { userRouter } from "./router/user";
-import { widgetRouter } from "./router/widgets";
+import { lazy } from "@trpc/server";
+
 import { createTRPCRouter } from "./trpc";
 
 export const appRouter = createTRPCRouter({
-  user: userRouter,
-  group: groupRouter,
-  invite: inviteRouter,
-  integration: integrationRouter,
-  board: boardRouter,
-  section: sectionRouter,
-  app: innerAppRouter,
-  searchEngine: searchEngineRouter,
-  widget: widgetRouter,
-  location: locationRouter,
-  log: logRouter,
-  icon: iconsRouter,
-  import: importRouter,
-  onboard: onboardRouter,
-  home: homeRouter,
-  docker: dockerRouter,
-  kubernetes: kubernetesRouter,
-  serverSettings: serverSettingsRouter,
-  cronJobs: cronJobsRouter,
-  apiKeys: apiKeysRouter,
-  media: mediaRouter,
-  updateChecker: updateCheckerRouter,
-  certificates: certificateRouter,
-  info: infoRouter,
+  user: lazy(() => import("./router/user").then((mod) => mod.userRouter)),
+  group: lazy(() => import("./router/group").then((mod) => mod.groupRouter)),
+  invite: lazy(() => import("./router/invite").then((mod) => mod.inviteRouter)),
+  integration: lazy(() => import("./router/integration/integration-router").then((mod) => mod.integrationRouter)),
+  board: lazy(() => import("./router/board").then((mod) => mod.boardRouter)),
+  section: lazy(() => import("./router/section/section-router").then((mod) => mod.sectionRouter)),
+  app: lazy(() => import("./router/app").then((mod) => mod.appRouter)),
+  searchEngine: lazy(() => import("./router/search-engine/search-engine-router").then((mod) => mod.searchEngineRouter)),
+  widget: lazy(() => import("./router/widgets").then((mod) => mod.widgetRouter)),
+  location: lazy(() => import("./router/location").then((mod) => mod.locationRouter)),
+  log: lazy(() => import("./router/log").then((mod) => mod.logRouter)),
+  icon: lazy(() => import("./router/icons").then((mod) => mod.iconsRouter)),
+  import: lazy(() => import("./router/import/import-router").then((mod) => mod.importRouter)),
+  onboard: lazy(() => import("./router/onboard/onboard-router").then((mod) => mod.onboardRouter)),
+  home: lazy(() => import("./router/home").then((mod) => mod.homeRouter)),
+  docker: lazy(() => import("./router/docker/docker-router").then((mod) => mod.dockerRouter)),
+  kubernetes: lazy(() => import("./router/kubernetes/router/kubernetes-router").then((mod) => mod.kubernetesRouter)),
+  serverSettings: lazy(() => import("./router/serverSettings").then((mod) => mod.serverSettingsRouter)),
+  cronJobs: lazy(() => import("./router/cron-jobs").then((mod) => mod.cronJobsRouter)),
+  apiKeys: lazy(() => import("./router/apiKeys").then((mod) => mod.apiKeysRouter)),
+  media: lazy(() => import("./router/medias/media-router").then((mod) => mod.mediaRouter)),
+  updateChecker: lazy(() => import("./router/update-checker").then((mod) => mod.updateCheckerRouter)),
+  certificates: lazy(() => import("./router/certificates/certificate-router").then((mod) => mod.certificateRouter)),
+  info: lazy(() => import("./router/info").then((mod) => mod.infoRouter)),
 });
 
 // export type definition of API

--- a/packages/api/src/router/kubernetes/router/kubernetes-router.ts
+++ b/packages/api/src/router/kubernetes/router/kubernetes-router.ts
@@ -1,22 +1,15 @@
+import { lazy } from "@trpc/server";
+
 import { createTRPCRouter } from "../../../trpc";
-import { clusterRouter } from "./cluster";
-import { configMapsRouter } from "./configMaps";
-import { ingressesRouter } from "./ingresses";
-import { namespacesRouter } from "./namespaces";
-import { nodesRouter } from "./nodes";
-import { podsRouter } from "./pods";
-import { secretsRouter } from "./secrets";
-import { servicesRouter } from "./services";
-import { volumesRouter } from "./volumes";
 
 export const kubernetesRouter = createTRPCRouter({
-  nodes: nodesRouter,
-  cluster: clusterRouter,
-  namespaces: namespacesRouter,
-  ingresses: ingressesRouter,
-  services: servicesRouter,
-  pods: podsRouter,
-  secrets: secretsRouter,
-  configMaps: configMapsRouter,
-  volumes: volumesRouter,
+  nodes: lazy(() => import("./nodes").then((mod) => mod.nodesRouter)),
+  cluster: lazy(() => import("./cluster").then((mod) => mod.clusterRouter)),
+  namespaces: lazy(() => import("./namespaces").then((mod) => mod.namespacesRouter)),
+  ingresses: lazy(() => import("./ingresses").then((mod) => mod.ingressesRouter)),
+  services: lazy(() => import("./services").then((mod) => mod.servicesRouter)),
+  pods: lazy(() => import("./pods").then((mod) => mod.podsRouter)),
+  secrets: lazy(() => import("./secrets").then((mod) => mod.secretsRouter)),
+  configMaps: lazy(() => import("./configMaps").then((mod) => mod.configMapsRouter)),
+  volumes: lazy(() => import("./volumes").then((mod) => mod.volumesRouter)),
 });

--- a/packages/api/src/router/widgets/index.ts
+++ b/packages/api/src/router/widgets/index.ts
@@ -1,46 +1,27 @@
+import { lazy } from "@trpc/server";
+
 import { createTRPCRouter } from "../../trpc";
-import { appRouter } from "./app";
-import { calendarRouter } from "./calendar";
-import { dnsHoleRouter } from "./dns-hole";
-import { downloadsRouter } from "./downloads";
-import { firewallRouter } from "./firewall";
-import { healthMonitoringRouter } from "./health-monitoring";
-import { indexerManagerRouter } from "./indexer-manager";
-import { mediaReleaseRouter } from "./media-release";
-import { mediaRequestsRouter } from "./media-requests";
-import { mediaServerRouter } from "./media-server";
-import { mediaTranscodingRouter } from "./media-transcoding";
-import { minecraftRouter } from "./minecraft";
-import { networkControllerRouter } from "./network-controller";
-import { notebookRouter } from "./notebook";
-import { notificationsRouter } from "./notifications";
-import { optionsRouter } from "./options";
-import { releasesRouter } from "./releases";
-import { rssFeedRouter } from "./rssFeed";
-import { smartHomeRouter } from "./smart-home";
-import { stockPriceRouter } from "./stocks";
-import { weatherRouter } from "./weather";
 
 export const widgetRouter = createTRPCRouter({
-  notebook: notebookRouter,
-  weather: weatherRouter,
-  app: appRouter,
-  dnsHole: dnsHoleRouter,
-  smartHome: smartHomeRouter,
-  stockPrice: stockPriceRouter,
-  mediaServer: mediaServerRouter,
-  mediaRelease: mediaReleaseRouter,
-  calendar: calendarRouter,
-  downloads: downloadsRouter,
-  mediaRequests: mediaRequestsRouter,
-  rssFeed: rssFeedRouter,
-  indexerManager: indexerManagerRouter,
-  healthMonitoring: healthMonitoringRouter,
-  mediaTranscoding: mediaTranscodingRouter,
-  minecraft: minecraftRouter,
-  options: optionsRouter,
-  releases: releasesRouter,
-  networkController: networkControllerRouter,
-  firewall: firewallRouter,
-  notifications: notificationsRouter,
+  notebook: lazy(() => import("./notebook").then((mod) => mod.notebookRouter)),
+  weather: lazy(() => import("./weather").then((mod) => mod.weatherRouter)),
+  app: lazy(() => import("./app").then((mod) => mod.appRouter)),
+  dnsHole: lazy(() => import("./dns-hole").then((mod) => mod.dnsHoleRouter)),
+  smartHome: lazy(() => import("./smart-home").then((mod) => mod.smartHomeRouter)),
+  stockPrice: lazy(() => import("./stocks").then((mod) => mod.stockPriceRouter)),
+  mediaServer: lazy(() => import("./media-server").then((mod) => mod.mediaServerRouter)),
+  mediaRelease: lazy(() => import("./media-release").then((mod) => mod.mediaReleaseRouter)),
+  calendar: lazy(() => import("./calendar").then((mod) => mod.calendarRouter)),
+  downloads: lazy(() => import("./downloads").then((mod) => mod.downloadsRouter)),
+  mediaRequests: lazy(() => import("./media-requests").then((mod) => mod.mediaRequestsRouter)),
+  rssFeed: lazy(() => import("./rssFeed").then((mod) => mod.rssFeedRouter)),
+  indexerManager: lazy(() => import("./indexer-manager").then((mod) => mod.indexerManagerRouter)),
+  healthMonitoring: lazy(() => import("./health-monitoring").then((mod) => mod.healthMonitoringRouter)),
+  mediaTranscoding: lazy(() => import("./media-transcoding").then((mod) => mod.mediaTranscodingRouter)),
+  minecraft: lazy(() => import("./minecraft").then((mod) => mod.minecraftRouter)),
+  options: lazy(() => import("./options").then((mod) => mod.optionsRouter)),
+  releases: lazy(() => import("./releases").then((mod) => mod.releasesRouter)),
+  networkController: lazy(() => import("./network-controller").then((mod) => mod.networkControllerRouter)),
+  firewall: lazy(() => import("./firewall").then((mod) => mod.firewallRouter)),
+  notifications: lazy(() => import("./notifications").then((mod) => mod.notificationsRouter)),
 });


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

In a test of multiple changes over 10 minutes where every 10 seconds it would call the docker containers endpoint of my main local homarr instance.
 I got the following results:

| Name | Average | Min | Max |
| - | -| - | - |
| latest [dev](https://github.com/homarr-labs/homarr/pkgs/container/homarr/646827136?tag=dev) image | 595mb | 587mb | 598mb |
| [memory-lazy-routers](https://github.com/homarr-labs/homarr/pkgs/container/homarr/646859738?tag=memory-lazy-routers) | 461mb | 458mb | 464mb |
| difference | -134mb | -129mb | -134mb |

Related to #3759 