### PR TITLE
perf(boards): remove loading overlay and show board immediately

### DIFF
--- a/apps/nextjs/src/app/[locale]/boards/(content)/_client.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_client.tsx
@@ -1,70 +1,27 @@
 "use client";
 
-import { useCallback, useRef } from "react";
-import { Box, LoadingOverlay, Stack } from "@mantine/core";
+import { Box, Stack } from "@mantine/core";
 
-import type { RouterOutputs } from "@homarr/api";
-import { clientApi } from "@homarr/api/client";
 import { useCurrentLayout, useRequiredBoard } from "@homarr/boards/context";
 
 import { BoardCategorySection } from "~/components/board/sections/category-section";
 import { BoardEmptySection } from "~/components/board/sections/empty-section";
 import { BoardBackgroundVideo } from "~/components/layout/background";
-import { fullHeightWithoutHeaderAndFooter } from "~/constants";
-import { useIsBoardReady } from "./_ready-context";
-
-let boardName: string | null = null;
-
-export const updateBoardName = (name: string | null) => {
-  boardName = name;
-};
-
-type UpdateCallback = (prev: RouterOutputs["board"]["getHomeBoard"]) => RouterOutputs["board"]["getHomeBoard"];
-
-export const useUpdateBoard = () => {
-  const utils = clientApi.useUtils();
-
-  const updateBoard = useCallback(
-    (updaterWithoutUndefined: UpdateCallback) => {
-      if (!boardName) {
-        throw new Error("Board name is not set");
-      }
-      utils.board.getBoardByName.setData({ name: boardName }, (previous) =>
-        previous ? updaterWithoutUndefined(previous) : previous,
-      );
-    },
-    [utils],
-  );
-
-  return {
-    updateBoard,
-  };
-};
 
 export const ClientBoard = () => {
   const board = useRequiredBoard();
   const currentLayoutId = useCurrentLayout();
-  const isReady = useIsBoardReady();
 
   const fullWidthSortedSections = board.sections
     .filter((section) => section.kind === "empty" || section.kind === "category")
     .sort((sectionA, sectionB) => sectionA.yOffset - sectionB.yOffset);
 
-  const ref = useRef<HTMLDivElement>(null);
-
   return (
     <Box h="100%" pos="relative">
       <BoardBackgroundVideo />
-      <LoadingOverlay
-        visible={!isReady}
-        transitionProps={{ duration: 500 }}
-        loaderProps={{ size: "lg" }}
-        h={fullHeightWithoutHeaderAndFooter}
-      />
-      <Stack ref={ref} h="100%" style={{ visibility: isReady ? "visible" : "hidden" }}>
+      <Stack h="100%">
         {fullWidthSortedSections.map((section) =>
           section.kind === "empty" ? (
-            // Unique keys per layout to always reinitialize the gridstack
             <BoardEmptySection key={`${currentLayoutId}-${section.id}`} section={section} />
           ) : (
             <BoardCategorySection key={`${currentLayoutId}-${section.id}`} section={section} />

--- a/apps/nextjs/src/app/[locale]/boards/(content)/_ready-context.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_ready-context.tsx
@@ -1,35 +1,14 @@
 "use client";
 
 import type { PropsWithChildren } from "react";
-import { createContext, useCallback, useContext, useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
-
-import { clientApi } from "@homarr/api/client";
-import { useRequiredBoard } from "@homarr/boards/context";
+import { createContext, useCallback, useContext } from "react";
 
 const BoardReadyContext = createContext<{
   markAsReady: (id: string) => void;
 } | null>(null);
 
 export const BoardReadyProvider = ({ children }: PropsWithChildren) => {
-  const pathname = usePathname();
-  const utils = clientApi.useUtils();
-  const board = useRequiredBoard();
-  const [readySections, setReadySections] = useState<string[]>([]);
-
-  useEffect(() => {
-    return () => {
-      setReadySections([]);
-    };
-  }, [pathname, utils]);
-
-  useEffect(() => {
-    setReadySections((previous) => previous.filter((id) => board.sections.some((section) => section.id === id)));
-  }, [board.sections.length, setReadySections]);
-
-  const markAsReady = useCallback((id: string) => {
-    setReadySections((previous) => (previous.includes(id) ? previous : [...previous, id]));
-  }, []);
+  const markAsReady = useCallback((_id: string) => {}, []);
 
   return (
     <BoardReadyContext.Provider

--- a/apps/nextjs/src/app/[locale]/boards/(content)/_ready-context.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_ready-context.tsx
@@ -8,6 +8,7 @@ const BoardReadyContext = createContext<{
 } | null>(null);
 
 export const BoardReadyProvider = ({ children }: PropsWithChildren) => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   const markAsReady = useCallback((_id: string) => {}, []);
 
   return (

--- a/apps/nextjs/src/app/[locale]/boards/(content)/_ready-context.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_ready-context.tsx
@@ -8,7 +8,6 @@ import { clientApi } from "@homarr/api/client";
 import { useRequiredBoard } from "@homarr/boards/context";
 
 const BoardReadyContext = createContext<{
-  isReady: boolean;
   markAsReady: (id: string) => void;
 } | null>(null);
 
@@ -18,7 +17,6 @@ export const BoardReadyProvider = ({ children }: PropsWithChildren) => {
   const board = useRequiredBoard();
   const [readySections, setReadySections] = useState<string[]>([]);
 
-  // Reset sections required for ready state
   useEffect(() => {
     return () => {
       setReadySections([]);
@@ -36,7 +34,6 @@ export const BoardReadyProvider = ({ children }: PropsWithChildren) => {
   return (
     <BoardReadyContext.Provider
       value={{
-        isReady: board.sections.length === readySections.length,
         markAsReady,
       }}
     >
@@ -53,14 +50,4 @@ export const useMarkSectionAsReady = () => {
   }
 
   return context.markAsReady;
-};
-
-export const useIsBoardReady = () => {
-  const context = useContext(BoardReadyContext);
-
-  if (!context) {
-    throw new Error("BoardReadyProvider is required");
-  }
-
-  return context.isReady;
 };


### PR DESCRIPTION
## Summary
- Remove the `LoadingOverlay` and hidden-until-ready visibility gating from the board client — the board now paints as soon as the server-rendered content arrives
- Remove dead duplicate `updateBoardName` / `useUpdateBoard` exports from `_client.tsx` (already live in `@homarr/boards/updater`)
- Remove unused `isReady` / `useIsBoardReady` from the ready context (only consumer was the overlay)

## Test plan
- [ ] Open a board with multiple sections — should render immediately without a spinner
- [ ] Edit mode still works (section actions still call `markAsReady`)
- [ ] No layout shift or flash of empty content on slow connections