### PR TITLE
feat: report container RAM usage to PostHog every 30 minutes

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -44,10 +44,33 @@ fi
 node apps/nextjs/server.js &
 NEXTJS_PID=$!
 
+report_ram() {
+  INTERVAL=${RAM_REPORT_INTERVAL:-1800}
+  while true; do
+    sleep "$INTERVAL"
+    MEM_USED_BYTES=$(cat /sys/fs/cgroup/memory.current)
+    MEM_MAX_RAW=$(cat /sys/fs/cgroup/memory.max)
+    MEM_USED_MB=$((MEM_USED_BYTES / 1048576))
+    if [ "$MEM_MAX_RAW" = "max" ]; then
+      MEM_MAX_MB=0
+    else
+      MEM_MAX_MB=$((MEM_MAX_RAW / 1048576))
+    fi
+
+    wget -q --post-data="{\"api_key\":\"phc_pWxeD1hbl4ip02JYReX1Crjkt5DhB3dduigirHMCtFE\",\"event\":\"ram_usage\",\"distinct_id\":\"${HOSTNAME:-homarr}\",\"properties\":{\"ram_used_mb\":${MEM_USED_MB},\"ram_max_mb\":${MEM_MAX_MB},\"ram_used_bytes\":${MEM_USED_BYTES},\"\$process_person_profile\":false}}" \
+      --header="Content-Type: application/json" \
+      -O /dev/null https://hog.ajnart.dev/i/v0/e/ 2>/dev/null
+    echo "Reported RAM: ${MEM_USED_MB}MB / ${MEM_MAX_MB}MB"
+  done
+}
+
+report_ram &
+REPORT_RAM_PID=$!
+
 # Function to handle SIGTERM and shut down services
 terminate() {
     echo "Received SIGTERM. Shutting down..."
-    kill -TERM $NGINX_PID $NEXTJS_PID 2>/dev/null
+    kill -TERM $REPORT_RAM_PID $NGINX_PID $NEXTJS_PID 2>/dev/null
     wait
     # kill redis-server last because of logging of other services and only if $REDIS_PID is set
     if [ -n "$REDIS_PID" ]; then


### PR DESCRIPTION
# Important 
> [!NOTE]
>  # This PR is meant to be reverted once the changes for the ram are merged into the main branch. We won't force users to send us their ram usage. Don't worry. 


# Why do we add this? 

We want real-world data on how lean this new version of Homarr actually is with our new changes compared to the mess it is currently so that we can flex about it on Reddit with a clickbait title on r/selfhosted. When will post a linkedin worthy title like "Homarr now uses 3x less memory," we want the receipts to prove it. 



# What we see on posthog dashboard (public dashboard)  
https://eu.posthog.com/shared/UG813OiixJQ9JKadGIHhRgecpz4R3Q

<img width="3666" height="2088" alt="CleanShot 2026-05-07 at 19 04 26" src="https://github.com/user-attachments/assets/d2a1dc37-6713-42bf-a346-3c5bc0cefa1a" />


## Summary

- Adds a background loop in `run.sh` that reads cgroup v2 memory stats and sends a `ram_usage` event to PostHog EU every 30 minutes
- Reports `ram_used_mb`, `ram_max_mb`, and `ram_used_bytes` per container
- Configurable interval via `RAM_REPORT_INTERVAL` env var (defaults to 1800s)
- No new dependencies — uses BusyBox `wget` already present in Alpine

## Test plan

- Built Docker image with `RAM_REPORT_INTERVAL=30` and verified events appear in PostHog
- Ran load test hitting multiple endpoints to confirm memory changes are reflected

<details>
<summary><h2>Test script: fire events manually</h2></summary>

```bash
#!/usr/bin/env bash
ITERATIONS=${1:-5}

for i in $(seq 1 "$ITERATIONS"); do
  MEM_USED_BYTES=$(cat /sys/fs/cgroup/memory.current)
  MEM_MAX_BYTES=$(cat /sys/fs/cgroup/memory.max)
  MEM_USED_MB=$((MEM_USED_BYTES / 1048576))
  MEM_MAX_MB=$((MEM_MAX_BYTES / 1048576))

  wget -q --post-data="{\"api_key\":\"phc_pWxeD1hbl4ip02JYReX1Crjkt5DhB3dduigirHMCtFE\",\"event\":\"ram_usage\",\"distinct_id\":\"${HOSTNAME:-test}\",\"properties\":{\"ram_used_mb\":${MEM_USED_MB},\"ram_max_mb\":${MEM_MAX_MB},\"ram_used_bytes\":${MEM_USED_BYTES},\"\$process_person_profile\":false}}" \
    --header="Content-Type: application/json" \
    -O /dev/null https://hog.ajnart.dev/i/v0/e/

  echo "[${i}/${ITERATIONS}] ram_usage: ${MEM_USED_MB}MB / ${MEM_MAX_MB}MB"
  sleep 2
done

echo "Done. Check PostHog for 'ram_usage' events."
```

Usage: `docker exec <container> bash test-ram-report.sh 10`

</details>

<details>
<summary><h2>Load test script: simulate traffic to grow memory</h2></summary>

```bash
#!/usr/bin/env bash
BASE_URL="${1:-http://localhost:3000}"
ROUNDS=${2:-50}
DELAY=${3:-2}

PATHS=(
  "/"
  "/en/boards"
  "/en/manage/users"
  "/en/manage/integrations"
  "/en/manage/settings"
  "/en/manage/tools/docker"
  "/api/health"
)

echo "Hitting ${BASE_URL} with ${ROUNDS} rounds, ${DELAY}s delay"
echo "Paths: ${#PATHS[@]} endpoints"

for i in $(seq 1 "$ROUNDS"); do
  PATH_IDX=$((RANDOM % ${#PATHS[@]}))
  URL="${BASE_URL}${PATHS[$PATH_IDX]}"
  wget -q -O /dev/null "$URL" 2>/dev/null
  echo "[${i}/${ROUNDS}] GET ${PATHS[$PATH_IDX]}"
  sleep "$DELAY"
done

echo "Load test complete."
```

Usage: `docker exec <container> bash load-test.sh http://localhost:3000 30 1`

</details>

<details>
<summary><h2>Dockerfile for testing (30s interval)</h2></summary>

```dockerfile
FROM ghcr.io/homarr-labs/homarr:next
COPY scripts/run.sh ./run.sh
ENV RAM_REPORT_INTERVAL=30
```

```bash
docker build -f Dockerfile.ram-test -t homarr-ram-test .
docker run -d --name homarr-ram-test -p 7575:7575 -e SECRET_ENCRYPTION_KEY=test1234567890abcdef homarr-ram-test
```

</details>