### PR TITLE
fix(analytics): disable auto-tracking pageviews

### DIFF
--- a/apps/nextjs/src/components/layout/analytics.tsx
+++ b/apps/nextjs/src/components/layout/analytics.tsx
@@ -9,7 +9,7 @@ export const Analytics = async () => {
   const analytics = await getServerSettingByKeyAsync(db, "analytics").catch(() => null);
 
   if (analytics?.enableGeneral) {
-    return <Script src="https://umami.homarr.dev/script.js" data-website-id={UMAMI_WEBSITE_ID} defer />;
+    return <Script src="https://umami.homarr.dev/script.js" data-website-id={UMAMI_WEBSITE_ID} data-auto-track="false" defer />;
   }
 
   return <></>;


### PR DESCRIPTION
Should stop umami from sending pageviews events. So it will only send events manually tagged (with `umami.track` , that we have no instance of so far in the frontend afaik) 

Adding this because currently we have **726238** rows/events for pageviews in 23 days so far 