### PR TITLE
feat(docker): add interactive container import with host and scheme config

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/apps/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/apps/page.tsx
@@ -11,12 +11,12 @@ import type { inferSearchParamsFromSchema } from "@homarr/common/types";
 import { getI18n, getScopedI18n } from "@homarr/translation/server";
 import { Link, SearchInput, TablePagination } from "@homarr/ui";
 
+import { DockerImportButton } from "~/components/apps/docker-import-button";
 import { ManageContainer } from "~/components/manage/manage-container";
 import { MobileAffixButton } from "~/components/manage/mobile-affix-button";
 import { DynamicBreadcrumb } from "~/components/navigation/dynamic-breadcrumb";
 import { NoResults } from "~/components/no-results";
 import { AppDeleteButton } from "./_app-delete-button";
-import { DockerImportButton } from "~/components/apps/docker-import-button";
 
 const searchParamsSchema = z.object({
   search: z.string().optional(),

--- a/apps/nextjs/src/components/apps/docker-import-button.tsx
+++ b/apps/nextjs/src/components/apps/docker-import-button.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Button } from "@mantine/core";
 import { IconBrandDocker } from "@tabler/icons-react";
+
 import { ImportDockerModal } from "./import-docker-modal";
 
 export const DockerImportButton = () => {
@@ -10,11 +11,7 @@ export const DockerImportButton = () => {
 
   return (
     <>
-      <Button 
-        leftSection={<IconBrandDocker size={20} />} 
-        variant="light" 
-        onClick={() => setOpened(true)}
-      >
+      <Button leftSection={<IconBrandDocker size={20} />} variant="light" onClick={() => setOpened(true)}>
         Import from Docker
       </Button>
 

--- a/apps/nextjs/src/components/apps/import-docker-modal.tsx
+++ b/apps/nextjs/src/components/apps/import-docker-modal.tsx
@@ -1,29 +1,53 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation"; 
-import { 
-  Dialog, Button, Checkbox, ScrollArea, Avatar, Loader, Badge, 
-  Text, Group, Stack, TextInput, SegmentedControl 
+import { useRouter } from "next/navigation";
+import {
+  Avatar,
+  Button,
+  Checkbox,
+  Dialog,
+  Group,
+  Loader,
+  ScrollArea,
+  SegmentedControl,
+  Stack,
+  Text,
+  TextInput,
 } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
+
 import { clientApi as api } from "@homarr/api/client";
 
 // Helper: Clean container name
 const guessCandidateUrl = (containerName: string) => {
   let slug = containerName.toLowerCase();
-  slug = slug.replace(/[_]/g, "-"); 
+  slug = slug.replace(/[_]/g, "-");
   const noiseWords = [
-    "development", "dev", "prod", "production", "docker", "compose", "stack",
-    "server", "service", "daemon", "container", "app", "official",
-    "homarr", "labs", "desktop", "extension"
+    "development",
+    "dev",
+    "prod",
+    "production",
+    "docker",
+    "compose",
+    "stack",
+    "server",
+    "service",
+    "daemon",
+    "container",
+    "app",
+    "official",
+    "homarr",
+    "labs",
+    "desktop",
+    "extension",
   ];
   noiseWords.forEach((word) => {
     slug = slug.replace(new RegExp(`\\b${word}\\b`, "g"), "");
   });
   slug = slug.replace(/[-]?\d+$/, "");
   slug = slug.replace(/-+/g, "-").replace(/^-|-$/g, "");
-  
+
   if (!slug || slug.length < 2) return null;
   return `https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/${slug}.png`;
 };
@@ -53,30 +77,35 @@ export const ImportDockerModal = ({ opened, onClose }: ImportDockerModalProps) =
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [schemes, setSchemes] = useState<Record<string, "http" | "https">>({});
   const [isImporting, setIsImporting] = useState(false);
-  
+
   // Validation State
   const [customHost, setCustomHost] = useState("localhost");
   const [hostError, setHostError] = useState<string | null>(null);
 
   const utils = api.useUtils();
-  const router = useRouter(); 
+  const router = useRouter();
   const createApp = api.app.create.useMutation();
 
-  const { data: candidates, isLoading, error } = api.docker.getCandidates.useQuery(undefined, { 
-    enabled: opened 
+  const {
+    data: candidates,
+    isLoading,
+    error,
+  } = api.docker.getCandidates.useQuery(undefined, {
+    enabled: opened,
   });
 
   // Validator Function
   const handleHostChange = (value: string) => {
     setCustomHost(value);
-    
+
     if (value.trim() === "") {
-      setHostError(null); 
+      setHostError(null);
       return;
     }
 
-    const validHostRegex = /^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]))*$/;
-    
+    const validHostRegex =
+      /^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))*$/;
+
     if (value.includes("://")) {
       setHostError("Do not include 'http://' or 'https://'. Just the IP or Hostname.");
     } else if (value.includes(":")) {
@@ -93,16 +122,16 @@ export const ImportDockerModal = ({ opened, onClose }: ImportDockerModalProps) =
     setIsImporting(true);
 
     const appsToImport = candidates.filter((c) => selectedIds.includes(c.id));
-    
+
     await Promise.all(
       appsToImport.map(async (c) => {
-        const validIconUrl = c.icon || await getValidatedIcon(c.name);
+        const validIconUrl = c.icon || (await getValidatedIcon(c.name));
         const scheme = schemes[c.id] || "http";
-        
+
         let finalUrl = c.url.replace(/^https?:\/\//, `${scheme}://`);
 
         if (customHost && finalUrl.includes("localhost")) {
-            finalUrl = finalUrl.replace("localhost", customHost);
+          finalUrl = finalUrl.replace("localhost", customHost);
         }
 
         return createApp.mutateAsync({
@@ -110,9 +139,9 @@ export const ImportDockerModal = ({ opened, onClose }: ImportDockerModalProps) =
           iconUrl: validIconUrl,
           href: finalUrl,
           description: "Imported from Docker",
-          pingUrl: "" 
+          pingUrl: "",
         });
-      })
+      }),
     );
 
     notifications.show({
@@ -121,9 +150,9 @@ export const ImportDockerModal = ({ opened, onClose }: ImportDockerModalProps) =
       color: "green",
     });
 
-    router.refresh(); 
+    router.refresh();
     await utils.app.invalidate();
-    
+
     setIsImporting(false);
     onClose();
     setSelectedIds([]);
@@ -131,78 +160,80 @@ export const ImportDockerModal = ({ opened, onClose }: ImportDockerModalProps) =
   };
 
   const toggleSelection = (id: string) => {
-    setSelectedIds((prev) =>
-      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]
-    );
+    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]));
   };
 
   return (
-    <Dialog 
-      opened={opened} 
-      withCloseButton 
-      onClose={onClose} 
+    <Dialog
+      opened={opened}
+      withCloseButton
+      onClose={onClose}
       size="xl"
-      radius="md" 
+      radius="md"
       shadow="xl"
       position={{ bottom: 20, right: 20 }}
     >
       <Stack gap="sm" mb="md">
-        <Text fw={700} size="lg">Import from Docker</Text>
-        
-        <TextInput 
-            label="Host IP / Domain" 
-            placeholder="e.g. 192.168.1.50"
-            value={customHost}
-            onChange={(e) => handleHostChange(e.currentTarget.value)}
-            description="Replaces 'localhost' in the final app URL."
-            error={hostError} 
+        <Text fw={700} size="lg">
+          Import from Docker
+        </Text>
+
+        <TextInput
+          label="Host IP / Domain"
+          placeholder="e.g. 192.168.1.50"
+          value={customHost}
+          onChange={(e) => handleHostChange(e.currentTarget.value)}
+          description="Replaces 'localhost' in the final app URL."
+          error={hostError}
         />
       </Stack>
 
-      <ScrollArea 
-        h={500}
-        type="always" 
-        offsetScrollbars 
-        className="pr-2 mb-4"
-      >
+      <ScrollArea h={500} type="always" offsetScrollbars className="pr-2 mb-4">
         {isLoading ? (
-          <Group justify="center" p="xl"><Loader /></Group>
+          <Group justify="center" p="xl">
+            <Loader />
+          </Group>
         ) : error ? (
-           <Text c="red" size="sm" ta="center">Error: {error.message}</Text>
+          <Text c="red" size="sm" ta="center">
+            Error: {error.message}
+          </Text>
         ) : candidates?.length === 0 ? (
-          <Text ta="center" c="dimmed" py="xl">No running containers found.</Text>
+          <Text ta="center" c="dimmed" py="xl">
+            No running containers found.
+          </Text>
         ) : (
           <Stack gap="xs">
             {candidates?.map((container) => {
-               const previewUrl = container.icon || guessCandidateUrl(container.name) || "https://cdn.simpleicons.org/docker";
-               const isSelected = selectedIds.includes(container.id);
-               const currentScheme = schemes[container.id] || "http";
+              const previewUrl =
+                container.icon || guessCandidateUrl(container.name) || "https://cdn.simpleicons.org/docker";
+              const isSelected = selectedIds.includes(container.id);
+              const currentScheme = schemes[container.id] || "http";
 
-               const displayUrl = container.url 
-                 .replace(/^https?:\/\//, `${currentScheme}://`) 
-                 .replace("localhost", customHost || "localhost");
+              const displayUrl = container.url
+                .replace(/^https?:\/\//, `${currentScheme}://`)
+                .replace("localhost", customHost || "localhost");
 
-               return (
-                <Group 
-                  key={container.id} 
-                  wrap="nowrap" 
+              return (
+                <Group
+                  key={container.id}
+                  wrap="nowrap"
                   align="center"
                   p="xs"
                   className={`rounded-md border transition-colors ${
-                    isSelected 
-                      ? "bg-blue-500/10 border-blue-500" 
+                    isSelected
+                      ? "bg-blue-500/10 border-blue-500"
                       : "hover:bg-gray-100 dark:hover:bg-zinc-800 border-transparent"
                   }`}
                 >
-                  <Checkbox 
-                    checked={isSelected} 
+                  <Checkbox
+                    checked={isSelected}
                     onChange={() => toggleSelection(container.id)}
                     style={{ cursor: "pointer" }}
                   />
-                  
-                  <Avatar 
-                    src={previewUrl} 
-                    radius="md" 
+
+                  <Avatar
+                    src={previewUrl}
+                    radius="md"
                     size="md"
                     color="blue"
                     onError={(e) => {
@@ -211,44 +242,46 @@ export const ImportDockerModal = ({ opened, onClose }: ImportDockerModalProps) =
                   >
                     {container.name.charAt(0)}
                   </Avatar>
-                  
-                  <div style={{ flex: 1, minWidth: 0, cursor: "pointer" }} onClick={() => toggleSelection(container.id)}>
+
+                  <div style={{ flex: 1, minWidth: 0 }}>
                     <Group gap="xs" wrap="nowrap">
-                      <Text fw={600} truncate>{container.name}</Text>
+                      <Text fw={600} truncate>
+                        {container.name}
+                      </Text>
                     </Group>
                     <Text size="xs" c="dimmed" truncate>
                       {displayUrl}
                     </Text>
                   </div>
 
-                  <div onClick={(e) => e.stopPropagation()}>
-                    <SegmentedControl 
-                      size="xs"
-                      data={[
-                        { label: 'HTTP', value: 'http' },
-                        { label: 'HTTPS', value: 'https' }
-                      ]}
-                      value={currentScheme}
-                      onChange={(value) => setSchemes(prev => ({
+                  <SegmentedControl
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()} // Also prevent Enter/Space from bubbling
+                    size="xs"
+                    data={[
+                      { label: "HTTP", value: "http" },
+                      { label: "HTTPS", value: "https" },
+                    ]}
+                    value={currentScheme}
+                    onChange={(value) =>
+                      setSchemes((prev) => ({
                         ...prev,
-                        [container.id]: value as "http" | "https"
-                      }))}
-                    />
-                  </div>
+                        [container.id]: value as "http" | "https",
+                      }))
+                    }
+                  />
                 </Group>
-               );
+              );
             })}
           </Stack>
         )}
       </ScrollArea>
 
       <Group justify="flex-end">
-        <Button variant="subtle" onClick={onClose} color="gray">Cancel</Button>
-        <Button 
-          onClick={handleImport} 
-          loading={isImporting} 
-          disabled={selectedIds.length === 0 || !!hostError}
-        >
+        <Button variant="subtle" onClick={onClose} color="gray">
+          Cancel
+        </Button>
+        <Button onClick={handleImport} loading={isImporting} disabled={selectedIds.length === 0 || Boolean(hostError)}>
           Import {selectedIds.length > 0 ? `(${selectedIds.length})` : ""}
         </Button>
       </Group>

--- a/packages/api/src/router/docker/docker-router.ts
+++ b/packages/api/src/router/docker/docker-router.ts
@@ -34,28 +34,26 @@ export const dockerRouter = createTRPCRouter({
       const nestedContainers = await Promise.all(
         instances.map(async ({ instance }) => {
           return await instance.listContainers({ all: false });
-        })
+        }),
       );
 
       const allContainers = nestedContainers.flat();
 
       return allContainers.map((c) => {
-          const publicPort = c.Ports?.find((p) => p.PublicPort)?.PublicPort;
-          // We default to localhost here, but the Frontend will override it
-          const defaultUrl = publicPort ? `http://localhost:${publicPort}` : "";
-          
-          const rawName = (c.Names && c.Names.length > 0) 
-            ? c.Names[0].replace(/^\//, "") 
-            : c.Id.substring(0, 12);
+        const publicPort = c.Ports?.find((p) => p.PublicPort)?.PublicPort;
+        // We default to localhost here, but the Frontend will override it
+        const defaultUrl = publicPort ? `http://localhost:${publicPort}` : "";
 
-          const containerName = rawName.charAt(0).toUpperCase() + rawName.slice(1);
+        const rawName = c.Names && c.Names.length > 0 ? c.Names[0].replace(/^\//, "") : c.Id.substring(0, 12);
 
-          return {
-            id: c.Id,
-            name: containerName,
-            icon: null, 
-            url: defaultUrl,
-          };
+        const containerName = rawName.charAt(0).toUpperCase() + rawName.slice(1);
+
+        return {
+          id: c.Id,
+          name: containerName,
+          icon: null,
+          url: defaultUrl,
+        };
       });
     }),
 


### PR DESCRIPTION

Introduces a new 'Import from Docker' modal that scans running containers.

Features include:
- Auto-discovery of container names and ports.
- Smart icon guessing with validation and fallback to generic Docker icon.
- Client-side host configuration (replacing localhost with custom IP).
- Per-app HTTP/HTTPS scheme toggles.
- Input validation for hostnames/IPs.
- Responsive UI with auto-scrolling and error handling.

<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [ ] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Screenshots:
<img width="969" height="364" alt="image" src="https://github.com/user-attachments/assets/4063e200-b32a-4ff6-9360-e1dd800240e2" />

**List docker containers:**

<img width="2551" height="1259" alt="image" src="https://github.com/user-attachments/assets/6fa1aaea-38af-4d5a-8103-30f40db4e1d3" />

**Select services, host ip/name & the scheme (http/https) then import:**

<img width="510" height="696" alt="image" src="https://github.com/user-attachments/assets/dda9dc6e-9947-430d-b392-4fbb5ffa0681" />

**The apps gets automatically created:**

<img width="1621" height="1207" alt="image" src="https://github.com/user-attachments/assets/95076a63-592e-4112-87df-14f4b5c541c1" />

