### PR TITLE
feat: add GPU monitoring support via Glances integration

### DIFF
--- a/packages/integrations/src/dashdot/dashdot-integration.ts
+++ b/packages/integrations/src/dashdot/dashdot-integration.ts
@@ -56,6 +56,7 @@ export class DashDotIntegration extends Integration implements ISystemHealthMoni
       availablePkgUpdates: 0,
       rebootRequired: false,
       smart: [], // API endpoint does not provide S.M.A.R.T data.
+      gpu: [], // API endpoint does not provide GPU data.
       uptime: info.uptime,
       version: `${info.operatingSystemVersion}`,
       loadAverage: {

--- a/packages/integrations/src/glances/glances-integration.ts
+++ b/packages/integrations/src/glances/glances-integration.ts
@@ -59,6 +59,14 @@ export class GlancesIntegration extends Integration implements ISystemHealthMoni
       loadAverage: null,
       smart: [],
       cpuTemp: undefined,
+      gpu: stats.gpu.map((gpu) => ({
+        gpuId: gpu.gpu_id,
+        name: gpu.name,
+        memoryUtilization: gpu.mem ?? 0,
+        processorUtilization: gpu.proc ?? 0,
+        temperature: gpu.temperature ?? null,
+        fanSpeed: gpu.fan_speed ?? null,
+      })),
     };
   }
 
@@ -150,4 +158,16 @@ const allSchema = z.object({
   quicklook: z.object({
     cpu_name: z.string(),
   }),
+  gpu: z
+    .array(
+      z.object({
+        gpu_id: z.string(),
+        name: z.string(),
+        mem: z.number().nullable().optional(),
+        proc: z.number().nullable().optional(),
+        temperature: z.number().nullable().optional(),
+        fan_speed: z.number().nullable().optional(),
+      }),
+    )
+    .default([]),
 });

--- a/packages/integrations/src/interfaces/health-monitoring/health-monitoring-types.ts
+++ b/packages/integrations/src/interfaces/health-monitoring/health-monitoring-types.ts
@@ -31,6 +31,14 @@ export interface SystemHealthMonitoring {
     overallStatus: string;
     healthy: boolean;
   }[];
+  gpu: {
+    gpuId: string;
+    name: string;
+    memoryUtilization: number;
+    processorUtilization: number;
+    temperature: number | null;
+    fanSpeed: number | null;
+  }[];
 }
 
 // TODO: in the future decouple this from the Proxmox integration

--- a/packages/integrations/src/mock/data/system-health-monitoring.ts
+++ b/packages/integrations/src/mock/data/system-health-monitoring.ts
@@ -36,6 +36,16 @@ export class SystemHealthMonitoringMockService implements ISystemHealthMonitorin
           healthy: true,
         },
       ],
+      gpu: [
+        {
+          gpuId: "mock0",
+          name: "Mock GPU RTX 4090",
+          memoryUtilization: Math.floor(Math.random() * 100),
+          processorUtilization: Math.floor(Math.random() * 100),
+          temperature: Math.floor(Math.random() * 90),
+          fanSpeed: Math.floor(Math.random() * 2000),
+        },
+      ],
     });
   }
 }

--- a/packages/integrations/src/openmediavault/openmediavault-integration.ts
+++ b/packages/integrations/src/openmediavault/openmediavault-integration.ts
@@ -86,6 +86,7 @@ export class OpenMediaVaultIntegration extends Integration implements ISystemHea
       cpuTemp: cpuTempResult.success ? cpuTempResult.data.response.cputemp : undefined,
       fileSystem,
       smart,
+      gpu: [],
     };
   }
 

--- a/packages/integrations/src/truenas/truenas-integration.ts
+++ b/packages/integrations/src/truenas/truenas-integration.ts
@@ -297,6 +297,7 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
       version: systemInformation.version,
       cpuModelName: systemInformation.model,
       rebootRequired: false,
+      gpu: [],
     };
   }
 

--- a/packages/integrations/src/unraid/unraid-integration.ts
+++ b/packages/integrations/src/unraid/unraid-integration.ts
@@ -70,6 +70,7 @@ export class UnraidIntegration extends Integration implements ISystemHealthMonit
         // See ArrayDiskStatus from https://studio.apollographql.com/public/Unraid-API/variant/current/explorer
         healthy: disk.status === "DISK_OK",
       })),
+      gpu: [],
     };
   }
 

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -1858,6 +1858,9 @@
         "memory": {
           "label": "Show Memory Info"
         },
+        "gpu": {
+          "label": "Show GPU Info"
+        },
         "showUptime": {
           "label": "Show Uptime"
         },
@@ -2726,6 +2729,7 @@
           "option": {
             "cpu": "CPU",
             "memory": "Memory",
+            "gpu": "GPU",
             "network": "Network"
           }
         },
@@ -2742,6 +2746,7 @@
       "card": {
         "cpu": "CPU",
         "memory": "MEM",
+        "gpu": "GPU",
         "network": "NET",
         "up": "UP",
         "down": "DOWN"

--- a/packages/widgets/src/health-monitoring/index.ts
+++ b/packages/widgets/src/health-monitoring/index.ts
@@ -19,6 +19,9 @@ export const { definition, componentLoader } = createWidgetDefinition("healthMon
         memory: factory.switch({
           defaultValue: true,
         }),
+        gpu: factory.switch({
+          defaultValue: true,
+        }),
         showUptime: factory.switch({
           defaultValue: true,
         }),

--- a/packages/widgets/src/health-monitoring/rings/gpu-ring.tsx
+++ b/packages/widgets/src/health-monitoring/rings/gpu-ring.tsx
@@ -1,0 +1,64 @@
+import { Center, RingProgress, Stack, Text, Tooltip } from "@mantine/core";
+import { IconDeviceDesktop } from "@tabler/icons-react";
+
+import { progressColor } from "../system-health";
+
+interface GpuRingProps {
+  gpu: {
+    gpuId: string;
+    name: string;
+    memoryUtilization: number;
+    processorUtilization: number;
+    temperature: number | null;
+    fanSpeed: number | null;
+  };
+  isTiny: boolean;
+  fahrenheit: boolean;
+}
+
+export const GpuRing = ({ gpu, isTiny, fahrenheit }: GpuRingProps) => {
+  const tempDisplay =
+    gpu.temperature != null
+      ? fahrenheit
+        ? `${(gpu.temperature * 1.8 + 32).toFixed(0)}°F`
+        : `${gpu.temperature}°C`
+      : null;
+
+  return (
+    <Tooltip
+      label={
+        <Stack gap={2}>
+          <Text size="xs" fw={600}>
+            {gpu.name}
+          </Text>
+          <Text size="xs">VRAM: {gpu.memoryUtilization.toFixed(1)}%</Text>
+          {tempDisplay && <Text size="xs">Temp: {tempDisplay}</Text>}
+          {gpu.fanSpeed != null && <Text size="xs">Fan: {gpu.fanSpeed} RPM</Text>}
+        </Stack>
+      }
+      multiline
+    >
+      <RingProgress
+        className={`health-monitoring-gpu health-monitoring-gpu-${gpu.gpuId}`}
+        roundCaps
+        size={isTiny ? 50 : 100}
+        thickness={isTiny ? 4 : 8}
+        label={
+          <Center style={{ flexDirection: "column" }}>
+            <Text
+              className="health-monitoring-gpu-utilization-value"
+              size={isTiny ? "8px" : "xs"}
+            >{`${gpu.processorUtilization.toFixed(0)}%`}</Text>
+            <IconDeviceDesktop className="health-monitoring-gpu-utilization-icon" size={isTiny ? 8 : 16} />
+          </Center>
+        }
+        sections={[
+          {
+            value: Number(gpu.processorUtilization.toFixed(2)),
+            color: progressColor(Number(gpu.processorUtilization.toFixed(2))),
+          },
+        ]}
+      />
+    </Tooltip>
+  );
+};

--- a/packages/widgets/src/health-monitoring/system-health.tsx
+++ b/packages/widgets/src/health-monitoring/system-health.tsx
@@ -39,6 +39,7 @@ import { useI18n } from "@homarr/translation/client";
 import type { WidgetComponentProps } from "../definition";
 import { CpuRing } from "./rings/cpu-ring";
 import { CpuTempRing } from "./rings/cpu-temp-ring";
+import { GpuRing } from "./rings/gpu-ring";
 import { formatMemoryUsage, MemoryRing } from "./rings/memory-ring";
 import classes from "./system-health.module.css";
 
@@ -187,6 +188,10 @@ export const SystemHealthMonitoring = ({
                   isTiny={isTiny}
                 />
               )}
+              {options.gpu &&
+                healthInfo.gpu.map((gpu) => (
+                  <GpuRing key={gpu.gpuId} gpu={gpu} isTiny={isTiny} fahrenheit={options.fahrenheit} />
+                ))}
             </Flex>
             {
               <Text className="health-monitoring-status-update-time" c="dimmed" size="xs" ta="center">

--- a/packages/widgets/src/system-resources/chart/gpu-chart.tsx
+++ b/packages/widgets/src/system-resources/chart/gpu-chart.tsx
@@ -1,0 +1,52 @@
+import { Paper, Text } from "@mantine/core";
+import { IconDeviceDesktop } from "@tabler/icons-react";
+
+import { useScopedI18n } from "@homarr/translation/client";
+
+import type { LabelDisplayModeOption } from "..";
+import { CommonChart } from "./common-chart";
+
+export const SystemResourceGPUChart = ({
+  gpuUsageOverTime,
+  hasShadow,
+  labelDisplayMode,
+}: {
+  gpuUsageOverTime: number[];
+  hasShadow: boolean;
+  labelDisplayMode: LabelDisplayModeOption;
+}) => {
+  const chartData = gpuUsageOverTime.map((usage, index) => ({ index, usage }));
+  const t = useScopedI18n("widget.systemResources.card");
+
+  return (
+    <CommonChart
+      data={chartData}
+      dataKey={"index"}
+      series={[{ name: "usage", color: "grape.5" }]}
+      title={t("gpu")}
+      icon={IconDeviceDesktop}
+      lastValue={
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        gpuUsageOverTime.length > 0 ? `${Math.round(gpuUsageOverTime[gpuUsageOverTime.length - 1]!)}%` : undefined
+      }
+      chartType={hasShadow ? "area" : "line"}
+      yAxisProps={{ domain: [0, 100] }}
+      labelDisplayMode={labelDisplayMode}
+      tooltipProps={{
+        content: ({ payload }) => {
+          if (!payload) {
+            return null;
+          }
+          const value = payload[0] ? Number(payload[0].value) : 0;
+          return (
+            <Paper px={3} py={2} withBorder shadow="md" radius="md">
+              <Text c="dimmed" size="xs">
+                {value.toFixed(0)}%
+              </Text>
+            </Paper>
+          );
+        },
+      }}
+    />
+  );
+};

--- a/packages/widgets/src/system-resources/component.tsx
+++ b/packages/widgets/src/system-resources/component.tsx
@@ -9,6 +9,7 @@ import { clientApi } from "@homarr/api/client";
 import type { WidgetComponentProps } from "../definition";
 import { CombinedNetworkTrafficChart } from "./chart/combined-network-traffic";
 import { SystemResourceCPUChart } from "./chart/cpu-chart";
+import { SystemResourceGPUChart } from "./chart/gpu-chart";
 import { SystemResourceMemoryChart } from "./chart/memory-chart";
 import { NetworkTrafficChart } from "./chart/network-traffic";
 
@@ -23,10 +24,13 @@ export default function SystemResources({ integrationIds, options }: WidgetCompo
   const memoryCapacityInBytes =
     (data[0]?.healthInfo.memAvailableInBytes ?? 0) + (data[0]?.healthInfo.memUsedInBytes ?? 0);
 
-  const [items, setItems] = useState<{ cpu: number; memory: number; network: { up: number; down: number } | null }[]>(
+  const [items, setItems] = useState<{ cpu: number; memory: number; gpu: number; network: { up: number; down: number } | null }[]>(
     data.map((item) => ({
       cpu: item.healthInfo.cpuUtilization,
       memory: item.healthInfo.memUsedInBytes,
+      gpu: item.healthInfo.gpu.length > 0
+        ? item.healthInfo.gpu.reduce((acc, g) => acc + g.processorUtilization, 0) / item.healthInfo.gpu.length
+        : 0,
       network: item.healthInfo.network,
     })),
   );
@@ -41,6 +45,9 @@ export default function SystemResources({ integrationIds, options }: WidgetCompo
           const next = {
             cpu: data.healthInfo.cpuUtilization,
             memory: data.healthInfo.memUsedInBytes,
+            gpu: data.healthInfo.gpu.length > 0
+              ? data.healthInfo.gpu.reduce((acc, g) => acc + g.processorUtilization, 0) / data.healthInfo.gpu.length
+              : 0,
             network: data.healthInfo.network,
           };
 
@@ -70,6 +77,15 @@ export default function SystemResources({ integrationIds, options }: WidgetCompo
           <SystemResourceMemoryChart
             memoryUsageOverTime={items.map((item) => item.memory)}
             totalCapacityInBytes={memoryCapacityInBytes}
+            hasShadow={options.hasShadow}
+            labelDisplayMode={options.labelDisplayMode}
+          />
+        </Box>
+      )}
+      {options.visibleCharts.includes("gpu") && (
+        <Box h={rowHeight}>
+          <SystemResourceGPUChart
+            gpuUsageOverTime={items.map((item) => item.gpu)}
             hasShadow={options.hasShadow}
             labelDisplayMode={options.labelDisplayMode}
           />

--- a/packages/widgets/src/system-resources/index.ts
+++ b/packages/widgets/src/system-resources/index.ts
@@ -19,7 +19,7 @@ export const { definition, componentLoader } = createWidgetDefinition("systemRes
     return optionsBuilder.from((factory) => ({
       hasShadow: factory.switch({ defaultValue: true }),
       visibleCharts: factory.multiSelect({
-        options: (["cpu", "memory", "network"] as const).map((key) => ({
+        options: (["cpu", "memory", "gpu", "network"] as const).map((key) => ({
           value: key,
           label: (t) => t(`widget.systemResources.option.visibleCharts.option.${key}`),
         })),


### PR DESCRIPTION
## Summary

Adds GPU monitoring support to both the **Health Monitoring** and **System Resources** widgets, powered by the Glances integration merged in #5102.

This addresses the community request in #5102 (comment) for GPU graphics card monitoring.

## What's included

### Data layer
- Extended `SystemHealthMonitoring` interface with optional `gpu[]` field containing: `gpuId`, `name`, `memoryUtilization`, `processorUtilization`, `temperature`, `fanSpeed`
- Extended Glances integration Zod schema to parse GPU data from `/api/4/all` endpoint
- Supports NVIDIA (pynvml), AMD, and Intel GPUs — whatever Glances detects
- All other integrations (dashdot, truenas, unraid, openmediavault) return `gpu: []` for backward compatibility

### Health Monitoring widget
- New GPU utilization ring (matches existing CPU/memory ring pattern)
- Tooltip shows GPU name, VRAM usage %, temperature (°C/°F), and fan speed
- Toggleable via "Show GPU Info" option
- Supports multiple GPUs (one ring per GPU)

### System Resources widget
- New GPU time-series chart (grape color, matches CPU/memory chart pattern)
- Added `gpu` option to `visibleCharts` multiselect
- Averages utilization across all GPUs for the chart line

### Other
- English translations for all new GPU labels
- Mock data includes sample GPU for development/testing

## Screenshots

_Widget screenshots can be provided once built and tested with a Glances instance that has GPU data._

## Testing

1. Configure a Glances integration pointing to a host with a GPU
2. Verify GPU rings appear in the Health Monitoring widget
3. Verify GPU chart appears in the System Resources widget
4. Verify widgets work correctly when no GPU data is available (graceful degradation)