### PR TITLE
perf: (next branch) reduce idle memory on startup

### DIFF
--- a/apps/nextjs/next.config.ts
+++ b/apps/nextjs/next.config.ts
@@ -32,6 +32,8 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizePackageImports: ["@mantine/core", "@mantine/hooks", "@tabler/icons-react"],
     turbopackFileSystemCacheForDev: true,
+    preloadEntriesOnStart: false,
+    webpackMemoryOptimizations: true,
   },
   transpilePackages: ["@homarr/ui", "@homarr/notifications", "@homarr/modals", "@homarr/spotlight", "@homarr/widgets"],
   images: {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -41,7 +41,7 @@ else
     REDIS_PID=$!
 fi
 
-NODE_OPTIONS="--max-old-space-size=${NEXTJS_HEAP_SIZE:-256}" node apps/nextjs/server.js &
+node apps/nextjs/server.js &
 NEXTJS_PID=$!
 
 # Function to handle SIGTERM and shut down services

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -41,7 +41,7 @@ else
     REDIS_PID=$!
 fi
 
-node apps/nextjs/server.js &
+NODE_OPTIONS="--max-old-space-size=${NEXTJS_HEAP_SIZE:-256}" node apps/nextjs/server.js &
 NEXTJS_PID=$!
 
 # Function to handle SIGTERM and shut down services


### PR DESCRIPTION
## Changes

- `preloadEntriesOnStart: false` — lazy load page modules instead of preloading all on startup
- `webpackMemoryOptimizations: true` — reduce build-time memory via Next.js experimental flag
- `NODE_OPTIONS=--max-old-space-size=256` — cap V8 heap (configurable via `NEXTJS_HEAP_SIZE` env var)

## Benchmark

Ran a generated comparison script that:
1. Pulls `ghcr.io/homarr-labs/homarr:next`
2. Builds the optimized image from this branch
3. Starts each container sequentially, waits 60s to stabilize, then samples memory 5 times at 10s intervals

```
Official (:next tag):  ~211-213 MiB idle
Optimized (this PR):   ~115-118 MiB idle
```

**~45% reduction in idle memory usage (213 MiB → 117 MiB).**

Same image size (124.6 MB), same PID count (18).

## Note 
I am a bit worried about that aggressive GC calls to keep it low, might not be the best thing to do, either way it's just to show-off the nextjs built-in optimizations we could leverage

<details>
<summary>Comparison script (not committed, generated by AI)</summary>

```bash
#!/usr/bin/env bash
set -e

OFFICIAL_IMAGE="ghcr.io/homarr-labs/homarr:next"
OPTIMIZED_IMAGE="homarr-optimized:local"
ENCRYPTION_KEY="0000000000000000000000000000000000000000000000000000000000000000"
WAIT_SECONDS=60
SAMPLE_COUNT=5
SAMPLE_INTERVAL=10

cleanup() {
    echo "Cleaning up containers..."
    docker rm -f homarr-official homarr-optimized 2>/dev/null || true
}
trap cleanup EXIT

echo "=== Homarr Memory Comparison ==="

echo "[1/5] Pulling official image..."
docker pull "$OFFICIAL_IMAGE"

echo "[2/5] Building optimized image..."
docker build -t "$OPTIMIZED_IMAGE" .

echo "[3/5] Starting official container..."
cleanup
docker run -d --name homarr-official -e SECRET_ENCRYPTION_KEY="$ENCRYPTION_KEY" -p 7575:7575 "$OFFICIAL_IMAGE"
echo "Waiting ${WAIT_SECONDS}s for stabilization..."
sleep "$WAIT_SECONDS"

echo "=== Official ==="
for i in $(seq 1 $SAMPLE_COUNT); do
    docker stats --no-stream --format "{{.MemUsage}}" homarr-official
    [ "$i" -lt "$SAMPLE_COUNT" ] && sleep "$SAMPLE_INTERVAL"
done

docker stop homarr-official

echo "[4/5] Starting optimized container..."
docker run -d --name homarr-optimized -e SECRET_ENCRYPTION_KEY="$ENCRYPTION_KEY" -p 7576:7575 "$OPTIMIZED_IMAGE"
echo "Waiting ${WAIT_SECONDS}s for stabilization..."
sleep "$WAIT_SECONDS"

echo "=== Optimized ==="
for i in $(seq 1 $SAMPLE_COUNT); do
    docker stats --no-stream --format "{{.MemUsage}}" homarr-optimized
    [ "$i" -lt "$SAMPLE_COUNT" ] && sleep "$SAMPLE_INTERVAL"
done

echo "[5/5] Image sizes:"
docker image inspect "$OFFICIAL_IMAGE" --format='Official: {{.Size}}'
docker image inspect "$OPTIMIZED_IMAGE" --format='Optimized: {{.Size}}'
echo "Done."
```

</details>