### PR TITLE
fix: prevent GitHub releases check from blocking app on API failure

### DIFF
--- a/packages/cron-jobs/src/jobs/update-checker.ts
+++ b/packages/cron-jobs/src/jobs/update-checker.ts
@@ -1,13 +1,11 @@
-import { EVERY_HOUR } from "@homarr/cron-jobs-core/expressions";
+import { EVERY_DAY } from "@homarr/cron-jobs-core/expressions";
 import { updateCheckerRequestHandler } from "@homarr/request-handler/update-checker";
 
 import { createCronJob } from "../lib";
 
-export const updateCheckerJob = createCronJob("updateChecker", EVERY_HOUR, {
+export const updateCheckerJob = createCronJob("updateChecker", EVERY_DAY, {
   runOnStart: true,
 }).withCallback(async () => {
   const handler = updateCheckerRequestHandler.handler({});
-  await handler.getCachedOrUpdatedDataAsync({
-    forceUpdate: true,
-  });
+  await handler.getCachedOrUpdatedDataAsync({});
 });

--- a/packages/request-handler/src/lib/cached-request-handler.ts
+++ b/packages/request-handler/src/lib/cached-request-handler.ts
@@ -40,10 +40,16 @@ export const createCachedRequestHandler = <TData, TInput extends Record<string, 
               };
             } catch (error) {
               if (options.fallbackToStaleOnError && channelData) {
-                logger.warn(new ErrorWithMetadata("Cached request handler using stale cache after fetch failure", {
-                  channel: channel.name,
-                  queryKey: options.queryKey,
-                }, { cause: error }));
+                logger.warn(
+                  new ErrorWithMetadata(
+                    "Cached request handler using stale cache after fetch failure",
+                    {
+                      channel: channel.name,
+                      queryKey: options.queryKey,
+                    },
+                    { cause: error },
+                  ),
+                );
                 return channelData;
               }
 

--- a/packages/request-handler/src/lib/cached-request-handler.ts
+++ b/packages/request-handler/src/lib/cached-request-handler.ts
@@ -15,6 +15,7 @@ interface Options<TData, TInput extends Record<string, unknown>> {
     options: Options<TData, TInput>,
   ) => ReturnType<typeof createChannelWithLatestAndEvents<TData>>;
   cacheDuration: Duration;
+  fallbackToStaleOnError?: boolean;
 }
 
 export const createCachedRequestHandler = <TData, TInput extends Record<string, unknown>>(
@@ -26,13 +27,39 @@ export const createCachedRequestHandler = <TData, TInput extends Record<string, 
 
       return {
         async getCachedOrUpdatedDataAsync({ forceUpdate = false }) {
+          const channelData = await channel.getAsync();
+
           const requestNewDataAsync = async () => {
-            const data = await options.requestAsync(input);
-            await channel.publishAndUpdateLastStateAsync(data);
-            return {
-              data,
-              timestamp: new Date(),
-            };
+            try {
+              const data = await options.requestAsync(input);
+              await channel.publishAndUpdateLastStateAsync(data);
+              return {
+                data,
+                timestamp: new Date(),
+              };
+            } catch (error) {
+              const staleFallbackHandlers: Record<string, () => { data: TData; timestamp: Date } | null | undefined> = {
+                enabled: () => channelData,
+                disabled: () => null,
+              };
+              const staleFallbackKeyMap: Record<string, string> = {
+                true: "enabled",
+                false: "disabled",
+              };
+              const staleFallbackKey = staleFallbackKeyMap[String(Boolean(options.fallbackToStaleOnError))];
+              const staleData = staleFallbackHandlers[staleFallbackKey]();
+
+              if (staleData) {
+                logger.warn("Cached request handler using stale cache after fetch failure", {
+                  channel: channel.name,
+                  queryKey: options.queryKey,
+                  cause: error instanceof Error ? error.message : String(error),
+                });
+                return staleData;
+              }
+
+              throw error;
+            }
           };
 
           if (forceUpdate) {
@@ -42,8 +69,6 @@ export const createCachedRequestHandler = <TData, TInput extends Record<string, 
             });
             return await requestNewDataAsync();
           }
-
-          const channelData = await channel.getAsync();
 
           const shouldRequestNewData =
             !channelData ||

--- a/packages/request-handler/src/lib/cached-request-handler.ts
+++ b/packages/request-handler/src/lib/cached-request-handler.ts
@@ -39,11 +39,10 @@ export const createCachedRequestHandler = <TData, TInput extends Record<string, 
               };
             } catch (error) {
               if (options.fallbackToStaleOnError && channelData) {
-                logger.warn("Cached request handler using stale cache after fetch failure", {
+                logger.warn(new ErrorWithMetadata("Cached request handler using stale cache after fetch failure", {
                   channel: channel.name,
                   queryKey: options.queryKey,
-                  cause: error instanceof Error ? error.message : String(error),
-                });
+                }, { cause: error });
                 return channelData;
               }
 

--- a/packages/request-handler/src/lib/cached-request-handler.ts
+++ b/packages/request-handler/src/lib/cached-request-handler.ts
@@ -1,6 +1,7 @@
 import dayjs from "dayjs";
 import type { Duration } from "dayjs/plugin/duration";
 
+import { ErrorWithMetadata } from "@homarr/core/infrastructure/logs/error";
 import { createLogger } from "@homarr/core/infrastructure/logs";
 import type { createChannelWithLatestAndEvents } from "@homarr/redis";
 
@@ -42,7 +43,7 @@ export const createCachedRequestHandler = <TData, TInput extends Record<string, 
                 logger.warn(new ErrorWithMetadata("Cached request handler using stale cache after fetch failure", {
                   channel: channel.name,
                   queryKey: options.queryKey,
-                }, { cause: error });
+                }, { cause: error }));
                 return channelData;
               }
 

--- a/packages/request-handler/src/lib/cached-request-handler.ts
+++ b/packages/request-handler/src/lib/cached-request-handler.ts
@@ -38,24 +38,13 @@ export const createCachedRequestHandler = <TData, TInput extends Record<string, 
                 timestamp: new Date(),
               };
             } catch (error) {
-              const staleFallbackHandlers: Record<string, () => { data: TData; timestamp: Date } | null | undefined> = {
-                enabled: () => channelData,
-                disabled: () => null,
-              };
-              const staleFallbackKeyMap: Record<string, string> = {
-                true: "enabled",
-                false: "disabled",
-              };
-              const staleFallbackKey = staleFallbackKeyMap[String(Boolean(options.fallbackToStaleOnError))];
-              const staleData = staleFallbackHandlers[staleFallbackKey]();
-
-              if (staleData) {
+              if (options.fallbackToStaleOnError && channelData) {
                 logger.warn("Cached request handler using stale cache after fetch failure", {
                   channel: channel.name,
                   queryKey: options.queryKey,
                   cause: error instanceof Error ? error.message : String(error),
                 });
-                return staleData;
+                return channelData;
               }
 
               throw error;

--- a/packages/request-handler/src/test/update-checker.spec.ts
+++ b/packages/request-handler/src/test/update-checker.spec.ts
@@ -111,6 +111,24 @@ describe("getAvailableUpdatesAsync", () => {
     // Assert
     expect(result).toEqual([]);
   });
+
+  test("should propagate GitHub API auth errors without blocking callers", async () => {
+    const currentVersion = "v1.2.3";
+    const listReleasesSpy = vi.spyOn(new Octokit().rest.repos, "listReleases");
+    listReleasesSpy.mockRejectedValue(new Error("Bad credentials"));
+
+    await expect(getAvailableUpdatesAsync(currentVersion)).rejects.toThrow("Bad credentials");
+  });
+
+  test("should propagate GitHub API quota exhausted errors without blocking callers", async () => {
+    const currentVersion = "v1.2.3";
+    const listReleasesSpy = vi.spyOn(new Octokit().rest.repos, "listReleases");
+    listReleasesSpy.mockRejectedValue(
+      new Error("Request quota exhausted for request GET /repos/{owner}/{repo}/releases"),
+    );
+
+    await expect(getAvailableUpdatesAsync(currentVersion)).rejects.toThrow("quota exhausted");
+  });
 });
 
 const fakeReleases = (...inputs: [string, boolean][]) => inputs.map(fakeRelease);

--- a/packages/request-handler/src/update-checker.ts
+++ b/packages/request-handler/src/update-checker.ts
@@ -15,7 +15,8 @@ const logger = createLogger({ module: "updateCheckerRequestHandler" });
 
 export const updateCheckerRequestHandler = createCachedRequestHandler({
   queryKey: "homarr-update-checker",
-  cacheDuration: dayjs.duration(1, "hour"),
+  cacheDuration: dayjs.duration(1, "day"),
+  fallbackToStaleOnError: true,
   async requestAsync(_) {
     return {
       availableUpdates: await getAvailableUpdatesAsync(packageJson.version),
@@ -58,6 +59,7 @@ export const getAvailableUpdatesAsync = async (currentVersion: string) => {
     request: {
       fetch: fetchWithTrustedCertificatesAsync,
     },
+    throttle: { enabled: false },
   });
 
   const isCurrentPrerelease = isPrereleaseTag(currentVersion);
@@ -100,7 +102,7 @@ export const getAvailableUpdatesAsync = async (currentVersion: string) => {
   const availableUpdates = semanticReleases
     .filter((release) => isCurrentPrerelease || !release.isPrerelease)
     .filter((release) => compareSemVer(release.tagName, currentVersion) > 0)
-    .sort((releaseA, releaseB) => compareSemVer(releaseB.tagName, releaseA.tagName));
+    .toSorted((releaseA, releaseB) => compareSemVer(releaseB.tagName, releaseA.tagName));
 
   if (availableUpdates.length === 0) {
     logger.debug("No available updates found", { currentVersion });


### PR DESCRIPTION
## Summary

- Add optional `fallbackToStaleOnError` to the cached request handler so failed upstream fetches can return last-known-good Redis data instead of throwing
- Harden the update checker against GitHub API failures (401, quota exhausted, unreachable): disable Octokit throttling for fast failure, extend cache TTL to 24h, and enable stale fallback
- Reduce GitHub API pressure by running the update checker cron daily and respecting cache TTL instead of force-refreshing every hour

Closes #5786

## Context

Users reported Homarr becoming completely inaccessible when the GitHub releases endpoint returns quota errors — especially visible in regions where GitHub is unreliable. The update checker was hitting `GET /repos/homarr-labs/homarr/releases` too often and Octokit would retry throttled requests, blocking admin page loads.

## Test plan

- [x] `NODE_ENV=development pnpm exec vitest run packages/request-handler/src/test/update-checker.spec.ts`
- [ ] Verify admin dashboard loads when GitHub API is unreachable (no update indicator shown, no page hang)
- [ ] Verify update indicator still appears when GitHub API is reachable and a newer release exists
- [ ] Verify stale cached update data is served when GitHub fails after a prior successful fetch