### PR TITLE
feat(manage): unified management page layout

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/apps/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/apps/page.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
 import { redirect } from "next/navigation";
-import { ActionIcon, ActionIconGroup, Anchor, Avatar, Card, Group, Stack, Text, Title } from "@mantine/core";
+import { ActionIcon, ActionIconGroup, Anchor, Avatar, Card, Group, Stack, Text } from "@mantine/core";
 import { IconBox, IconPencil } from "@tabler/icons-react";
 import { z } from "zod/v4";
 
@@ -11,9 +11,8 @@ import type { inferSearchParamsFromSchema } from "@homarr/common/types";
 import { getI18n, getScopedI18n } from "@homarr/translation/server";
 import { Link, SearchInput, TablePagination } from "@homarr/ui";
 
-import { ManageContainer } from "~/components/manage/manage-container";
+import { ManagePageLayout } from "~/components/manage/manage-page-layout";
 import { MobileAffixButton } from "~/components/manage/mobile-affix-button";
-import { DynamicBreadcrumb } from "~/components/navigation/dynamic-breadcrumb";
 import { NoResults } from "~/components/no-results";
 import { AppDeleteButton } from "./_app-delete-button";
 
@@ -39,34 +38,31 @@ export default async function AppsPage(props: AppsPageProps) {
   const { items: apps, totalCount } = await api.app.getPaginated(searchParams);
   const t = await getScopedI18n("app");
 
-  return (
-    <ManageContainer>
-      <DynamicBreadcrumb />
-      <Stack>
-        <Title>{t("page.list.title")}</Title>
-        <Group justify="space-between" align="center">
-          <SearchInput placeholder={`${t("search")}...`} defaultValue={searchParams.search} flexExpand />
-          {session.user.permissions.includes("app-create") && (
-            <MobileAffixButton component={Link} href="/manage/apps/new">
-              {t("page.create.title")}
-            </MobileAffixButton>
-          )}
-        </Group>
-        {apps.length === 0 && <AppNoResults />}
-        {apps.length > 0 && (
-          <Stack gap="sm">
-            {apps.map((app) => (
-              <AppCard key={app.id} app={app} />
-            ))}
-          </Stack>
-        )}
+  const canCreate = session.user.permissions.includes("app-create");
 
-        {/* Added margin to not hide pagination behind affix-button */}
-        <Group justify="end" mb={48}>
-          <TablePagination total={Math.ceil(totalCount / searchParams.pageSize)} />
-        </Group>
-      </Stack>
-    </ManageContainer>
+  return (
+    <ManagePageLayout
+      title={t("page.list.title")}
+      primaryAction={
+        canCreate ? (
+          <MobileAffixButton component={Link} href="/manage/apps/new">
+            {t("page.create.title")}
+          </MobileAffixButton>
+        ) : undefined
+      }
+      toolbar={<SearchInput placeholder={`${t("search")}...`} defaultValue={searchParams.search} flexExpand />}
+      footer={<TablePagination total={Math.ceil(totalCount / searchParams.pageSize)} />}
+      floatingPrimaryAction={canCreate}
+    >
+      {apps.length === 0 && <AppNoResults />}
+      {apps.length > 0 && (
+        <Stack gap="sm">
+          {apps.map((app) => (
+            <AppCard key={app.id} app={app} />
+          ))}
+        </Stack>
+      )}
+    </ManagePageLayout>
   );
 }
 

--- a/apps/nextjs/src/app/[locale]/manage/boards/_components/create-board-button.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/boards/_components/create-board-button.tsx
@@ -1,43 +1,38 @@
 "use client";
 
-import { Affix, Button, Menu } from "@mantine/core";
+import { Button, Menu } from "@mantine/core";
 import { IconCategoryPlus, IconChevronDown, IconFileImport } from "@tabler/icons-react";
 
 import { useModalAction } from "@homarr/modals";
 import { AddBoardModal, ImportBoardModal } from "@homarr/modals-collection";
 import { useI18n } from "@homarr/translation/client";
 
+import { ManageMobilePrimaryAction } from "~/components/manage/manage-mobile-primary-action";
+
 export const CreateBoardButton = () => {
   const t = useI18n();
   const { openModal: openAddModal } = useModalAction(AddBoardModal);
   const { openModal: openImportModal } = useModalAction(ImportBoardModal);
 
-  const buttonGroupContent = (
-    <>
-      <Button leftSection={<IconCategoryPlus size="1rem" />} onClick={openAddModal}>
-        {t("management.page.board.action.new.label")}
-      </Button>
-      <Menu position="bottom-end">
-        <Menu.Target>
-          <Button px="xs" ms={1}>
-            <IconChevronDown size="1rem" />
-          </Button>
-        </Menu.Target>
-        <Menu.Dropdown>
-          <Menu.Item onClick={openImportModal} leftSection={<IconFileImport size="1rem" />}>
-            {t("board.action.oldImport.label")}
-          </Menu.Item>
-        </Menu.Dropdown>
-      </Menu>
-    </>
-  );
-
   return (
-    <>
-      <Button.Group visibleFrom="md">{buttonGroupContent}</Button.Group>
-      <Affix hiddenFrom="md" position={{ bottom: 20, right: 20 }}>
-        <Button.Group>{buttonGroupContent}</Button.Group>
-      </Affix>
-    </>
+    <ManageMobilePrimaryAction>
+      <Button.Group>
+        <Button leftSection={<IconCategoryPlus size="1rem" />} onClick={openAddModal}>
+          {t("management.page.board.action.new.label")}
+        </Button>
+        <Menu position="bottom-end">
+          <Menu.Target>
+            <Button px="xs" ms={1}>
+              <IconChevronDown size="1rem" />
+            </Button>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item onClick={openImportModal} leftSection={<IconFileImport size="1rem" />}>
+              {t("board.action.oldImport.label")}
+            </Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </Button.Group>
+    </ManageMobilePrimaryAction>
   );
 };

--- a/apps/nextjs/src/app/[locale]/manage/boards/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/boards/page.tsx
@@ -9,12 +9,17 @@ import {
   Group,
   Menu,
   MenuTarget,
-  Stack,
   Text,
-  Title,
   Tooltip,
 } from "@mantine/core";
-import { IconDeviceMobile, IconDotsVertical, IconHomeFilled, IconLock, IconWorld } from "@tabler/icons-react";
+import {
+  IconDeviceMobile,
+  IconDotsVertical,
+  IconHomeFilled,
+  IconLayoutDashboard,
+  IconLock,
+  IconWorld,
+} from "@tabler/icons-react";
 
 import type { RouterOutputs } from "@homarr/api";
 import { api } from "@homarr/api/server";
@@ -23,8 +28,8 @@ import { getScopedI18n } from "@homarr/translation/server";
 import { Link, UserAvatar } from "@homarr/ui";
 
 import { getBoardPermissionsAsync } from "~/components/board/permissions/server";
-import { ManageContainer } from "~/components/manage/manage-container";
-import { DynamicBreadcrumb } from "~/components/navigation/dynamic-breadcrumb";
+import { ManagePageLayout } from "~/components/manage/manage-page-layout";
+import { NoResults } from "~/components/no-results";
 import { BoardCardMenuDropdown } from "./_components/board-card-menu-dropdown";
 import { CreateBoardButton } from "./_components/create-board-button";
 
@@ -35,23 +40,22 @@ export default async function ManageBoardsPage() {
   const canCreateBoards = session?.user.permissions.includes("board-create");
 
   return (
-    <ManageContainer>
-      <DynamicBreadcrumb />
-      <Stack>
-        <Group justify="space-between">
-          <Title mb="md">{t("title")}</Title>
-          {canCreateBoards && <CreateBoardButton />}
-        </Group>
-
-        <Grid mb={{ base: "xl", md: 0 }}>
+    <ManagePageLayout
+      title={t("title")}
+      primaryAction={canCreateBoards ? <CreateBoardButton /> : undefined}
+      floatingPrimaryAction={canCreateBoards}
+    >
+      {boards.length === 0 && <NoResults icon={IconLayoutDashboard} title={t("noResults.title")} />}
+      {boards.length > 0 && (
+        <Grid>
           {boards.map((board) => (
             <GridCol span={{ base: 12, md: 6 }} key={board.id}>
               <BoardCard board={board} />
             </GridCol>
           ))}
         </Grid>
-      </Stack>
-    </ManageContainer>
+      )}
+    </ManagePageLayout>
   );
 }
 

--- a/apps/nextjs/src/app/[locale]/manage/integrations/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/integrations/page.tsx
@@ -7,9 +7,7 @@ import {
   AccordionPanel,
   ActionIcon,
   ActionIconGroup,
-  Affix,
   Anchor,
-  Box,
   Button,
   Divider,
   Group,
@@ -24,9 +22,8 @@ import {
   TableThead,
   TableTr,
   Text,
-  Title,
 } from "@mantine/core";
-import { IconChevronDown, IconChevronUp, IconPencil, IconPlugX } from "@tabler/icons-react";
+import { IconChevronDown, IconPencil, IconPlugX } from "@tabler/icons-react";
 
 import type { RouterOutputs } from "@homarr/api";
 import { api } from "@homarr/api/server";
@@ -37,8 +34,8 @@ import { getIntegrationName } from "@homarr/definitions";
 import { getScopedI18n } from "@homarr/translation/server";
 import { CountBadge, IntegrationAvatar, Link } from "@homarr/ui";
 
-import { ManageContainer } from "~/components/manage/manage-container";
-import { DynamicBreadcrumb } from "~/components/navigation/dynamic-breadcrumb";
+import { ManageMobilePrimaryAction } from "~/components/manage/manage-mobile-primary-action";
+import { ManagePageLayout } from "~/components/manage/manage-page-layout";
 import { NoResults } from "~/components/no-results";
 import { env } from "~/env";
 import { ActiveTabAccordion } from "../../../../components/active-tab-accordion";
@@ -66,38 +63,23 @@ export default async function IntegrationsPage(props: IntegrationsPageProps) {
   const canCreateIntegrations = session.user.permissions.includes("integration-create");
 
   return (
-    <ManageContainer>
-      <DynamicBreadcrumb />
-      <Stack>
-        <Group justify="space-between" align="center">
-          <Title>{t("page.list.title")}</Title>
-
-          {canCreateIntegrations && (
-            <>
-              <Box>
-                <IntegrationSelectMenu>
-                  <Affix hiddenFrom="md" position={{ bottom: 20, right: 20 }}>
-                    <MenuTarget>
-                      <Button rightSection={<IconChevronUp size={16} stroke={1.5} />}>{t("action.create")}</Button>
-                    </MenuTarget>
-                  </Affix>
-                </IntegrationSelectMenu>
-              </Box>
-
-              <Box visibleFrom="md">
-                <IntegrationSelectMenu>
-                  <MenuTarget>
-                    <Button rightSection={<IconChevronDown size={16} stroke={1.5} />}>{t("action.create")}</Button>
-                  </MenuTarget>
-                </IntegrationSelectMenu>
-              </Box>
-            </>
-          )}
-        </Group>
-
-        <IntegrationList integrations={integrations} activeTab={searchParams.tab} />
-      </Stack>
-    </ManageContainer>
+    <ManagePageLayout
+      title={t("page.list.title")}
+      primaryAction={
+        canCreateIntegrations ? (
+          <ManageMobilePrimaryAction>
+            <IntegrationSelectMenu>
+              <MenuTarget>
+                <Button rightSection={<IconChevronDown size={16} stroke={1.5} />}>{t("action.create")}</Button>
+              </MenuTarget>
+            </IntegrationSelectMenu>
+          </ManageMobilePrimaryAction>
+        ) : undefined
+      }
+      floatingPrimaryAction={canCreateIntegrations}
+    >
+      <IntegrationList integrations={integrations} activeTab={searchParams.tab} />
+    </ManagePageLayout>
   );
 }
 

--- a/apps/nextjs/src/app/[locale]/manage/medias/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/medias/page.tsx
@@ -4,17 +4,15 @@ import {
   Anchor,
   Group,
   Image,
-  Stack,
   Table,
   TableTbody,
   TableTd,
   TableTh,
   TableThead,
   TableTr,
-  Title,
   Tooltip,
 } from "@mantine/core";
-import { IconExternalLink } from "@tabler/icons-react";
+import { IconExternalLink, IconPhoto } from "@tabler/icons-react";
 import { z } from "zod/v4";
 
 import type { RouterOutputs } from "@homarr/api";
@@ -26,8 +24,9 @@ import { createLocalImageUrl } from "@homarr/icons/local";
 import { getI18n } from "@homarr/translation/server";
 import { Link, SearchInput, TablePagination, UserAvatar } from "@homarr/ui";
 
-import { ManageContainer } from "~/components/manage/manage-container";
-import { DynamicBreadcrumb } from "~/components/navigation/dynamic-breadcrumb";
+import { ManageMobilePrimaryAction } from "~/components/manage/manage-mobile-primary-action";
+import { ManagePageLayout } from "~/components/manage/manage-page-layout";
+import { NoResults } from "~/components/no-results";
 import { CopyMedia } from "./_actions/copy-media";
 import { DeleteMedia } from "./_actions/delete-media";
 import { IncludeFromAllUsersSwitch } from "./_actions/show-all";
@@ -48,7 +47,7 @@ interface MediaListPageProps {
   searchParams: Promise<inferSearchParamsFromSchema<typeof searchParamsSchema>>;
 }
 
-export default async function GroupsListPage(props: MediaListPageProps) {
+export default async function MediaListPage(props: MediaListPageProps) {
   const session = await auth();
 
   if (!session) {
@@ -58,22 +57,31 @@ export default async function GroupsListPage(props: MediaListPageProps) {
   const t = await getI18n();
   const searchParams = searchParamsSchema.parse(await props.searchParams);
   const { items: medias, totalCount } = await api.media.getPaginated(searchParams);
+  const canUpload = session.user.permissions.includes("media-upload");
 
   return (
-    <ManageContainer>
-      <DynamicBreadcrumb />
-      <Stack>
-        <Title>{t("media.plural")}</Title>
-        <Group justify="space-between">
-          <Group>
-            <SearchInput placeholder={`${t("media.search")}...`} defaultValue={searchParams.search} />
-            {session.user.permissions.includes("media-view-all") && (
-              <IncludeFromAllUsersSwitch defaultChecked={searchParams.includeFromAllUsers} />
-            )}
-          </Group>
-
-          {session.user.permissions.includes("media-upload") && <UploadMediaButton />}
+    <ManagePageLayout
+      title={t("media.plural")}
+      primaryAction={
+        canUpload ? (
+          <ManageMobilePrimaryAction>
+            <UploadMediaButton />
+          </ManageMobilePrimaryAction>
+        ) : undefined
+      }
+      toolbar={
+        <Group>
+          <SearchInput placeholder={`${t("media.search")}...`} defaultValue={searchParams.search} />
+          {session.user.permissions.includes("media-view-all") && (
+            <IncludeFromAllUsersSwitch defaultChecked={searchParams.includeFromAllUsers} />
+          )}
         </Group>
+      }
+      footer={<TablePagination total={Math.ceil(totalCount / searchParams.pageSize)} />}
+      floatingPrimaryAction={canUpload}
+    >
+      {medias.length === 0 && <NoResults icon={IconPhoto} title={t("media.noResults.title")} />}
+      {medias.length > 0 && (
         <Table striped highlightOnHover>
           <TableThead>
             <TableTr>
@@ -90,13 +98,8 @@ export default async function GroupsListPage(props: MediaListPageProps) {
             ))}
           </TableTbody>
         </Table>
-
-        {/* Added margin to not hide pagination behind affix-button */}
-        <Group justify="end" mb={48}>
-          <TablePagination total={Math.ceil(totalCount / searchParams.pageSize)} />
-        </Group>
-      </Stack>
-    </ManageContainer>
+      )}
+    </ManagePageLayout>
   );
 }
 

--- a/apps/nextjs/src/app/[locale]/manage/search-engines/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/search-engines/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { ActionIcon, ActionIconGroup, Anchor, Avatar, Card, Group, Stack, Text, Title } from "@mantine/core";
+import { ActionIcon, ActionIconGroup, Anchor, Avatar, Card, Group, Stack, Text } from "@mantine/core";
 import { IconPencil, IconSearch } from "@tabler/icons-react";
 import { z } from "zod/v4";
 
@@ -10,9 +10,8 @@ import type { inferSearchParamsFromSchema } from "@homarr/common/types";
 import { getI18n, getScopedI18n } from "@homarr/translation/server";
 import { Link, SearchInput, TablePagination } from "@homarr/ui";
 
-import { ManageContainer } from "~/components/manage/manage-container";
+import { ManagePageLayout } from "~/components/manage/manage-page-layout";
 import { MobileAffixButton } from "~/components/manage/mobile-affix-button";
-import { DynamicBreadcrumb } from "~/components/navigation/dynamic-breadcrumb";
 import { NoResults } from "~/components/no-results";
 import { SearchEngineDeleteButton } from "./_search-engine-delete-button";
 
@@ -38,34 +37,31 @@ export default async function SearchEnginesPage(props: SearchEnginesPageProps) {
 
   const tEngine = await getScopedI18n("search.engine");
 
-  return (
-    <ManageContainer>
-      <DynamicBreadcrumb />
-      <Stack>
-        <Title>{tEngine("page.list.title")}</Title>
-        <Group justify="space-between" align="center">
-          <SearchInput placeholder={`${tEngine("search")}...`} defaultValue={searchParams.search} flexExpand />
-          {session.user.permissions.includes("search-engine-create") && (
-            <MobileAffixButton component={Link} href="/manage/search-engines/new">
-              {tEngine("page.create.title")}
-            </MobileAffixButton>
-          )}
-        </Group>
-        {searchEngines.length === 0 && <SearchEngineNoResults />}
-        {searchEngines.length > 0 && (
-          <Stack gap="sm">
-            {searchEngines.map((searchEngine) => (
-              <SearchEngineCard key={searchEngine.id} searchEngine={searchEngine} />
-            ))}
-          </Stack>
-        )}
+  const canCreate = session.user.permissions.includes("search-engine-create");
 
-        {/* Added margin to not hide pagination behind affix-button */}
-        <Group justify="end" mb={48}>
-          <TablePagination total={Math.ceil(totalCount / searchParams.pageSize)} />
-        </Group>
-      </Stack>
-    </ManageContainer>
+  return (
+    <ManagePageLayout
+      title={tEngine("page.list.title")}
+      primaryAction={
+        canCreate ? (
+          <MobileAffixButton component={Link} href="/manage/search-engines/new">
+            {tEngine("page.create.title")}
+          </MobileAffixButton>
+        ) : undefined
+      }
+      toolbar={<SearchInput placeholder={`${tEngine("search")}...`} defaultValue={searchParams.search} flexExpand />}
+      footer={<TablePagination total={Math.ceil(totalCount / searchParams.pageSize)} />}
+      floatingPrimaryAction={canCreate}
+    >
+      {searchEngines.length === 0 && <SearchEngineNoResults />}
+      {searchEngines.length > 0 && (
+        <Stack gap="sm">
+          {searchEngines.map((searchEngine) => (
+            <SearchEngineCard key={searchEngine.id} searchEngine={searchEngine} />
+          ))}
+        </Stack>
+      )}
+    </ManagePageLayout>
   );
 }
 

--- a/apps/nextjs/src/app/[locale]/manage/users/_components/user-list.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/_components/user-list.tsx
@@ -1,24 +1,22 @@
 "use client";
 
 import { useMemo } from "react";
-import { Anchor, Button, Group, Text, Title, Tooltip } from "@mantine/core";
+import { Anchor, Group, Text, Tooltip } from "@mantine/core";
 import { IconCheck } from "@tabler/icons-react";
 import type { MRT_ColumnDef } from "mantine-react-table";
 import { MantineReactTable } from "mantine-react-table";
 
 import type { RouterOutputs } from "@homarr/api";
 import { clientApi } from "@homarr/api/client";
-import { useI18n, useScopedI18n } from "@homarr/translation/client";
+import { useI18n } from "@homarr/translation/client";
 import { Link, UserAvatar } from "@homarr/ui";
 import { useTranslatedMantineReactTable } from "@homarr/ui/hooks";
 
 interface UserListComponentProps {
   initialUserList: RouterOutputs["user"]["getAll"];
-  credentialsProviderEnabled: boolean;
 }
 
-export const UserListComponent = ({ initialUserList, credentialsProviderEnabled }: UserListComponentProps) => {
-  const tUserList = useScopedI18n("management.page.user.list");
+export const UserListComponent = ({ initialUserList }: UserListComponentProps) => {
   const t = useI18n();
   const { data, isLoading } = clientApi.user.getAll.useQuery(undefined, {
     initialData: initialUserList,
@@ -69,21 +67,10 @@ export const UserListComponent = ({ initialUserList, credentialsProviderEnabled 
     enableFullScreenToggle: false,
     layoutMode: "grid-no-grow",
     getRowId: (row) => row.id,
-    renderTopToolbarCustomActions: () =>
-      credentialsProviderEnabled ? (
-        <Button component={Link} href="/manage/users/create">
-          {t("management.page.user.create.title")}
-        </Button>
-      ) : null,
     state: {
       isLoading,
     },
   });
 
-  return (
-    <>
-      <Title mb="md">{tUserList("title")}</Title>
-      <MantineReactTable table={table} />
-    </>
-  );
+  return <MantineReactTable table={table} />;
 };

--- a/apps/nextjs/src/app/[locale]/manage/users/groups/_client.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/groups/_client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
-import { Group, TextInput } from "@mantine/core";
+import { useMemo, useState } from "react";
+import { TextInput } from "@mantine/core";
 import { IconSearch } from "@tabler/icons-react";
 
 import type { RouterOutputs } from "@homarr/api";
@@ -33,29 +33,20 @@ export const GroupsList = ({ groups }: GroupsListProps) => {
 
   return (
     <>
-      <Group justify="space-between">
-        <TextInput
-          leftSection={<IconSearch size={20} stroke={1.5} />}
-          value={search}
-          onChange={(event) => setSearch(event.currentTarget.value)}
-          placeholder={`${t("group.search")}...`}
-          style={{ flex: 1 }}
-        />
-        <AddGroup />
-      </Group>
-
+      <TextInput
+        leftSection={<IconSearch size={20} stroke={1.5} />}
+        value={search}
+        onChange={(event) => setSearch(event.currentTarget.value)}
+        placeholder={`${t("group.search")}...`}
+      />
       <GroupsTable groups={filteredGroups} initialGroupIds={initialGroupIds} hasFilter={search.length !== 0} />
     </>
   );
 };
 
-const AddGroup = () => {
+export const AddGroupButton = () => {
   const t = useI18n();
   const { openModal } = useModalAction(AddGroupModal);
 
-  const handleAddGroup = useCallback(() => {
-    openModal();
-  }, [openModal]);
-
-  return <MobileAffixButton onClick={handleAddGroup}>{t("group.action.create.label")}</MobileAffixButton>;
+  return <MobileAffixButton onClick={() => openModal()}>{t("group.action.create.label")}</MobileAffixButton>;
 };

--- a/apps/nextjs/src/app/[locale]/manage/users/groups/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/groups/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { Card, Group, Stack, Text, ThemeIcon, Title, UnstyledButton } from "@mantine/core";
+import { Card, Group, Stack, Text, ThemeIcon, UnstyledButton } from "@mantine/core";
 import { IconChevronRight, IconUsersGroup } from "@tabler/icons-react";
 
 import { api } from "@homarr/api/server";
@@ -8,9 +8,8 @@ import { everyoneGroup } from "@homarr/definitions";
 import { getI18n } from "@homarr/translation/server";
 import { Link } from "@homarr/ui";
 
-import { ManageContainer } from "~/components/manage/manage-container";
-import { DynamicBreadcrumb } from "~/components/navigation/dynamic-breadcrumb";
-import { GroupsList } from "./_client";
+import { ManagePageLayout } from "~/components/manage/manage-page-layout";
+import { AddGroupButton, GroupsList } from "./_client";
 import classes from "./groups.module.css";
 
 export default async function GroupsListPage() {
@@ -26,11 +25,8 @@ export default async function GroupsListPage() {
   const groupsWithoutEveryone = groups.filter((group) => group.name !== everyoneGroup);
 
   return (
-    <ManageContainer size="xl">
-      <DynamicBreadcrumb />
+    <ManagePageLayout title={t("group.title")} primaryAction={<AddGroupButton />} floatingPrimaryAction>
       <Stack>
-        <Title>{t("group.title")}</Title>
-
         {dbEveryoneGroup && (
           <UnstyledButton component={Link} href={`/manage/users/groups/${dbEveryoneGroup.id}`}>
             <Card className={classes.everyoneGroup}>
@@ -53,6 +49,6 @@ export default async function GroupsListPage() {
 
         <GroupsList groups={groupsWithoutEveryone} />
       </Stack>
-    </ManageContainer>
+    </ManagePageLayout>
   );
 }

--- a/apps/nextjs/src/app/[locale]/manage/users/invites/_components/invite-create-button.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/invites/_components/invite-create-button.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Button } from "@mantine/core";
+
+import { useModalAction } from "@homarr/modals";
+import { InviteCreateModal } from "@homarr/modals-collection";
+import { useScopedI18n } from "@homarr/translation/client";
+
+import { MANAGE_ACTION_BUTTON_MIN_WIDTH } from "~/components/manage/manage-page.constants";
+
+export const InviteCreateButton = () => {
+  const t = useScopedI18n("management.page.user.invite");
+  const { openModal } = useModalAction(InviteCreateModal);
+
+  return (
+    <Button miw={MANAGE_ACTION_BUTTON_MIN_WIDTH} onClick={() => openModal()}>
+      {t("action.new.title")}
+    </Button>
+  );
+};

--- a/apps/nextjs/src/app/[locale]/manage/users/invites/_components/invite-list.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/invites/_components/invite-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
-import { ActionIcon, Button, Title } from "@mantine/core";
+import { ActionIcon } from "@mantine/core";
 import { IconTrash } from "@tabler/icons-react";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
@@ -10,8 +10,7 @@ import { MantineReactTable } from "mantine-react-table";
 
 import type { RouterOutputs } from "@homarr/api";
 import { clientApi } from "@homarr/api/client";
-import { useConfirmModal, useModalAction } from "@homarr/modals";
-import { InviteCreateModal } from "@homarr/modals-collection";
+import { useConfirmModal } from "@homarr/modals";
 import { useScopedI18n } from "@homarr/translation/client";
 import { useTranslatedMantineReactTable } from "@homarr/ui/hooks";
 
@@ -65,7 +64,6 @@ export const InviteListComponent = ({ initialInvites }: InviteListComponentProps
     enableFullScreenToggle: false,
     layoutMode: "grid-no-grow",
     getRowId: (row) => row.id,
-    renderTopToolbarCustomActions: RenderTopToolbarCustomActions,
     state: {
       isLoading,
     },
@@ -74,22 +72,7 @@ export const InviteListComponent = ({ initialInvites }: InviteListComponentProps
     },
   });
 
-  return (
-    <>
-      <Title mb="md">{t("title")}</Title>
-      <MantineReactTable table={table} />
-    </>
-  );
-};
-
-const RenderTopToolbarCustomActions = () => {
-  const t = useScopedI18n("management.page.user.invite");
-  const { openModal } = useModalAction(InviteCreateModal);
-  const handleNewInvite = useCallback(() => {
-    openModal();
-  }, [openModal]);
-
-  return <Button onClick={handleNewInvite}>{t("action.new.title")}</Button>;
+  return <MantineReactTable table={table} />;
 };
 
 const RenderRowActions = ({ row }: { row: MRT_Row<RouterOutputs["invite"]["getAll"][number]> }) => {

--- a/apps/nextjs/src/app/[locale]/manage/users/invites/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/invites/page.tsx
@@ -3,8 +3,11 @@ import { notFound } from "next/navigation";
 import { api } from "@homarr/api/server";
 import { auth } from "@homarr/auth/next";
 import { isProviderEnabled } from "@homarr/auth/server";
+import { getScopedI18n } from "@homarr/translation/server";
 
-import { DynamicBreadcrumb } from "~/components/navigation/dynamic-breadcrumb";
+import { ManageMobilePrimaryAction } from "~/components/manage/manage-mobile-primary-action";
+import { ManagePageLayout } from "~/components/manage/manage-page-layout";
+import { InviteCreateButton } from "./_components/invite-create-button";
 import { InviteListComponent } from "./_components/invite-list";
 
 export default async function InvitesOverviewPage() {
@@ -17,11 +20,20 @@ export default async function InvitesOverviewPage() {
     return notFound();
   }
 
+  const t = await getScopedI18n("management.page.user.invite");
   const initialInvites = await api.invite.getAll();
+
   return (
-    <>
-      <DynamicBreadcrumb />
+    <ManagePageLayout
+      title={t("title")}
+      primaryAction={
+        <ManageMobilePrimaryAction>
+          <InviteCreateButton />
+        </ManageMobilePrimaryAction>
+      }
+      floatingPrimaryAction
+    >
       <InviteListComponent initialInvites={initialInvites} />
-    </>
+    </ManagePageLayout>
   );
 }

--- a/apps/nextjs/src/app/[locale]/manage/users/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/page.tsx
@@ -4,8 +4,10 @@ import { api } from "@homarr/api/server";
 import { auth } from "@homarr/auth/next";
 import { isProviderEnabled } from "@homarr/auth/server";
 import { getScopedI18n } from "@homarr/translation/server";
+import { Link } from "@homarr/ui";
 
-import { DynamicBreadcrumb } from "~/components/navigation/dynamic-breadcrumb";
+import { ManagePageLayout } from "~/components/manage/manage-page-layout";
+import { MobileAffixButton } from "~/components/manage/mobile-affix-button";
 import { createMetaTitle } from "~/metadata";
 import { UserListComponent } from "./_components/user-list";
 
@@ -27,13 +29,23 @@ export default async function UsersPage() {
     return notFound();
   }
 
+  const t = await getScopedI18n("management.page.user");
   const userList = await api.user.getAll();
   const credentialsProviderEnabled = isProviderEnabled("credentials");
 
   return (
-    <>
-      <DynamicBreadcrumb />
-      <UserListComponent initialUserList={userList} credentialsProviderEnabled={credentialsProviderEnabled} />
-    </>
+    <ManagePageLayout
+      title={t("list.title")}
+      primaryAction={
+        credentialsProviderEnabled ? (
+          <MobileAffixButton component={Link} href="/manage/users/create">
+            {t("create.title")}
+          </MobileAffixButton>
+        ) : undefined
+      }
+      floatingPrimaryAction={credentialsProviderEnabled}
+    >
+      <UserListComponent initialUserList={userList} />
+    </ManagePageLayout>
   );
 }

--- a/apps/nextjs/src/components/manage/manage-mobile-primary-action.tsx
+++ b/apps/nextjs/src/components/manage/manage-mobile-primary-action.tsx
@@ -1,0 +1,15 @@
+import type { PropsWithChildren } from "react";
+import { Affix, Box } from "@mantine/core";
+
+import { MANAGE_ACTION_BUTTON_MIN_WIDTH, MANAGE_AFFIX_POSITION } from "./manage-page.constants";
+
+export const ManageMobilePrimaryAction = ({ children }: PropsWithChildren) => (
+  <>
+    <Box visibleFrom="md" miw={MANAGE_ACTION_BUTTON_MIN_WIDTH}>
+      {children}
+    </Box>
+    <Affix hiddenFrom="md" position={MANAGE_AFFIX_POSITION}>
+      {children}
+    </Affix>
+  </>
+);

--- a/apps/nextjs/src/components/manage/manage-page-layout.tsx
+++ b/apps/nextjs/src/components/manage/manage-page-layout.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+import type { MantineSize } from "@mantine/core";
+import { Group, Stack, Title } from "@mantine/core";
+
+import { DynamicBreadcrumb } from "~/components/navigation/dynamic-breadcrumb";
+import { ManageContainer } from "./manage-container";
+import { MANAGE_FLOATING_ACTION_BOTTOM_OFFSET } from "./manage-page.constants";
+
+interface ManagePageLayoutProps {
+  title: ReactNode;
+  primaryAction?: ReactNode;
+  toolbar?: ReactNode;
+  footer?: ReactNode;
+  floatingPrimaryAction?: boolean;
+  size?: MantineSize;
+  children: ReactNode;
+}
+
+export const ManagePageLayout = ({
+  title,
+  primaryAction,
+  toolbar,
+  footer,
+  floatingPrimaryAction,
+  size,
+  children,
+}: ManagePageLayoutProps) => {
+  const titleNode = typeof title === "string" ? <Title>{title}</Title> : title;
+
+  return (
+    <ManageContainer size={size}>
+      <DynamicBreadcrumb />
+      <Stack pb={floatingPrimaryAction ? { base: MANAGE_FLOATING_ACTION_BOTTOM_OFFSET, md: 0 } : undefined}>
+        <Group justify="space-between" align="center">
+          {titleNode}
+          {primaryAction}
+        </Group>
+        {toolbar}
+        {children}
+        {footer && <Group justify="end">{footer}</Group>}
+      </Stack>
+    </ManageContainer>
+  );
+};

--- a/apps/nextjs/src/components/manage/manage-page.constants.ts
+++ b/apps/nextjs/src/components/manage/manage-page.constants.ts
@@ -1,0 +1,5 @@
+export const MANAGE_AFFIX_POSITION = { bottom: 20, right: 20 } as const;
+
+export const MANAGE_FLOATING_ACTION_BOTTOM_OFFSET = 48;
+
+export const MANAGE_ACTION_BUTTON_MIN_WIDTH = 160;

--- a/apps/nextjs/src/components/manage/mobile-affix-button.tsx
+++ b/apps/nextjs/src/components/manage/mobile-affix-button.tsx
@@ -2,13 +2,15 @@ import { forwardRef } from "react";
 import type { ButtonProps } from "@mantine/core";
 import { Affix, Button, createPolymorphicComponent } from "@mantine/core";
 
+import { MANAGE_ACTION_BUTTON_MIN_WIDTH, MANAGE_AFFIX_POSITION } from "./manage-page.constants";
+
 type MobileAffixButtonProps = Omit<ButtonProps, "visibleFrom" | "hiddenFrom">;
 
 export const MobileAffixButton = createPolymorphicComponent<"button", MobileAffixButtonProps>(
   forwardRef<HTMLButtonElement, MobileAffixButtonProps>((props, ref) => (
     <>
-      <Button ref={ref} visibleFrom="md" {...props} />
-      <Affix hiddenFrom="md" position={{ bottom: 20, right: 20 }}>
+      <Button ref={ref} visibleFrom="md" miw={MANAGE_ACTION_BUTTON_MIN_WIDTH} {...props} />
+      <Affix hiddenFrom="md" position={MANAGE_AFFIX_POSITION}>
         <Button ref={ref} {...props} />
       </Affix>
     </>

--- a/apps/nextjs/src/components/no-results.tsx
+++ b/apps/nextjs/src/components/no-results.tsx
@@ -20,7 +20,7 @@ export const NoResults = ({ icon: Icon, title, action }: NoResultsProps) => {
         <Text fw={500} size="lg">
           {title}
         </Text>
-        {!action?.hidden && <Anchor href={action?.href}>{action?.label}</Anchor>}
+        {action && !action.hidden && <Anchor href={action.href}>{action.label}</Anchor>}
       </Stack>
     </Card>
   );

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -1054,6 +1054,9 @@
       "open": {
         "label": "Open media"
       }
+    },
+    "noResults": {
+      "title": "No media uploaded"
     }
   },
   "common": {
@@ -3451,6 +3454,9 @@
         "visibility": {
           "public": "This board is public",
           "private": "This board is private"
+        },
+        "noResults": {
+          "title": "No boards yet"
         },
         "modal": {
           "createBoard": {


### PR DESCRIPTION
## Summary

- Introduce `ManagePageLayout` component that provides a consistent structure (title row, primary action, toolbar, content, footer) across all management list pages
- Consolidate shared constants (`MANAGE_AFFIX_POSITION`, `MANAGE_FLOATING_ACTION_BOTTOM_OFFSET`, `MANAGE_ACTION_BUTTON_MIN_WIDTH`) eliminating duplicated magic values
- Migrate all 8 management pages (boards, apps, integrations, search-engines, media, users, invites, groups) to the unified layout
- Extract create/action buttons from inline table toolbars into page-level `primaryAction` slots
- Fix `NoResults` component bug where an empty `<Anchor>` rendered when `action` was undefined
- Add empty state displays for boards and media pages
- Enforce consistent action button min-width (160px) across all pages

## Screenshots 
<img width="4336" height="2670" alt="CleanShot 2026-05-20 at 13 58 25" src="https://github.com/user-attachments/assets/e3c59b87-0de2-4a6b-8722-dd1d5653b02d" />
<img width="4336" height="2670" alt="CleanShot 2026-05-20 at 13 58 23" src="https://github.com/user-attachments/assets/2bf98a93-6149-4202-b4d0-e93c2ccef287" />
<img width="4336" height="2670" alt="CleanShot 2026-05-20 at 13 58 21" src="https://github.com/user-attachments/assets/6115cf9c-7ff5-4a83-a465-f105bdde2a2b" />
<img width="4336" height="2670" alt="CleanShot 2026-05-20 at 13 58 17" src="https://github.com/user-attachments/assets/c3b8a3f2-fffe-446d-8fda-a7a75b557e43" />
<img width="4336" height="2670" alt="CleanShot 2026-05-20 at 13 58 15" src="https://github.com/user-attachments/assets/36ccccbf-d3c1-4b4c-9d81-5fd23d9e5eab" />
<img width="4336" height="2670" alt="CleanShot 2026-05-20 at 13 58 13" src="https://github.com/user-attachments/assets/16620b7b-3ed5-4dcd-88f5-4f2c3e2cadd8" />
<img width="4336" height="2670" alt="CleanShot 2026-05-20 at 13 58 10" src="https://github.com/user-attachments/assets/7726199e-9098-49a8-a469-2c4c4ad431db" />
<img width="4336" height="2670" alt="CleanShot 2026-05-20 at 13 58 07" src="https://github.com/user-attachments/assets/d1511489-3631-4d0f-8e06-a66720b3f35a" />

## Pages affected

| Page | Changes |
|------|---------|
| Boards | Migrated to layout, added NoResults empty state |
| Apps | Migrated toolbar/footer/primaryAction to layout slots |
| Integrations | Migrated, wrapped dropdown menu in ManageMobilePrimaryAction |
| Search engines | Migrated toolbar/footer/primaryAction to layout slots |
| Media | Migrated, added NoResults empty state |
| Users | Extracted create button from MRT toolbar to page level |
| Invites | Extracted InviteCreateButton, stripped list to table-only |
| Groups | Migrated, extracted AddGroupButton to primaryAction slot |

## New shared components

- `ManagePageLayout` — reusable layout with title, primaryAction, toolbar, children, footer slots
- `ManageMobilePrimaryAction` — renders children inline on desktop, in bottom-right Affix on mobile
- `manage-page.constants.ts` — single source of truth for affix position, bottom offset, button min-width

## Test plan

- [ ] Verify all management pages render correctly on desktop and mobile viewports
- [ ] Verify primary action buttons have consistent width across pages
- [ ] Verify mobile affix buttons appear at bottom-right on small screens
- [ ] Verify empty states display when no items exist (boards, media, apps, search-engines, integrations)
- [ ] Verify groups page create button works via modal