### PR TITLE
ci: typo in runner for validating prebuilt-debian with arm64

### DIFF
--- a/.github/workflows/on-pr-prebuilt-debian-validate.yml
+++ b/.github/workflows/on-pr-prebuilt-debian-validate.yml
@@ -27,7 +27,7 @@ jobs:
             exit 1
           fi
   prebuilt-debian-validate-arm64:
-    runs-on: ubuntu-24.04-
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).
