### PR TITLE
ci: disable skip-stability-days for forks

### DIFF
--- a/.github/workflows/skip-renovate-stability-days.yml
+++ b/.github/workflows/skip-renovate-stability-days.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   skip-stability-days:
-    if: ${{ !startsWith(github.head_ref, 'renovate/') }}
+    if: ${{ !startsWith(github.head_ref, 'renovate/')  && github.event.pull_request.head.repo.full_name == github.repository }}
     name: Skip Stability Days
     runs-on: ubuntu-latest
     timeout-minutes: 1


### PR DESCRIPTION
This is a temporary test to see if it is actually skipped