### PR TITLE
revert(deps): downgrade pnpm to v10

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,7 +22,7 @@
       automerge: true,
     },
     {
-      // disallow automerge for dependencies requiring postinstall scripts
+      // disallow automerge for onlyBuiltDependencies
       matchPackageNames: [
         "@tree-sitter-grammars/tree-sitter-yaml",
         "bcrypt",
@@ -39,7 +39,7 @@
   ],
   // Updates lockfile for prebuilt-debian after if package.json is updated, otherwise only root lockfile is updated
   postUpgradeTasks: {
-    commands: ["cd deployments/prebuilt-debian && pnpm install --lockfile-only"],
+    commands: ["cd deployments/prebuilt-debian && pnpm install --ignore-workspace --lockfile-only"],
     fileFilters: ["deployments/prebuilt-debian/pnpm-lock.yaml"],
     executionMode: "update",
   },

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# Expo doesn't play nice with pnpm by default. 
+# The symbolic links of pnpm break the rules of Expo monorepos.
+# @link https://docs.expo.dev/guides/monorepos/#common-issues
+node-linker=hoisted
+strict-peer-dependencies=false
+engine-strict=true

--- a/deployments/prebuilt-debian/Dockerfile
+++ b/deployments/prebuilt-debian/Dockerfile
@@ -2,6 +2,5 @@ FROM node:24.15.0-trixie AS base
 WORKDIR /app
 COPY package.json .
 COPY pnpm-lock.yaml .
-COPY pnpm-workspace.yaml .
 RUN corepack enable pnpm && pnpm install --frozen-lockfile
 CMD ["sleep", "60s"]

--- a/deployments/prebuilt-debian/package.json
+++ b/deployments/prebuilt-debian/package.json
@@ -4,9 +4,9 @@
   "dependencies": {
     "better-sqlite3": "^12.9.0"
   },
-  "packageManager": "pnpm@11.0.4",
+  "packageManager": "pnpm@11.0.3",
   "engines": {
     "node": ">=24.15.0",
-    "pnpm": ">=11.0.4"
+    "pnpm": ">=11.0.3"
   }
 }

--- a/deployments/prebuilt-debian/package.json
+++ b/deployments/prebuilt-debian/package.json
@@ -4,9 +4,14 @@
   "dependencies": {
     "better-sqlite3": "^12.9.0"
   },
-  "packageManager": "pnpm@11.0.3",
+  "packageManager": "pnpm@10.33.2",
   "engines": {
     "node": ">=24.15.0",
-    "pnpm": ">=11.0.3"
+    "pnpm": ">=10.33.2"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
   }
 }

--- a/deployments/prebuilt-debian/pnpm-workspace.yaml
+++ b/deployments/prebuilt-debian/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-allowBuilds:
-  better-sqlite3: true

--- a/package.json
+++ b/package.json
@@ -57,12 +57,55 @@
     "turbo": "catalog:",
     "typescript": "catalog:",
     "vite-tsconfig-paths": "catalog:",
-    "vitest": "catalog:",
-    "yaml": "catalog:"
+    "vitest": "catalog:"
   },
-  "packageManager": "pnpm@11.0.3",
+  "packageManager": "pnpm@10.33.2",
   "engines": {
     "node": ">=24.15.0",
-    "pnpm": ">=11.0.3"
+    "pnpm": ">=10.33.2"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@tree-sitter-grammars/tree-sitter-yaml",
+      "bcrypt",
+      "better-sqlite3",
+      "cpu-features",
+      "esbuild",
+      "sharp",
+      "ssh2",
+      "tree-sitter",
+      "tree-sitter-json"
+    ],
+    "overrides": {
+      "@babel/helpers@<7.26.10": ">=7.29.2",
+      "@babel/runtime@<7.26.10": ">=7.29.2",
+      "axios@>=1.0.0 <1.8.2": ">=1.16.0",
+      "brace-expansion@>=2.0.0 <=2.0.1": ">=5.0.5",
+      "brace-expansion@>=1.0.0 <=1.1.11": ">=5.0.5",
+      "esbuild@<=0.24.2": ">=0.28.0",
+      "form-data@>=4.0.0 <4.0.4": ">=4.0.5",
+      "hono@<4.6.5": ">=4.12.16",
+      "linkifyjs@<4.3.2": ">=4.3.2",
+      "nanoid@>=4.0.0 <5.0.9": ">=5.1.11",
+      "prismjs@<1.30.0": ">=1.30.0",
+      "proxmox-api>undici": "7.24.6",
+      "react-is": "^19.2.5",
+      "rollup@>=4.0.0 <4.22.4": ">=4.60.2",
+      "sha.js@<=2.4.11": ">=2.4.12",
+      "tar-fs@>=3.0.0 <3.0.9": ">=3.1.2",
+      "tar-fs@>=2.0.0 <2.1.3": ">=3.1.2",
+      "tmp@<=0.2.3": ">=0.2.5",
+      "vite@>=5.0.0 <=5.4.18": ">=8.0.10"
+    },
+    "patchedDependencies": {
+      "@types/node-unifi": "patches/@types__node-unifi.patch",
+      "trpc-to-openapi": "patches/trpc-to-openapi.patch"
+    },
+    "allowUnusedPatches": true,
+    "ignoredBuiltDependencies": [
+      "@scarf/scarf",
+      "core-js-pure",
+      "protobufjs"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
     "vitest": "catalog:",
     "yaml": "catalog:"
   },
-  "packageManager": "pnpm@11.0.4",
+  "packageManager": "pnpm@11.0.3",
   "engines": {
     "node": ">=24.15.0",
-    "pnpm": ">=11.0.4"
+    "pnpm": ">=11.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -566,8 +566,8 @@ overrides:
   '@babel/helpers@<7.26.10': '>=7.29.2'
   '@babel/runtime@<7.26.10': '>=7.29.2'
   axios@>=1.0.0 <1.8.2: '>=1.16.0'
-  brace-expansion@>=1.0.0 <=1.1.11: '>=5.0.5'
   brace-expansion@>=2.0.0 <=2.0.1: '>=5.0.5'
+  brace-expansion@>=1.0.0 <=1.1.11: '>=5.0.5'
   esbuild@<=0.24.2: '>=0.28.0'
   form-data@>=4.0.0 <4.0.4: '>=4.0.5'
   hono@<4.6.5: '>=4.12.16'
@@ -578,14 +578,18 @@ overrides:
   react-is: ^19.2.5
   rollup@>=4.0.0 <4.22.4: '>=4.60.2'
   sha.js@<=2.4.11: '>=2.4.12'
-  tar-fs@>=2.0.0 <2.1.3: '>=3.1.2'
   tar-fs@>=3.0.0 <3.0.9: '>=3.1.2'
+  tar-fs@>=2.0.0 <2.1.3: '>=3.1.2'
   tmp@<=0.2.3: '>=0.2.5'
   vite@>=5.0.0 <=5.4.18: '>=8.0.10'
 
 patchedDependencies:
-  '@types/node-unifi': 5e6ae51e2a17a7f9729bfa30b0eb3d0842a5810ac6db47603ab4a6efa1ed84c5
-  trpc-to-openapi: 2ca3c16af0fcca0c736697ad4fe553a14f794524fa9ce0d5c3e8ee4aea76090c
+  '@types/node-unifi':
+    hash: 5e6ae51e2a17a7f9729bfa30b0eb3d0842a5810ac6db47603ab4a6efa1ed84c5
+    path: patches/@types__node-unifi.patch
+  trpc-to-openapi:
+    hash: 2ca3c16af0fcca0c736697ad4fe553a14f794524fa9ce0d5c3e8ee4aea76090c
+    path: patches/trpc-to-openapi.patch
 
 importers:
 
@@ -660,9 +664,6 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.5(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.1.12(@types/node@24.12.2)(sass@1.99.0)(sugarss@5.0.0(postcss@8.5.8))(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.4))
-      yaml:
-        specifier: 'catalog:'
-        version: 2.8.4
 
   apps/nextjs:
     dependencies:
@@ -1454,7 +1455,7 @@ importers:
     dependencies:
       '@t3-oss/env-nextjs':
         specifier: 'catalog:'
-        version: 0.13.11(typescript@5.9.3)(zod@4.4.2)
+        version: 0.13.11(arktype@2.1.20)(typescript@5.9.3)(zod@4.4.2)
       better-sqlite3:
         specifier: 'catalog:'
         version: 12.9.0
@@ -1463,7 +1464,7 @@ importers:
         version: 0.2.9
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@24.12.2))(pg@8.20.0)
+        version: 0.45.2(@libsql/client-wasm@0.14.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(gel@2.0.0)(mysql2@3.22.3(@types/node@24.12.2))(pg@8.20.0)
       ioredis:
         specifier: 'catalog:'
         version: 5.10.1
@@ -1717,10 +1718,10 @@ importers:
         version: 0.31.10
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@24.12.2))(pg@8.20.0)
+        version: 0.45.2(@libsql/client-wasm@0.14.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(gel@2.0.0)(mysql2@3.22.3(@types/node@24.12.2))(pg@8.20.0)
       drizzle-zod:
         specifier: 'catalog:'
-        version: 0.8.3(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@24.12.2))(pg@8.20.0))(zod@4.4.2)
+        version: 0.8.3(drizzle-orm@0.45.2(@libsql/client-wasm@0.14.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(gel@2.0.0)(mysql2@3.22.3(@types/node@24.12.2))(pg@8.20.0))(zod@4.4.2)
       mysql2:
         specifier: 'catalog:'
         version: 3.22.3(@types/node@24.12.2)
@@ -3000,6 +3001,12 @@ packages:
     resolution: {integrity: sha512-2aDL3WUv8hMJb2L3r/PIQWsTLyq7RQr3v9xD16fiz6O8ys1xEyLhhTOv8gxtZvJiTzjTF5pHoArvRdesGL1DMQ==}
     hasBin: true
 
+  '@ark/schema@0.46.0':
+    resolution: {integrity: sha512-c2UQdKgP2eqqDArfBqQIJppxJHvNNXuQPeuSPlDML4rjw+f1cu0qAlzOG4b8ujgm9ctIDWwhpyw6gjG5ledIVQ==}
+
+  '@ark/util@0.46.0':
+    resolution: {integrity: sha512-JPy/NGWn/lvf1WmGCPw2VGpBg5utZraE84I7wli18EDF3p3zc/e9WolT35tINeZO3l7C77SjqRJeAUoT0CvMRg==}
+
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -4276,6 +4283,14 @@ packages:
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
+  '@libsql/client-wasm@0.14.0':
+    resolution: {integrity: sha512-gB/jtz0xuwrqAHApBv9e9JSew2030Fhj2edyZ83InZ4yPj/Q2LTUlEhaspEYT0T0xsAGqPy38uGrmq/OGS+DdQ==}
+    bundledDependencies:
+      - '@libsql/libsql-wasm-experimental'
+
+  '@libsql/core@0.14.0':
+    resolution: {integrity: sha512-nhbuXf7GP3PSZgdCY2Ecj8vz187ptHlZQ0VRc751oB2C1W8jQUXKKklvt7t1LJiUTQBVJuadF628eUk+3cRi4Q==}
+
   '@mantine/charts@8.3.18':
     resolution: {integrity: sha512-oudif3EUH7Nb9DPm0abAPxpFYDWWjR3k2S5ll0/CcB+pJzlhwaBG19QwpOJaRA6VAvAXDDKOXCO4mi9XCEN78g==}
     peerDependencies:
@@ -4370,7 +4385,6 @@ packages:
 
   '@million/lint@1.0.14':
     resolution: {integrity: sha512-u6/kglVwZRu5+GMmtkNlGLqJVkgTl0TtM+hLa9rBg7pldx+5NG5bk45NvL37uZmAr2Xfa1C6qHb7GrFwfP372g==}
-    deprecated: This package is no longer maintained
     hasBin: true
 
   '@ndaidong/bellajs@12.0.1':
@@ -4650,6 +4664,9 @@ packages:
   '@parcel/watcher@2.4.1':
     resolution: {integrity: sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==}
     engines: {node: '>= 10.0.0'}
+
+  '@petamoriken/float16@3.9.3':
+    resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -6108,6 +6125,9 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  arktype@2.1.20:
+    resolution: {integrity: sha512-IZCEEXaJ8g+Ijd59WtSYwtjnqXiwM8sWQ5EjGamcto7+HVN9eK0C4p0zDlCuAwWhpqr6fIBkxPuYDl4/Mcj/+Q==}
+
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
@@ -7084,6 +7104,10 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -7546,6 +7570,11 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  gel@2.0.0:
+    resolution: {integrity: sha512-Oq3Fjay71s00xzDc0BF/mpcLmnA+uRqMEJK8p5K4PaZjUEsxaeo+kR9OHBVAf289/qPd+0OcLOLUN0UhqiUCog==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
 
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
@@ -8096,6 +8125,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
+
   isomorphic-dompurify@3.12.0:
     resolution: {integrity: sha512-8n+j+6ypTHvriJwFOQ2qusQ6bzGjZVcR3jbe1pBpLcGI1dn4WIl0ctLBngqE5QttquQBAlKXwJeTMw+X7x7qKw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
@@ -8163,6 +8196,9 @@ packages:
         optional: true
       react:
         optional: true
+
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
   js-file-download@0.4.12:
     resolution: {integrity: sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==}
@@ -10949,6 +10985,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -11176,6 +11217,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
 
   '@antfu/ni@0.21.12': {}
+
+  '@ark/schema@0.46.0':
+    dependencies:
+      '@ark/util': 0.46.0
+    optional: true
+
+  '@ark/util@0.46.0':
+    optional: true
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -12270,6 +12319,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@libsql/client-wasm@0.14.0':
+    dependencies:
+      '@libsql/core': 0.14.0
+      js-base64: 3.7.8
+    optional: true
+
+  '@libsql/core@0.14.0':
+    dependencies:
+      js-base64: 3.7.8
+    optional: true
+
   '@mantine/charts@8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@mantine/hooks@8.3.18(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.5)(react@19.2.5)(redux@5.0.1))':
     dependencies:
       '@mantine/core': 8.3.18(@mantine/hooks@8.3.18(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -12673,6 +12733,9 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.4.1
       '@parcel/watcher-win32-ia32': 2.4.1
       '@parcel/watcher-win32-x64': 2.4.1
+
+  '@petamoriken/float16@3.9.3':
+    optional: true
 
   '@pinojs/redact@0.4.0': {}
 
@@ -13429,15 +13492,17 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@t3-oss/env-core@0.13.11(typescript@5.9.3)(zod@4.4.2)':
+  '@t3-oss/env-core@0.13.11(arktype@2.1.20)(typescript@5.9.3)(zod@4.4.2)':
     optionalDependencies:
+      arktype: 2.1.20
       typescript: 5.9.3
       zod: 4.4.2
 
-  '@t3-oss/env-nextjs@0.13.11(typescript@5.9.3)(zod@4.4.2)':
+  '@t3-oss/env-nextjs@0.13.11(arktype@2.1.20)(typescript@5.9.3)(zod@4.4.2)':
     dependencies:
-      '@t3-oss/env-core': 0.13.11(typescript@5.9.3)(zod@4.4.2)
+      '@t3-oss/env-core': 0.13.11(arktype@2.1.20)(typescript@5.9.3)(zod@4.4.2)
     optionalDependencies:
+      arktype: 2.1.20
       typescript: 5.9.3
       zod: 4.4.2
 
@@ -14476,6 +14541,12 @@ snapshots:
 
   aria-query@5.3.2: {}
 
+  arktype@2.1.20:
+    dependencies:
+      '@ark/schema': 0.46.0
+      '@ark/util': 0.46.0
+    optional: true
+
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -15303,17 +15374,19 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@24.12.2))(pg@8.20.0):
+  drizzle-orm@0.45.2(@libsql/client-wasm@0.14.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(gel@2.0.0)(mysql2@3.22.3(@types/node@24.12.2))(pg@8.20.0):
     optionalDependencies:
+      '@libsql/client-wasm': 0.14.0
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.20.0
       better-sqlite3: 12.9.0
+      gel: 2.0.0
       mysql2: 3.22.3(@types/node@24.12.2)
       pg: 8.20.0
 
-  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@24.12.2))(pg@8.20.0))(zod@4.4.2):
+  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@libsql/client-wasm@0.14.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(gel@2.0.0)(mysql2@3.22.3(@types/node@24.12.2))(pg@8.20.0))(zod@4.4.2):
     dependencies:
-      drizzle-orm: 0.45.2(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@24.12.2))(pg@8.20.0)
+      drizzle-orm: 0.45.2(@libsql/client-wasm@0.14.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.9.0)(gel@2.0.0)(mysql2@3.22.3(@types/node@24.12.2))(pg@8.20.0)
       zod: 4.4.2
 
   dunder-proto@1.0.1:
@@ -15395,6 +15468,9 @@ snapshots:
       java-properties: 1.0.2
 
   env-paths@2.2.1: {}
+
+  env-paths@3.0.0:
+    optional: true
 
   environment@1.1.0: {}
 
@@ -16066,6 +16142,18 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  gel@2.0.0:
+    dependencies:
+      '@petamoriken/float16': 3.9.3
+      debug: 4.4.3
+      env-paths: 3.0.0
+      semver: 7.7.4
+      shell-quote: 1.8.3
+      which: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   generate-function@2.3.1:
     dependencies:
       is-property: 1.0.2
@@ -16602,6 +16690,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isexe@3.1.5:
+    optional: true
+
   isomorphic-dompurify@3.12.0(@noble/hashes@2.0.1):
     dependencies:
       dompurify: 3.4.2
@@ -16684,6 +16775,9 @@ snapshots:
       '@babel/template': 7.28.6
       '@types/react': 19.2.14
       react: 19.2.5
+
+  js-base64@3.7.8:
+    optional: true
 
   js-file-download@0.4.12: {}
 
@@ -19905,6 +19999,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  which@4.0.0:
+    dependencies:
+      isexe: 3.1.5
+    optional: true
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,22 +2,6 @@ packages:
   - apps/*
   - packages/*
   - tooling/*
-allowBuilds:
-  "@scarf/scarf": false
-  "@swc/core": false
-  "@tree-sitter-grammars/tree-sitter-yaml": true
-  bcrypt: true
-  better-sqlite3: true
-  core-js-pure: false
-  cpu-features: true
-  esbuild: true
-  protobufjs: false
-  sharp: true
-  ssh2: true
-  tree-sitter: true
-  tree-sitter-json: true
-  nice-napi: false
-allowUnusedPatches: true
 catalog:
   "@auth/core": ^0.41.2
   "@auth/drizzle-adapter": ^1.11.2
@@ -29,7 +13,7 @@ catalog:
   "@dnd-kit/sortable": ^10.0.0
   "@dnd-kit/utilities": ^3.2.2
   "@drizzle-team/brocli": ^0.12.0
-  "@eslint/js": 10.0.1
+  '@eslint/js': 10.0.1
   "@extractus/feed-extractor": 7.1.7
   "@gitbeaker/rest": ^43.8.0
   "@homarr/gridstack": ^1.12.0
@@ -205,32 +189,7 @@ catalog:
   zod-form-data: ^3.0.1
   zod-validation-error: ^5.0.0
 catalogMode: strict
-engineStrict: true
 minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - next
   - "@next/*"
-nodeLinker: hoisted
-overrides:
-  "@babel/helpers@<7.26.10": ">=7.29.2"
-  "@babel/runtime@<7.26.10": ">=7.29.2"
-  "axios@>=1.0.0 <1.8.2": ">=1.16.0"
-  "brace-expansion@>=1.0.0 <=1.1.11": ">=5.0.5"
-  "brace-expansion@>=2.0.0 <=2.0.1": ">=5.0.5"
-  "esbuild@<=0.24.2": ">=0.28.0"
-  "form-data@>=4.0.0 <4.0.4": ">=4.0.5"
-  "hono@<4.6.5": ">=4.12.16"
-  "linkifyjs@<4.3.2": ">=4.3.2"
-  "nanoid@>=4.0.0 <5.0.9": ">=5.1.11"
-  "prismjs@<1.30.0": ">=1.30.0"
-  "proxmox-api>undici": "7.24.6"
-  "react-is": "^19.2.5"
-  "rollup@>=4.0.0 <4.22.4": ">=4.60.2"
-  "sha.js@<=2.4.11": ">=2.4.12"
-  "tar-fs@>=2.0.0 <2.1.3": ">=3.1.2"
-  "tar-fs@>=3.0.0 <3.0.9": ">=3.1.2"
-  "tmp@<=0.2.3": ">=0.2.5"
-  "vite@>=5.0.0 <=5.4.18": ">=8.0.10"
-patchedDependencies:
-  "@types/node-unifi": "patches/@types__node-unifi.patch"
-  trpc-to-openapi: "patches/trpc-to-openapi.patch"

--- a/test/renovate.spec.ts
+++ b/test/renovate.spec.ts
@@ -2,24 +2,21 @@ import fs from "fs/promises";
 import { join } from "path";
 import json5 from "json5";
 import { describe, test } from "vitest";
-import { parse as parseYaml } from "yaml";
 
 describe("Renovate configuration tests", () => {
-  test("automerge should be disabled for built dependencies", async () => {
-    const pnpmConfig = await fs.readFile(join(__dirname, "../pnpm-workspace.yaml"), "utf-8").then(parseYaml);
+  test("automerge should be disabled for onlyBuiltDependencies", async () => {
+    const packageJson = await import("../package.json");
     const renovateConfig = await fs.readFile(join(__dirname, "../.github/renovate.json5"), "utf-8").then(json5.parse);
-    const dependenciesWithBuilt = Object.entries(pnpmConfig.allowBuilds)
-      .filter(([_, value]) => value === true)
-      .map(([key, _]) => key);
+    const onlyBuiltDependencies = packageJson.pnpm.onlyBuiltDependencies;
     const automergeDisabledDeps = renovateConfig.packageRules
       .filter((rule: any) => rule.automerge === false)
       .flatMap((rule: any) => rule.matchPackageNames || []);
 
-    const missingDeps = dependenciesWithBuilt.filter((dep: string) => !automergeDisabledDeps.includes(dep));
+    const missingDeps = onlyBuiltDependencies.filter((dep: string) => !automergeDisabledDeps.includes(dep));
 
     if (missingDeps.length > 0) {
       throw new Error(
-        `The following built dependencies are missing automerge disable rules in renovate.json5: ${missingDeps.join(", ")}`,
+        `The following onlyBuiltDependencies are missing automerge disable rules in renovate.json5: ${missingDeps.join(", ")}`,
       );
     }
   });


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Reverts #5660

We reverted this commit due to issues with `ERR_PNPM_MISSING_TIME` (see https://github.com/pnpm/pnpm/issues/11238)
That happend for example [here](https://github.com/homarr-labs/homarr/pull/5670#issuecomment-4405282041)
Once this is fixed, we'll be able to update to pnpm v11 again