### PR TITLE
fix(lang): portuguese is linked to brazilian portuguese on crowdin

### DIFF
--- a/packages/translation/src/config.ts
+++ b/packages/translation/src/config.ts
@@ -284,6 +284,17 @@ export const localeConfigurations = {
       return import("dayjs/locale/pt").then((module) => module.default);
     },
   },
+  "pt-br": {
+    name: "Português (Brasil)",
+    translatedName: "Portuguese (Brazil)",
+    icon: flagIcon("br"),
+    importMrtLocalization() {
+      return import("mantine-react-table/locales/pt-BR/index.esm.mjs").then((module) => module.MRT_Localization_PT_BR);
+    },
+    importDayJsLocale() {
+      return import("dayjs/locale/pt-br").then((module) => module.default);
+    },
+  },
   ro: {
     name: "Românesc",
     translatedName: "Romanian",


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Closes #5618

Until today we only had `Poruguese, Brazilian` as language selected on Crowdin
But in the UI we used the Portuguese flag for it

Now we have split the two languages and I added a custom language code for the mapping of brazilian portuguese to `pt-br` 