### PR TITLE
fix(glances): unable to parse uptime of 1 day

### DIFF
--- a/packages/integrations/src/glances/glances-integration.ts
+++ b/packages/integrations/src/glances/glances-integration.ts
@@ -95,7 +95,18 @@ export class GlancesIntegration extends Integration implements ISystemHealthMoni
   }
 }
 
-const regex = /^(?:(?<days>\d+) days, )?(?<hours>\d+):(?<minutes>\d+):(?<seconds>\d+)$/m;
+// Glances is written in python and uses the following code to format uptime:
+// from datetime import datetime
+// uptime = datetime.now() - datetime.fromtimestamp(1773395580)
+// str(uptime).split(".")[0]
+// This results in one of the following formats:
+// - 71 days, 9:51:35
+// - 1 day, 9:50:23
+// - 9:51:24
+// - 0:22:02
+// - 0:00:17
+// See https://github.com/nicolargo/glances/blob/4139b10c5c3a98afc67a19ae67d66d2d94d7db6a/glances/plugins/uptime/__init__.py#L58
+const regex = /^(?:(?<days>\d+) days?, )?(?<hours>\d+):(?<minutes>\d+):(?<seconds>\d+)$/m;
 
 const allSchema = z.object({
   cpu: z.object({


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Closes #5199

Before:
<img width="1468" height="470" alt="image" src="https://github.com/user-attachments/assets/a66c0137-9a72-417c-87c6-850ffa226d7c" />

After:
<img width="1470" height="475" alt="image" src="https://github.com/user-attachments/assets/52a0502a-0b8c-4d1d-afd7-02484c47f65e" />

I used the following code to generate different versions:

```py
from datetime import datetime
uptime = datetime.now() - datetime.fromtimestamp(1773395580)
str(uptime).split(".")[0]
```