### PR TITLE
fix: preserve all-day event dates in Nextcloud calendar integration

### DIFF
--- a/packages/integrations/src/nextcloud/nextcloud.integration.ts
+++ b/packages/integrations/src/nextcloud/nextcloud.integration.ts
@@ -113,7 +113,7 @@ export class NextcloudIntegration extends Integration implements ICalendarIntegr
           // next actually returns undefined when there are no more occurrences
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           while ((next = iterator.next())) {
-            const nextStartDate = next.convertToZone(ICAL.Timezone.utcTimezone).toJSDate();
+            const nextStartDate = next.isDate ? next.toJSDate() : next.convertToZone(ICAL.Timezone.utcTimezone).toJSDate();
             if (nextStartDate > end) break;
             const nextEndDate = new Date(nextStartDate.getTime() + durationMs);
             if (nextEndDate < start) continue;
@@ -121,7 +121,7 @@ export class NextcloudIntegration extends Integration implements ICalendarIntegr
             startDates.push(nextStartDate);
           }
         } else {
-          startDates = [veventObject.startDate.convertToZone(ICAL.Timezone.utcTimezone).toJSDate()];
+          startDates = [veventObject.startDate.isDate ? veventObject.startDate.toJSDate() : veventObject.startDate.convertToZone(ICAL.Timezone.utcTimezone).toJSDate()];
         }
 
         return startDates.map((startDate) => {

--- a/packages/integrations/src/nextcloud/nextcloud.integration.ts
+++ b/packages/integrations/src/nextcloud/nextcloud.integration.ts
@@ -113,7 +113,9 @@ export class NextcloudIntegration extends Integration implements ICalendarIntegr
           // next actually returns undefined when there are no more occurrences
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           while ((next = iterator.next())) {
-            const nextStartDate = next.isDate ? next.toJSDate() : next.convertToZone(ICAL.Timezone.utcTimezone).toJSDate();
+            const nextStartDate = next.isDate
+              ? next.toJSDate()
+              : next.convertToZone(ICAL.Timezone.utcTimezone).toJSDate();
             if (nextStartDate > end) break;
             const nextEndDate = new Date(nextStartDate.getTime() + durationMs);
             if (nextEndDate < start) continue;
@@ -121,7 +123,11 @@ export class NextcloudIntegration extends Integration implements ICalendarIntegr
             startDates.push(nextStartDate);
           }
         } else {
-          startDates = [veventObject.startDate.isDate ? veventObject.startDate.toJSDate() : veventObject.startDate.convertToZone(ICAL.Timezone.utcTimezone).toJSDate()];
+          startDates = [
+            veventObject.startDate.isDate
+              ? veventObject.startDate.toJSDate()
+              : veventObject.startDate.convertToZone(ICAL.Timezone.utcTimezone).toJSDate(),
+          ];
         }
 
         return startDates.map((startDate) => {


### PR DESCRIPTION
## Summary

All-day Nextcloud calendar events (birthdays, holidays) were showing on wrong dates for non-UTC timezones. The fix: skip UTC conversion for DATE-only values.

## Root cause

`nextcloud.integration.ts` lines 116 and 124 call `convertToZone(ICAL.Timezone.utcTimezone)` on every event. iCal all-day events use the DATE type (e.g. `DTSTART;VALUE=DATE:20260416`) with no time component. Converting that to UTC shifts the value: a birthday on April 16 in EST becomes `2026-04-16T04:00:00Z`, which renders across two days on the Homarr calendar.

## Fix

Check `ICAL.Time.isDate` before converting. DATE-only values (`isDate === true`) skip the UTC conversion and use `toJSDate()` directly. Timed events continue converting to UTC as before.

Two lines changed, both in the same pattern:
- Line 116: recurring event occurrences
- Line 124: non-recurring event start date

Fixes #5420

This contribution was developed with AI assistance (Claude Code).
