### PR TITLE
fix: exclude .env files from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,6 @@ README.md
 dev
 .build
 e2e
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
## Summary
- Add `.env` and `.env.*` to `.dockerignore` (keep `.env.example`)
- Prevents local secrets from being copied into Docker images

## Test plan
- [ ] `docker build` still succeeds
- [ ] `.env` files are not present in the built image