### PR TITLE
feat: add "allowModals" option for iframe widget

### DIFF
--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -1625,6 +1625,9 @@
         },
         "allowGeolocation": {
           "label": "Allow geolocation"
+        },
+        "allowModals": {
+          "label": "Allow modals"
         }
       },
       "error": {
@@ -2033,7 +2036,6 @@
           "directStream": "Direct Stream"
         }
       },
-
       "recentActivity": {
         "title": "Recent Activity",
         "empty": "No recent activity",

--- a/packages/widgets/src/iframe/component.tsx
+++ b/packages/widgets/src/iframe/component.tsx
@@ -105,6 +105,10 @@ const getSandboxFlags = (
     baseSandbox.push("allow-popups-to-escape-sandbox");
   }
 
+  if (permissions.allowModals) {
+    baseSandbox.push("allow-modals");
+  }
+
   return baseSandbox;
 };
 

--- a/packages/widgets/src/iframe/index.ts
+++ b/packages/widgets/src/iframe/index.ts
@@ -17,6 +17,7 @@ export const { definition, componentLoader } = createWidgetDefinition("iframe", 
       allowMicrophone: factory.switch(),
       allowCamera: factory.switch(),
       allowGeolocation: factory.switch(),
+      allowModals: factory.switch(),
     }));
   },
 }).withDynamicImport(() => import("./component"));


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

https://github.com/homarr-labs/documentation/pull/514

This adds a "allowModals" toggle for iframe widgets, similarly to existing options.
For reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe#allow-modals