### PR TITLE
feat(widgets): add in-place app editing in widget edit modal

### DIFF
--- a/packages/widgets/src/modals/embedded-app-edit-form.tsx
+++ b/packages/widgets/src/modals/embedded-app-edit-form.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useImperativeHandle, useRef } from "react";
+import { Alert, Center, Loader, Stack } from "@mantine/core";
+import { IconInfoCircle } from "@tabler/icons-react";
+
+import { clientApi } from "@homarr/api/client";
+import type { AppFormHandle } from "@homarr/forms-collection";
+import { AppForm } from "@homarr/forms-collection";
+import { showErrorNotification, showSuccessNotification } from "@homarr/notifications";
+import { useI18n } from "@homarr/translation/client";
+
+export interface EmbeddedAppEditFormHandle {
+  submitIfDirty: () => void;
+}
+
+interface EmbeddedAppEditFormProps {
+  appId: string;
+  handleRef: React.Ref<EmbeddedAppEditFormHandle>;
+}
+
+export const EmbeddedAppEditForm = ({ appId, handleRef }: EmbeddedAppEditFormProps) => {
+  const t = useI18n();
+  const appFormRef = useRef<AppFormHandle>(null);
+  const { data: app, isPending: isLoadingApp } = clientApi.app.byId.useQuery({ id: appId });
+
+  const { mutate, isPending: isMutating } = clientApi.app.update.useMutation({
+    onSuccess: () => {
+      showSuccessNotification({
+        title: t("app.page.edit.notification.success.title"),
+        message: t("app.page.edit.notification.success.message"),
+      });
+    },
+    onError: () => {
+      showErrorNotification({
+        title: t("app.page.edit.notification.error.title"),
+        message: t("app.page.edit.notification.error.message"),
+      });
+    },
+  });
+
+  useImperativeHandle(
+    handleRef,
+    () => ({
+      submitIfDirty: () => {
+        if (appFormRef.current?.isDirty()) {
+          appFormRef.current.submit();
+        }
+      },
+    }),
+    [],
+  );
+
+  if (isLoadingApp || !app) {
+    return (
+      <Center py="xl">
+        <Loader />
+      </Center>
+    );
+  }
+
+  return (
+    <Stack>
+      <Alert icon={<IconInfoCircle size={16} />} color="blue" variant="light">
+        {t("item.edit.app.propagationNotice")}
+      </Alert>
+      <AppForm
+        formRef={appFormRef}
+        hideButtons
+        showBackToOverview={false}
+        buttonLabels={{ submit: "" }}
+        initialValues={app}
+        handleSubmit={(values) => {
+          mutate({ id: appId, ...values });
+        }}
+        isPending={isMutating}
+      />
+    </Stack>
+  );
+};


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [ ] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

## Summary

Adds the ability to edit app properties (name, icon, URL, description, ping URL) directly from the dashboard's "Edit item - App" modal, removing the need to navigate to `/manage/apps/edit/[id]`.

- New `EmbeddedAppEditForm` component that fetches the app by ID and renders the shared `AppForm` in headless mode (no buttons, no `<form>` wrapper)
- Calls `clientApi.app.update` on save, gated by `form.isDirty()` so untouched apps are never mutated
- Permission-gated: the "Edit app" tab only appears for users with `app-modify-all`
- Informational alert explains that changes propagate across all dashboards

**Remaining changes** (unstaged, will be committed separately):
- `AppForm`: `hideButtons` and `formRef` props for external submission control
- `WidgetEditModal`: Mantine Tabs wrapping "Edit widget" / "Edit app" panels
- `BoardItemMenu`: passes `appId` from widget options to the modal
- Translation keys for tab labels and propagation notice