### PR TITLE
ci: disable skip-stability-days for forks

### DIFF
--- a/.github/workflows/skip-renovate-stability-days.yml
+++ b/.github/workflows/skip-renovate-stability-days.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   skip-stability-days:
-    if: ${{ !startsWith(github.head_ref, 'renovate/') }}
+    if: ${{ !startsWith(github.head_ref, 'renovate/') && github.event.pull_request.head.repo.full_name == github.repository }}
     name: Skip Stability Days
     runs-on: ubuntu-latest
     timeout-minutes: 1


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

The goal of this change is to prevent the skip-stability-days workflow from running for pull-requests by forks. Currently it always fails for them as the token used does not have the permission to write the commit-status. Therefore I suggest we disable it for fork prs to prevent confusion.

See https://github.com/homarr-labs/homarr/pull/5450 as an example where the same change was made in a fork pr and the job was skipped.

<img width="761" height="72" alt="image" src="https://github.com/user-attachments/assets/2a11a4dc-e14d-4be4-b175-316499cd33eb" />
