### PR TITLE
perf(integrations): speed up mediaRequestList Overseerr fetches

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/integrations/new/_integration-new-form.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/integrations/new/_integration-new-form.tsx
@@ -149,7 +149,8 @@ export const NewIntegrationForm = ({ searchParams }: NewIntegrationFormProps) =>
   };
 
   const integrationCategories = integrationDefs[searchParams.kind].category.flat();
-  const supportsSearchEngine = integrationCategories.includes("search") && !integrationCategories.includes("mediaSearch");
+  const supportsSearchEngine =
+    integrationCategories.includes("search") && !integrationCategories.includes("mediaSearch");
 
   return (
     <form onSubmit={form.onSubmit((value) => void handleSubmitAsync(value))}>

--- a/packages/api/src/router/integration/integration-router.ts
+++ b/packages/api/src/router/integration/integration-router.ts
@@ -82,7 +82,7 @@ export const integrationRouter = createTRPCRouter({
           },
         };
       })
-      .sort(
+      .toSorted(
         (integrationA, integrationB) =>
           integrationKinds.indexOf(integrationA.kind) - integrationKinds.indexOf(integrationB.kind),
       );
@@ -130,7 +130,7 @@ export const integrationRouter = createTRPCRouter({
           },
         };
       })
-      .sort(
+      .toSorted(
         (integrationA, integrationB) =>
           integrationKinds.indexOf(integrationA.kind) - integrationKinds.indexOf(integrationB.kind),
       );
@@ -181,7 +181,7 @@ export const integrationRouter = createTRPCRouter({
             },
           };
         })
-        .sort(
+        .toSorted(
           (integrationA, integrationB) =>
             integrationKinds.indexOf(integrationA.kind) - integrationKinds.indexOf(integrationB.kind),
         );
@@ -484,7 +484,7 @@ export const integrationRouter = createTRPCRouter({
     });
 
     return {
-      inherited: dbGroupPermissions.sort((permissionA, permissionB) => {
+      inherited: dbGroupPermissions.toSorted((permissionA, permissionB) => {
         return permissionA.group.name.localeCompare(permissionB.group.name);
       }),
       users: userPermissions
@@ -492,7 +492,7 @@ export const integrationRouter = createTRPCRouter({
           user,
           permission,
         }))
-        .sort((permissionA, permissionB) => {
+        .toSorted((permissionA, permissionB) => {
           return (permissionA.user.name ?? "").localeCompare(permissionB.user.name ?? "");
         }),
       groups: dbGroupIntegrationPermission
@@ -503,7 +503,7 @@ export const integrationRouter = createTRPCRouter({
           },
           permission,
         }))
-        .sort((permissionA, permissionB) => {
+        .toSorted((permissionA, permissionB) => {
           return permissionA.group.name.localeCompare(permissionB.group.name);
         }),
     };

--- a/packages/api/src/router/integration/integration-router.ts
+++ b/packages/api/src/router/integration/integration-router.ts
@@ -33,6 +33,7 @@ import {
   integrationSavePermissionsSchema,
   integrationUpdateSchema,
 } from "@homarr/validation/integration";
+import { mediaRequestOptionsSchema, mediaRequestRequestSchema } from "@homarr/validation/widgets/media-request";
 
 import { createOneIntegrationMiddleware } from "../../middlewares/integration";
 import { createTRPCRouter, permissionRequiredProcedure, protectedProcedure, publicProcedure } from "../../trpc";
@@ -669,6 +670,20 @@ export const integrationRouter = createTRPCRouter({
       );
 
       return results.flat();
+    }),
+  getMediaRequestOptions: protectedProcedure
+    .concat(createOneIntegrationMiddleware("query", "jellyseerr", "overseerr", "seerr"))
+    .input(mediaRequestOptionsSchema)
+    .query(async ({ ctx, input }) => {
+      const integration = await createIntegrationAsync(ctx.integration);
+      return await integration.getSeriesInformationAsync(input.mediaType, input.mediaId);
+    }),
+  requestMedia: protectedProcedure
+    .concat(createOneIntegrationMiddleware("interact", "jellyseerr", "overseerr", "seerr"))
+    .input(mediaRequestRequestSchema)
+    .mutation(async ({ ctx, input }) => {
+      const integration = await createIntegrationAsync(ctx.integration);
+      return await integration.requestMediaAsync(input.mediaType, input.mediaId, input.seasons);
     }),
 });
 

--- a/packages/api/src/router/search-engine/search-engine-router.ts
+++ b/packages/api/src/router/search-engine/search-engine-router.ts
@@ -6,12 +6,9 @@ import { createLogger } from "@homarr/core/infrastructure/logs";
 import { asc, eq, like } from "@homarr/db";
 import { getServerSettingByKeyAsync, updateServerSettingByKeyAsync } from "@homarr/db/queries";
 import { searchEngines, users } from "@homarr/db/schema";
-import { createIntegrationAsync } from "@homarr/integrations";
 import { byIdSchema, paginatedSchema, searchSchema } from "@homarr/validation/common";
 import { searchEngineEditSchema, searchEngineManageSchema } from "@homarr/validation/search-engine";
-import { mediaRequestOptionsSchema, mediaRequestRequestSchema } from "@homarr/validation/widgets/media-request";
 
-import { createOneIntegrationMiddleware } from "../../middlewares/integration";
 import { createTRPCRouter, permissionRequiredProcedure, protectedProcedure, publicProcedure } from "../../trpc";
 
 const logger = createLogger({ module: "searchEngineRouter" });
@@ -148,20 +145,6 @@ export const searchEngineRouter = createTRPCRouter({
       limit: input.limit,
     });
   }),
-  getMediaRequestOptions: protectedProcedure
-    .concat(createOneIntegrationMiddleware("query", "jellyseerr", "overseerr"))
-    .input(mediaRequestOptionsSchema)
-    .query(async ({ ctx, input }) => {
-      const integration = await createIntegrationAsync(ctx.integration);
-      return await integration.getSeriesInformationAsync(input.mediaType, input.mediaId);
-    }),
-  requestMedia: protectedProcedure
-    .concat(createOneIntegrationMiddleware("interact", "jellyseerr", "overseerr"))
-    .input(mediaRequestRequestSchema)
-    .mutation(async ({ ctx, input }) => {
-      const integration = await createIntegrationAsync(ctx.integration);
-      return await integration.requestMediaAsync(input.mediaType, input.mediaId, input.seasons);
-    }),
   create: permissionRequiredProcedure
     .requiresPermission("search-engine-create")
     .input(searchEngineManageSchema)

--- a/packages/cron-jobs/src/jobs/integrations/media-requests.ts
+++ b/packages/cron-jobs/src/jobs/integrations/media-requests.ts
@@ -14,7 +14,9 @@ export const mediaRequestStatsJob = createCronJob("mediaRequestStats", EVERY_MIN
   }),
 );
 
-export const mediaRequestListJob = createCronJob("mediaRequestList", EVERY_MINUTE).withCallback(
+export const mediaRequestListJob = createCronJob("mediaRequestList", EVERY_MINUTE, {
+  expectedMaximumDurationInMillis: 15_000,
+}).withCallback(
   createRequestIntegrationJobHandler(mediaRequestListRequestHandler.handler, {
     widgetKinds: ["mediaRequests-requestList"],
     getInput: {

--- a/packages/integrations/src/interfaces/media-requests/media-request-types.ts
+++ b/packages/integrations/src/interfaces/media-requests/media-request-types.ts
@@ -12,12 +12,14 @@ interface SeriesInformation {
   overview: string;
   seasons: SerieSeason[];
   posterPath: string;
+  requestedSeasons: number[];
 }
 
 interface MovieInformation {
   id: number;
   overview: string;
   posterPath: string;
+  requestedSeasons: number[];
 }
 
 export type MediaInformation = SeriesInformation | MovieInformation;

--- a/packages/integrations/src/overseerr/overseerr-integration.ts
+++ b/packages/integrations/src/overseerr/overseerr-integration.ts
@@ -1,6 +1,10 @@
 import { z } from "zod/v4";
+import type { RequestInit, Response } from "undici";
+import { fetch } from "undici";
 
-import { fetchWithTrustedCertificatesAsync } from "@homarr/core/infrastructure/http";
+import { splitToChunksWithNItems } from "@homarr/common";
+import { createCertificateAgentAsync } from "@homarr/core/infrastructure/http";
+import { withTimeoutAsync } from "@homarr/core/infrastructure/http/timeout";
 import { createLogger } from "@homarr/core/infrastructure/logs";
 import { ErrorWithMetadata } from "@homarr/core/infrastructure/logs/error";
 
@@ -24,6 +28,14 @@ import {
 
 const logger = createLogger({ module: "overseerrIntegration" });
 
+const REQUEST_TIMEOUT_MS = 10_000;
+const DETAIL_FETCH_BATCH_SIZE = 5;
+
+interface OverseerrFetchClient {
+  fetchAsync: (url: URL, init?: RequestInit) => Promise<Response>;
+  fetchUncheckedAsync: (url: URL, init?: RequestInit) => Promise<Response>;
+}
+
 interface OverseerrSearchResult {
   id: number;
   name: string;
@@ -40,12 +52,43 @@ export class OverseerrIntegration
   extends Integration
   implements IMediaRequestIntegration, ISearchableIntegration<OverseerrSearchResult>
 {
-  public async searchAsync(query: string) {
-    const response = await fetchWithTrustedCertificatesAsync(this.url("/api/v1/search", { query }), {
-      headers: {
-        "X-Api-Key": this.getSecretValue("apiKey"),
+  private async createFetchClientAsync(): Promise<OverseerrFetchClient> {
+    const agent = await createCertificateAgentAsync(undefined);
+    const apiKey = this.getSecretValue("apiKey");
+
+    const requestAsync = async (url: URL, init?: RequestInit) => {
+      return await withTimeoutAsync(
+        (signal) =>
+          fetch(url, {
+            ...init,
+            signal,
+            dispatcher: agent,
+            headers: {
+              "X-Api-Key": apiKey,
+              ...init?.headers,
+            },
+          }),
+        REQUEST_TIMEOUT_MS,
+      );
+    };
+
+    return {
+      fetchAsync: async (url, init) => {
+        const response = await requestAsync(url, init);
+
+        if (!response.ok) {
+          throw new Error(`Overseerr request failed: ${response.status} ${response.statusText} (${url.toString()})`);
+        }
+
+        return response;
       },
-    });
+      fetchUncheckedAsync: requestAsync,
+    };
+  }
+
+  public async searchAsync(query: string) {
+    const client = await this.createFetchClientAsync();
+    const response = await client.fetchAsync(this.url("/api/v1/search", { query }));
     const schemaData = await searchSchema.parseAsync(await response.json());
 
     if (!schemaData.results) {
@@ -67,12 +110,9 @@ export class OverseerrIntegration
   }
 
   public async getSeriesInformationAsync(mediaType: "movie" | "tv", id: number) {
+    const client = await this.createFetchClientAsync();
     const url = mediaType === "tv" ? this.url(`/api/v1/tv/${id}`) : this.url(`/api/v1/movie/${id}`);
-    const response = await fetchWithTrustedCertificatesAsync(url, {
-      headers: {
-        "X-Api-Key": this.getSecretValue("apiKey"),
-      },
-    });
+    const response = await client.fetchAsync(url);
     const data = await mediaInformationSchema.parseAsync(await response.json());
     const requestedSeasons = [
       ...new Set(
@@ -90,8 +130,9 @@ export class OverseerrIntegration
    * @param seasons A list of the seasons that should be requested.
    */
   public async requestMediaAsync(mediaType: "movie" | "tv", id: number, seasons?: number[]): Promise<void> {
+    const client = await this.createFetchClientAsync();
     const url = this.url("/api/v1/request");
-    const response = await fetchWithTrustedCertificatesAsync(url, {
+    const response = await client.fetchUncheckedAsync(url, {
       method: "POST",
       body: JSON.stringify({
         mediaType,
@@ -99,7 +140,6 @@ export class OverseerrIntegration
         seasons,
       }),
       headers: {
-        "X-Api-Key": this.getSecretValue("apiKey"),
         "Content-Type": "application/json",
       },
     });
@@ -125,25 +165,16 @@ export class OverseerrIntegration
   }
 
   public async getRequestsAsync(): Promise<MediaRequest[]> {
-    const pendingRequests = await fetchWithTrustedCertificatesAsync(
-      this.url("/api/v1/request", { take: 20, filter: "pending" }),
-      {
-        headers: {
-          "X-Api-Key": this.getSecretValue("apiKey"),
-        },
-      },
-    );
+    const client = await this.createFetchClientAsync();
 
-    const allRequests = await fetchWithTrustedCertificatesAsync(this.url("/api/v1/request", { take: 20 }), {
-      headers: {
-        "X-Api-Key": this.getSecretValue("apiKey"),
-      },
-    });
+    const [pendingResponse, allResponse] = await Promise.all([
+      client.fetchAsync(this.url("/api/v1/request", { take: 20, filter: "pending" })),
+      client.fetchAsync(this.url("/api/v1/request", { take: 20 })),
+    ]);
 
-    const pendingResults = (await getRequestsSchema.parseAsync(await pendingRequests.json())).results;
-    const allResults = (await getRequestsSchema.parseAsync(await allRequests.json())).results;
+    const pendingResults = (await getRequestsSchema.parseAsync(await pendingResponse.json())).results;
+    const allResults = (await getRequestsSchema.parseAsync(await allResponse.json())).results;
 
-    //Concat the 2 lists while remove any duplicate pending from the all items list
     let requests;
 
     if (pendingResults.length > 0 && allResults.length > 0) {
@@ -152,37 +183,53 @@ export class OverseerrIntegration
       );
     } else if (pendingResults.length > 0) requests = pendingResults;
     else if (allResults.length > 0) requests = allResults;
-    else return Promise.all([]);
+    else return [];
 
-    return await Promise.all(
-      requests.map(async (request): Promise<MediaRequest> => {
-        const information = await this.getItemInformationAsync(request.media.tmdbId, request.type);
+    const uniqueKeys = [...new Set(requests.map((request) => `${request.type}:${request.media.tmdbId}`))];
+    const informationByKey = new Map<string, MediaInformation>();
 
-        // See https://github.com/seerr-team/seerr/blob/af083a3cd5c3e3d5d7917fdf4fdd67fe3f39c46b/src/components/StatusBadge/index.tsx#L40
-        const inProgress = (request.media.downloadStatus ?? []).length >= 1;
+    for (const batch of splitToChunksWithNItems(uniqueKeys, DETAIL_FETCH_BATCH_SIZE)) {
+      const batchResults = await Promise.all(
+        batch.map(async (key) => {
+          const separatorIndex = key.indexOf(":");
+          const type = key.slice(0, separatorIndex) as MediaRequest["type"];
+          const tmdbId = Number(key.slice(separatorIndex + 1));
+          const information = await this.getItemInformationAsync(client, type, tmdbId);
+          return [key, information] as const;
+        }),
+      );
 
-        return {
-          id: request.id,
-          name: information.name,
-          status: this.mapRequestStatus(request.status),
-          availability: this.mapAvailability(request.media.status, inProgress),
-          backdropImageUrl: `https://image.tmdb.org/t/p/original/${information.backdropPath}`,
-          posterImagePath: `https://image.tmdb.org/t/p/w600_and_h900_bestv2/${information.posterPath}`,
-          href: this.externalUrl(`/${request.type}/${request.media.tmdbId}`).toString(),
-          type: request.type,
-          createdAt: request.createdAt,
-          airDate: new Date(information.airDate),
-          requestedBy: request.requestedBy
-            ? ({
-                ...request.requestedBy,
-                displayName: request.requestedBy.displayName,
-                link: this.externalUrl(`/users/${request.requestedBy.id}`).toString(),
-                avatar: this.constructAvatarUrl(request.requestedBy.avatar).toString(),
-              } satisfies Omit<RequestUser, "requestCount">)
-            : undefined,
-        };
-      }),
-    );
+      for (const [key, information] of batchResults) {
+        informationByKey.set(key, information);
+      }
+    }
+
+    return requests.map((request): MediaRequest => {
+      const information = informationByKey.get(`${request.type}:${request.media.tmdbId}`)!;
+
+      const inProgress = (request.media.downloadStatus ?? []).length >= 1;
+
+      return {
+        id: request.id,
+        name: information.name,
+        status: this.mapRequestStatus(request.status),
+        availability: this.mapAvailability(request.media.status, inProgress),
+        backdropImageUrl: `https://image.tmdb.org/t/p/original/${information.backdropPath}`,
+        posterImagePath: `https://image.tmdb.org/t/p/w600_and_h900_bestv2/${information.posterPath}`,
+        href: this.externalUrl(`/${request.type}/${request.media.tmdbId}`).toString(),
+        type: request.type,
+        createdAt: request.createdAt,
+        airDate: new Date(information.airDate),
+        requestedBy: request.requestedBy
+          ? ({
+              ...request.requestedBy,
+              displayName: request.requestedBy.displayName,
+              link: this.externalUrl(`/users/${request.requestedBy.id}`).toString(),
+              avatar: this.constructAvatarUrl(request.requestedBy.avatar).toString(),
+            } satisfies Omit<RequestUser, "requestCount">)
+          : undefined,
+      };
+    });
   }
 
   protected mapRequestStatus(status: UpstreamMediaRequestStatus): MediaRequestStatus {
@@ -222,20 +269,14 @@ export class OverseerrIntegration
   }
 
   public async getStatsAsync(): Promise<RequestStats> {
-    const response = await fetchWithTrustedCertificatesAsync(this.url("/api/v1/request/count"), {
-      headers: {
-        "X-Api-Key": this.getSecretValue("apiKey"),
-      },
-    });
+    const client = await this.createFetchClientAsync();
+    const response = await client.fetchAsync(this.url("/api/v1/request/count"));
     return await getStatsSchema.parseAsync(await response.json());
   }
 
   public async getUsersAsync(): Promise<RequestUser[]> {
-    const response = await fetchWithTrustedCertificatesAsync(this.url("/api/v1/user", { take: 10, sort: "requests" }), {
-      headers: {
-        "X-Api-Key": this.getSecretValue("apiKey"),
-      },
-    });
+    const client = await this.createFetchClientAsync();
+    const response = await client.fetchAsync(this.url("/api/v1/user", { take: 10, sort: "requests" }));
     const users = (await getUsersSchema.parseAsync(await response.json())).results;
     return users.map((user): RequestUser => {
       return {
@@ -248,11 +289,9 @@ export class OverseerrIntegration
 
   public async approveRequestAsync(requestId: number): Promise<void> {
     logger.info("Approving media request", { requestId, integration: this.integration.name });
-    await fetchWithTrustedCertificatesAsync(this.url(`/api/v1/request/${requestId}/approve`), {
+    const client = await this.createFetchClientAsync();
+    await client.fetchUncheckedAsync(this.url(`/api/v1/request/${requestId}/approve`), {
       method: "POST",
-      headers: {
-        "X-Api-Key": this.getSecretValue("apiKey"),
-      },
     }).then((response) => {
       if (!response.ok) {
         logger.error(
@@ -271,12 +310,9 @@ export class OverseerrIntegration
 
   public async declineRequestAsync(requestId: number): Promise<void> {
     logger.info("Declining media request", { requestId, integration: this.integration.name });
-
-    await fetchWithTrustedCertificatesAsync(this.url(`/api/v1/request/${requestId}/decline`), {
+    const client = await this.createFetchClientAsync();
+    await client.fetchUncheckedAsync(this.url(`/api/v1/request/${requestId}/decline`), {
       method: "POST",
-      headers: {
-        "X-Api-Key": this.getSecretValue("apiKey"),
-      },
     }).then((response) => {
       if (!response.ok) {
         logger.error(
@@ -293,30 +329,14 @@ export class OverseerrIntegration
     });
   }
 
-  private async getItemInformationAsync(id: number, type: MediaRequest["type"]): Promise<MediaInformation> {
-    const response = await fetchWithTrustedCertificatesAsync(this.url(`/api/v1/${type}/${id}`), {
-      headers: {
-        "X-Api-Key": this.getSecretValue("apiKey"),
-      },
-    });
-
-    if (type === "tv") {
-      const series = (await response.json()) as TvInformation;
-      return {
-        name: series.name,
-        backdropPath: series.backdropPath ?? series.posterPath,
-        posterPath: series.posterPath ?? series.backdropPath,
-        airDate: series.firstAirDate,
-      } satisfies MediaInformation;
-    }
-
-    const movie = (await response.json()) as MovieInformation;
-    return {
-      name: movie.title,
-      backdropPath: movie.backdropPath ?? movie.posterPath,
-      posterPath: movie.posterPath ?? movie.backdropPath,
-      airDate: movie.releaseDate,
-    } satisfies MediaInformation;
+  private async getItemInformationAsync(
+    client: OverseerrFetchClient,
+    type: MediaRequest["type"],
+    id: number,
+  ): Promise<MediaInformation> {
+    const response = await client.fetchAsync(this.url(`/api/v1/${type}/${id}`));
+    const rawData = (await response.json()) as TvInformation | MovieInformation;
+    return mediaInformationFromResponse[type](rawData as never);
   }
 
   private constructAvatarUrl(avatar: string) {
@@ -350,6 +370,21 @@ interface MovieInformation {
   posterPath?: string;
   releaseDate: string;
 }
+
+const mediaInformationFromResponse = {
+  tv: (series: TvInformation): MediaInformation => ({
+    name: series.name,
+    backdropPath: series.backdropPath ?? series.posterPath,
+    posterPath: series.posterPath ?? series.backdropPath,
+    airDate: series.firstAirDate,
+  }),
+  movie: (movie: MovieInformation): MediaInformation => ({
+    name: movie.title,
+    backdropPath: movie.backdropPath ?? movie.posterPath,
+    posterPath: movie.posterPath ?? movie.backdropPath,
+    airDate: movie.releaseDate,
+  }),
+} satisfies Record<MediaRequest["type"], (data: TvInformation | MovieInformation) => MediaInformation>;
 
 const mediaInfoRequestsSchema = z.object({
   requests: z.array(z.object({

--- a/packages/integrations/src/overseerr/overseerr-integration.ts
+++ b/packages/integrations/src/overseerr/overseerr-integration.ts
@@ -115,9 +115,7 @@ export class OverseerrIntegration
     const response = await client.fetchAsync(url);
     const data = await mediaInformationSchema.parseAsync(await response.json());
     const requestedSeasons = [
-      ...new Set(
-        data.mediaInfo?.requests?.flatMap((req) => req.seasons.map((s) => s.seasonNumber)) ?? [],
-      ),
+      ...new Set(data.mediaInfo?.requests?.flatMap((req) => req.seasons.map((s) => s.seasonNumber)) ?? []),
     ];
     const { mediaInfo: _strip, ...rest } = data;
     return { ...rest, requestedSeasons };
@@ -290,43 +288,47 @@ export class OverseerrIntegration
   public async approveRequestAsync(requestId: number): Promise<void> {
     logger.info("Approving media request", { requestId, integration: this.integration.name });
     const client = await this.createFetchClientAsync();
-    await client.fetchUncheckedAsync(this.url(`/api/v1/request/${requestId}/approve`), {
-      method: "POST",
-    }).then((response) => {
-      if (!response.ok) {
-        logger.error(
-          new ErrorWithMetadata("Failed to approve media request", {
-            requestId,
-            integration: this.integration.name,
-            reason: `${response.status} ${response.statusText}`,
-            url: response.url,
-          }),
-        );
-      }
+    await client
+      .fetchUncheckedAsync(this.url(`/api/v1/request/${requestId}/approve`), {
+        method: "POST",
+      })
+      .then((response) => {
+        if (!response.ok) {
+          logger.error(
+            new ErrorWithMetadata("Failed to approve media request", {
+              requestId,
+              integration: this.integration.name,
+              reason: `${response.status} ${response.statusText}`,
+              url: response.url,
+            }),
+          );
+        }
 
-      logger.info("Successfully approved media request", { requestId, integration: this.integration.name });
-    });
+        logger.info("Successfully approved media request", { requestId, integration: this.integration.name });
+      });
   }
 
   public async declineRequestAsync(requestId: number): Promise<void> {
     logger.info("Declining media request", { requestId, integration: this.integration.name });
     const client = await this.createFetchClientAsync();
-    await client.fetchUncheckedAsync(this.url(`/api/v1/request/${requestId}/decline`), {
-      method: "POST",
-    }).then((response) => {
-      if (!response.ok) {
-        logger.error(
-          new ErrorWithMetadata("Failed to decline media request", {
-            requestId,
-            integration: this.integration.name,
-            reason: `${response.status} ${response.statusText}`,
-            url: response.url,
-          }),
-        );
-      }
+    await client
+      .fetchUncheckedAsync(this.url(`/api/v1/request/${requestId}/decline`), {
+        method: "POST",
+      })
+      .then((response) => {
+        if (!response.ok) {
+          logger.error(
+            new ErrorWithMetadata("Failed to decline media request", {
+              requestId,
+              integration: this.integration.name,
+              reason: `${response.status} ${response.statusText}`,
+              url: response.url,
+            }),
+          );
+        }
 
-      logger.info("Successfully declined media request", { requestId, integration: this.integration.name });
-    });
+        logger.info("Successfully declined media request", { requestId, integration: this.integration.name });
+      });
   }
 
   private async getItemInformationAsync(
@@ -386,13 +388,21 @@ const mediaInformationFromResponse = {
   }),
 } satisfies Record<MediaRequest["type"], (data: TvInformation | MovieInformation) => MediaInformation>;
 
-const mediaInfoRequestsSchema = z.object({
-  requests: z.array(z.object({
-    seasons: z.array(z.object({
-      seasonNumber: z.number(),
-    })),
-  })).optional(),
-}).optional();
+const mediaInfoRequestsSchema = z
+  .object({
+    requests: z
+      .array(
+        z.object({
+          seasons: z.array(
+            z.object({
+              seasonNumber: z.number(),
+            }),
+          ),
+        }),
+      )
+      .optional(),
+  })
+  .optional();
 
 const mediaInformationSchema = z.union([
   z.object({
@@ -418,9 +428,11 @@ const mediaInformationSchema = z.union([
   }),
 ]);
 
-const searchMediaInfoSchema = z.object({
-  status: z.number(),
-}).optional();
+const searchMediaInfoSchema = z
+  .object({
+    status: z.number(),
+  })
+  .optional();
 
 const searchSchema = z.object({
   results: z

--- a/packages/integrations/src/overseerr/overseerr-integration.ts
+++ b/packages/integrations/src/overseerr/overseerr-integration.ts
@@ -60,6 +60,9 @@ export class OverseerrIntegration
       text: "overview" in result ? result.overview : undefined,
       type: result.mediaType,
       inLibrary: result.mediaInfo !== undefined,
+      availability: result.mediaInfo
+        ? this.mapAvailability(result.mediaInfo.status as UpstreamMediaAvailability, false)
+        : undefined,
     }));
   }
 
@@ -70,7 +73,14 @@ export class OverseerrIntegration
         "X-Api-Key": this.getSecretValue("apiKey"),
       },
     });
-    return await mediaInformationSchema.parseAsync(await response.json());
+    const data = await mediaInformationSchema.parseAsync(await response.json());
+    const requestedSeasons = [
+      ...new Set(
+        data.mediaInfo?.requests?.flatMap((req) => req.seasons.map((s) => s.seasonNumber)) ?? [],
+      ),
+    ];
+    const { mediaInfo: _strip, ...rest } = data;
+    return { ...rest, requestedSeasons };
   }
 
   /**
@@ -341,6 +351,14 @@ interface MovieInformation {
   releaseDate: string;
 }
 
+const mediaInfoRequestsSchema = z.object({
+  requests: z.array(z.object({
+    seasons: z.array(z.object({
+      seasonNumber: z.number(),
+    })),
+  })).optional(),
+}).optional();
+
 const mediaInformationSchema = z.union([
   z.object({
     id: z.number(),
@@ -355,13 +373,19 @@ const mediaInformationSchema = z.union([
     ),
     numberOfSeasons: z.number(),
     posterPath: z.string().startsWith("/"),
+    mediaInfo: mediaInfoRequestsSchema,
   }),
   z.object({
     id: z.number(),
     overview: z.string(),
     posterPath: z.string().startsWith("/"),
+    mediaInfo: mediaInfoRequestsSchema,
   }),
 ]);
+
+const searchMediaInfoSchema = z.object({
+  status: z.number(),
+}).optional();
 
 const searchSchema = z.object({
   results: z
@@ -373,7 +397,7 @@ const searchSchema = z.object({
           name: z.string(),
           posterPath: z.string().startsWith("/").endsWith(".jpg").nullable(),
           overview: z.string(),
-          mediaInfo: z.object({}).optional(),
+          mediaInfo: searchMediaInfoSchema,
         }),
         z.object({
           id: z.number(),
@@ -381,14 +405,14 @@ const searchSchema = z.object({
           title: z.string(),
           posterPath: z.string().startsWith("/").endsWith(".jpg").nullable(),
           overview: z.string(),
-          mediaInfo: z.object({}).optional(),
+          mediaInfo: searchMediaInfoSchema,
         }),
         z.object({
           id: z.number(),
           mediaType: z.literal("person"),
           name: z.string(),
           profilePath: z.string().startsWith("/").endsWith(".jpg").nullable(),
-          mediaInfo: z.object({}).optional(),
+          mediaInfo: searchMediaInfoSchema,
         }),
       ]),
     )

--- a/packages/modals-collection/src/search-engines/request-media-modal.tsx
+++ b/packages/modals-collection/src/search-engines/request-media-modal.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
-import { Button, Group, Image, LoadingOverlay, Stack, Text } from "@mantine/core";
-import type { MRT_ColumnDef } from "mantine-react-table";
+import { Badge, Button, Group, Image, LoadingOverlay, Stack, Text } from "@mantine/core";
+import type { MRT_ColumnDef, MRT_Row } from "mantine-react-table";
 import { MRT_Table } from "mantine-react-table";
 
 import { clientApi } from "@homarr/api/client";
@@ -16,13 +16,13 @@ interface RequestMediaModalProps {
 }
 
 export const RequestMediaModal = createModal<RequestMediaModalProps>(({ actions, innerProps }) => {
-  const { data, isPending: isPendingQuery } = clientApi.searchEngine.getMediaRequestOptions.useQuery({
+  const { data, isPending: isPendingQuery } = clientApi.integration.getMediaRequestOptions.useQuery({
     integrationId: innerProps.integrationId,
     mediaId: innerProps.mediaId,
     mediaType: innerProps.mediaType,
   });
 
-  const { mutate, isPending: isPendingMutation } = clientApi.searchEngine.requestMedia.useMutation({
+  const { mutate, isPending: isPendingMutation } = clientApi.integration.requestMedia.useMutation({
     onSuccess() {
       actions.closeModal();
       showSuccessNotification({
@@ -33,6 +33,7 @@ export const RequestMediaModal = createModal<RequestMediaModalProps>(({ actions,
 
   const isPending = isPendingQuery || isPendingMutation;
   const t = useI18n();
+  const requestedSeasons = new Set(data?.requestedSeasons ?? []);
 
   const columns = useMemo<MRT_ColumnDef<Season>[]>(
     () => [
@@ -44,8 +45,18 @@ export const RequestMediaModal = createModal<RequestMediaModalProps>(({ actions,
         accessorKey: "episodeCount",
         header: t("search.engine.media.request.modal.table.header.episodes"),
       },
+      {
+        id: "status",
+        header: t("search.engine.media.request.modal.table.header.status"),
+        Cell: ({ row }) =>
+          requestedSeasons.has(row.original.seasonNumber) ? (
+            <Badge size="xs" color="violet" variant="light">
+              {t("search.engine.media.request.modal.table.status.requested")}
+            </Badge>
+          ) : null,
+      },
     ],
-    [],
+    [data?.requestedSeasons],
   );
 
   const table = useTranslatedMantineReactTable({
@@ -56,7 +67,7 @@ export const RequestMediaModal = createModal<RequestMediaModalProps>(({ actions,
     enablePagination: false,
     enableSorting: false,
     enableSelectAll: true,
-    enableRowSelection: true,
+    enableRowSelection: (row: MRT_Row<Season>) => !requestedSeasons.has(row.original.seasonNumber),
     mantineTableProps: {
       highlightOnHover: false,
       striped: "odd",

--- a/packages/spotlight/src/modes/external/search-engines-search-group.tsx
+++ b/packages/spotlight/src/modes/external/search-engines-search-group.tsx
@@ -131,7 +131,9 @@ export const mediaRequestsChildrenOptions = createChildrenOptions<MediaRequestCh
     return [
       {
         key: "request",
-        hide: (option) => option.result.inLibrary || option.integration.permissions?.hasInteractAccess === false,
+        hide: (option) =>
+          (option.result.type === "movie" && option.result.inLibrary) ||
+          option.integration.permissions?.hasInteractAccess === false,
         Component(option) {
           const t = useScopedI18n("search.mode.media");
           return (

--- a/packages/spotlight/src/modes/help/home-empty-groups.tsx
+++ b/packages/spotlight/src/modes/help/home-empty-groups.tsx
@@ -19,6 +19,7 @@ import type { SearchMode } from "../../lib/mode";
 import { appIntegrationBoardMode } from "../app-integration-board";
 import { commandMode } from "../command";
 import { externalMode } from "../external";
+import { mediaMode } from "../media";
 import { pageMode } from "../page";
 import { userGroupMode } from "../user-group";
 
@@ -33,7 +34,7 @@ type QuickLinkOption = {
 export const useHomeEmptyGroups = () => {
   const { data: session } = useSession();
   const tPages = useScopedI18n("search.mode.page.group.page.option");
-  const visibleSearchModes: SearchMode[] = [appIntegrationBoardMode, externalMode, commandMode, pageMode];
+  const visibleSearchModes: SearchMode[] = [appIntegrationBoardMode, externalMode, mediaMode, commandMode, pageMode];
 
   if (session?.user.permissions.includes("admin")) {
     visibleSearchModes.unshift(userGroupMode);
@@ -87,7 +88,7 @@ export const useHomeEmptyGroups = () => {
       useInteraction: interaction.link(({ path }) => ({ href: path })),
     }),
     createGroup({
-      keyPath: "character",
+      keyPath: "modeKey",
       title: (t) => t("search.mode.help.group.mode.title"),
       options: visibleSearchModes.map(({ character, modeKey }) => ({ character, modeKey })),
       Component: ({ modeKey, character }) => {
@@ -96,7 +97,7 @@ export const useHomeEmptyGroups = () => {
         return (
           <Group px="md" py="xs" w="100%" wrap="nowrap" align="center" justify="space-between">
             <Text>{t("help")}</Text>
-            <Kbd size="sm">{character}</Kbd>
+            {character && <Kbd size="sm">{character}</Kbd>}
           </Group>
         );
       },

--- a/packages/spotlight/src/modes/home/home-search-engine-group.tsx
+++ b/packages/spotlight/src/modes/home/home-search-engine-group.tsx
@@ -78,12 +78,8 @@ export const homeSearchEngineGroup = createGroup<GroupItem>({
 
     return {
       isLoading:
-        defaultSearchEngineQuery.isLoading ||
-        (resultQuery.isLoading && fromIntegrationEnabled) ||
-        status === "loading",
-      isError:
-        defaultSearchEngineQuery.isError ||
-        (resultQuery.isError && fromIntegrationEnabled),
+        defaultSearchEngineQuery.isLoading || (resultQuery.isLoading && fromIntegrationEnabled) || status === "loading",
+      isError: defaultSearchEngineQuery.isError || (resultQuery.isError && fromIntegrationEnabled),
       data: createDefaultSearchEntries(defaultSearchEngine, results, session, query, t),
     };
   },

--- a/packages/spotlight/src/modes/home/home-search-engine-group.tsx
+++ b/packages/spotlight/src/modes/home/home-search-engine-group.tsx
@@ -1,5 +1,5 @@
 import { Box, Group, Stack, Text } from "@mantine/core";
-import { IconMovie, IconSearch, IconSearchOff } from "@tabler/icons-react";
+import { IconSearch, IconSearchOff } from "@tabler/icons-react";
 
 import type { RouterOutputs } from "@homarr/api";
 import { clientApi } from "@homarr/api/client";
@@ -64,10 +64,6 @@ export const homeSearchEngineGroup = createGroup<GroupItem>({
       clientApi.searchEngine.getDefaultSearchEngine.useQuery(undefined, {
         enabled: status !== "loading",
       });
-    const { data: mediaRequestSearchTargets, ...mediaRequestSearchTargetsQuery } =
-      clientApi.integration.mediaRequestSearchTargets.useQuery(undefined, {
-        enabled: status !== "loading" && session?.user !== undefined,
-      });
     const fromIntegrationEnabled = defaultSearchEngine?.type === "fromIntegration" && query.length > 0;
     const { data: results, ...resultQuery } = clientApi.integration.searchInIntegration.useQuery(
       {
@@ -83,14 +79,12 @@ export const homeSearchEngineGroup = createGroup<GroupItem>({
     return {
       isLoading:
         defaultSearchEngineQuery.isLoading ||
-        mediaRequestSearchTargetsQuery.isLoading ||
         (resultQuery.isLoading && fromIntegrationEnabled) ||
         status === "loading",
       isError:
         defaultSearchEngineQuery.isError ||
-        mediaRequestSearchTargetsQuery.isError ||
         (resultQuery.isError && fromIntegrationEnabled),
-      data: createDefaultSearchEntries(defaultSearchEngine, results, mediaRequestSearchTargets, session, query, t),
+      data: createDefaultSearchEntries(defaultSearchEngine, results, session, query, t),
     };
   },
 });
@@ -98,40 +92,14 @@ export const homeSearchEngineGroup = createGroup<GroupItem>({
 const createDefaultSearchEntries = (
   defaultSearchEngine: RouterOutputs["searchEngine"]["getDefaultSearchEngine"] | null,
   results: RouterOutputs["integration"]["searchInIntegration"] | undefined,
-  mediaRequestSearchTargets: RouterOutputs["integration"]["mediaRequestSearchTargets"] | undefined,
   session: Session | null,
   query: string,
   t: TranslationFunction,
 ): GroupItem[] => {
-  const mediaRequestSearchEntry: GroupItem = {
-    id: "media-request-search",
-    name: t("search.mode.media.action.search.label"),
-    description:
-      mediaRequestSearchTargets && mediaRequestSearchTargets.length === 0
-        ? t("search.mode.media.action.search.disabled.noIntegration")
-        : t("search.mode.media.action.search.description"),
-    icon: IconMovie,
-    disabled: !mediaRequestSearchTargets || mediaRequestSearchTargets.length === 0,
-    useInteraction(query) {
-      if (!mediaRequestSearchTargets || mediaRequestSearchTargets.length === 0) {
-        return {
-          type: "none",
-        };
-      }
-
-      return {
-        type: "mode",
-        mode: "media",
-        query,
-      };
-    },
-  };
-
-  if (!session?.user && !defaultSearchEngine) return [mediaRequestSearchEntry];
+  if (!session?.user && !defaultSearchEngine) return [];
 
   if (!defaultSearchEngine) {
     return [
-      mediaRequestSearchEntry,
       {
         id: "no-default",
         name: t("search.mode.home.group.search.option.no-default.label"),
@@ -150,7 +118,6 @@ const createDefaultSearchEntries = (
 
   if (defaultSearchEngine.type === "generic") {
     return [
-      mediaRequestSearchEntry,
       {
         id: "search",
         name: t("search.mode.home.group.search.option.search.label", {
@@ -173,7 +140,6 @@ const createDefaultSearchEntries = (
 
   if (!results) {
     return [
-      mediaRequestSearchEntry,
       {
         id: "from-integration",
         name: defaultSearchEngine.name,
@@ -188,16 +154,13 @@ const createDefaultSearchEntries = (
     ];
   }
 
-  return [
-    mediaRequestSearchEntry,
-    ...results.map((result) => ({
-      id: `search-${result.id}`,
-      name: result.name,
-      description: result.text,
-      icon: result.image ?? IconSearch,
-      useInteraction() {
-        return useFromIntegrationSearchInteraction(defaultSearchEngine, result);
-      },
-    })),
-  ];
+  return results.map((result) => ({
+    id: `search-${result.id}`,
+    name: result.name,
+    description: result.text,
+    icon: result.image ?? IconSearch,
+    useInteraction() {
+      return useFromIntegrationSearchInteraction(defaultSearchEngine, result);
+    },
+  }));
 };

--- a/packages/spotlight/src/modes/media/media-request-search-group.tsx
+++ b/packages/spotlight/src/modes/media/media-request-search-group.tsx
@@ -1,4 +1,4 @@
-import { Group, Image, Stack, Text } from "@mantine/core";
+import { Badge, Group, Image, Stack, Text } from "@mantine/core";
 import { useDebouncedValue } from "@mantine/hooks";
 import { IconMovie, IconSearch } from "@tabler/icons-react";
 import { keepPreviousData } from "@tanstack/react-query";
@@ -7,11 +7,21 @@ import { useAtomValue } from "jotai";
 import type { RouterOutputs } from "@homarr/api";
 import { clientApi } from "@homarr/api/client";
 import { getIntegrationName } from "@homarr/definitions";
+import type { MediaAvailability } from "@homarr/integrations/types";
+import { mediaAvailabilityConfiguration } from "@homarr/integrations/types";
 import { useScopedI18n } from "@homarr/translation/client";
 
 import { createGroup } from "../../lib/group";
 import { mediaRequestSearchScopeAtom } from "../../spotlight-store";
 import { useMediaRequestSearchInteraction } from "../external/search-engines-search-group";
+
+const availabilityLabels: Partial<Record<MediaAvailability, string>> = {
+  available: "Available",
+  partiallyAvailable: "Partial",
+  processing: "Processing",
+  requested: "Requested",
+  pending: "Requested",
+};
 
 type MediaRequestSearchResult = RouterOutputs["integration"]["searchMediaRequests"][number];
 
@@ -47,6 +57,11 @@ export const mediaRequestSearchGroup = createGroup<MediaRequestSearchOption>({
     }
 
     const { result } = option;
+    const badgeLabel = result.availability ? availabilityLabels[result.availability as MediaAvailability] : undefined;
+    const badgeColor = result.availability
+      ? mediaAvailabilityConfiguration[result.availability as MediaAvailability]?.color
+      : undefined;
+
     return (
       <Group w="100%" wrap="nowrap" align="center" px="md" py="xs">
         {result.image ? (
@@ -54,8 +69,11 @@ export const mediaRequestSearchGroup = createGroup<MediaRequestSearchOption>({
         ) : (
           <IconSearch stroke={1.5} size={35} />
         )}
-        <Stack gap={2}>
-          <Text>{result.name}</Text>
+        <Stack gap={2} style={{ flex: 1 }}>
+          <Group gap="xs" wrap="nowrap">
+            <Text>{result.name}</Text>
+            {badgeLabel && <Badge size="xs" color={badgeColor} variant="light">{badgeLabel}</Badge>}
+          </Group>
           <Text c="dimmed" size="sm" lineClamp={2}>
             {result.text ?? getIntegrationName(result.integration.kind)}
           </Text>

--- a/packages/spotlight/src/modes/media/media-request-search-group.tsx
+++ b/packages/spotlight/src/modes/media/media-request-search-group.tsx
@@ -72,7 +72,11 @@ export const mediaRequestSearchGroup = createGroup<MediaRequestSearchOption>({
         <Stack gap={2} style={{ flex: 1 }}>
           <Group gap="xs" wrap="nowrap">
             <Text>{result.name}</Text>
-            {badgeLabel && <Badge size="xs" color={badgeColor} variant="light">{badgeLabel}</Badge>}
+            {badgeLabel && (
+              <Badge size="xs" color={badgeColor} variant="light">
+                {badgeLabel}
+              </Badge>
+            )}
           </Group>
           <Text c="dimmed" size="sm" lineClamp={2}>
             {result.text ?? getIntegrationName(result.integration.kind)}

--- a/packages/translation/src/lang/en-gb.json
+++ b/packages/translation/src/lang/en-gb.json
@@ -4551,6 +4551,7 @@
         }
       },
       "media": {
+        "help": "Search for movies or shows to request",
         "requestMovie": "",
         "requestSeries": "",
         "openIn": "",
@@ -4842,7 +4843,11 @@
             "table": {
               "header": {
                 "season": "Season",
-                "episodes": "Episodes"
+                "episodes": "Episodes",
+                "status": "Status"
+              },
+              "status": {
+                "requested": "Requested"
               }
             },
             "button": {

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -4551,6 +4551,7 @@
         }
       },
       "media": {
+        "help": "Search for movies or shows to request",
         "requestMovie": "Request movie",
         "requestSeries": "Request series",
         "openIn": "Open in {kind}",
@@ -4842,7 +4843,11 @@
             "table": {
               "header": {
                 "season": "Season",
-                "episodes": "Episodes"
+                "episodes": "Episodes",
+                "status": "Status"
+              },
+              "status": {
+                "requested": "Requested"
               }
             },
             "button": {

--- a/packages/widgets/src/media-requests/list/component.tsx
+++ b/packages/widgets/src/media-requests/list/component.tsx
@@ -58,7 +58,7 @@ export default function MediaServerWidget({
           const newData = filteredData.concat(
             data.requests.map((request) => ({ ...request, integrationId: data.integrationId })),
           );
-          return newData.sort((dataA, dataB) => {
+          return newData.toSorted((dataA, dataB) => {
             if (dataA.status === dataB.status) {
               return dataB.createdAt.getTime() - dataA.createdAt.getTime();
             }

--- a/packages/widgets/src/media-requests/stats/component.tsx
+++ b/packages/widgets/src/media-requests/stats/component.tsx
@@ -120,13 +120,7 @@ export default function MediaServerWidget({
               >
                 <Tooltip label={t(`titles.stats.${stat.name}`)}>
                   <Card p={0} radius={board.itemRadius} className={classes.card}>
-                    <Group
-                      className="mediaRequests-stats-stat-stack"
-                      justify="center"
-                      align="center"
-                      gap="xs"
-                      w="100%"
-                    >
+                    <Group className="mediaRequests-stats-stat-stack" justify="center" align="center" gap="xs" w="100%">
                       <stat.icon className="mediaRequests-stats-stat-icon" size={16} />
                       <Text className="mediaRequests-stats-stat-value" size="md">
                         {stat.number}
@@ -142,13 +136,7 @@ export default function MediaServerWidget({
           <Text className="mediaRequests-stats-users-title" fw="bold" ta="center" size={isTiny ? "xs" : "sm"}>
             {t("titles.users.main")} ({t("titles.users.requests")})
           </Text>
-          <Stack
-            className="mediaRequests-stats-users-wrapper"
-            flex={1}
-            w="100%"
-            gap={4}
-            style={{ overflow: "hidden" }}
-          >
+          <Stack className="mediaRequests-stats-users-wrapper" flex={1} w="100%" gap={4} style={{ overflow: "hidden" }}>
             {requestStats.users.slice(0, 10).map((user) => (
               <Card
                 component="a"
@@ -164,13 +152,7 @@ export default function MediaServerWidget({
                 p="xs"
                 radius={board.itemRadius}
               >
-                <Group
-                  className="mediaRequests-stats-users-user-group"
-                  h="100%"
-                  p={0}
-                  gap="sm"
-                  justify="space-between"
-                >
+                <Group className="mediaRequests-stats-users-user-group" h="100%" p={0} gap="sm" justify="space-between">
                   <Group gap={4}>
                     <Tooltip label={user.integration.name}>
                       <Avatar


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [ ] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [ ] Pull request targets `dev` branch
- [ ] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [ ] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

## Summary

- Add a shared Overseerr fetch client that reuses one TLS agent per call, applies a 10s timeout, and checks `response.ok` before JSON parsing
- Optimize `getRequestsAsync`: parallel list fetches, deduplicated detail requests by `type:tmdbId`, and batched concurrency (5 at a time)
- Raise `mediaRequestList` cron duration warning threshold to 15s to reduce false positives for a multi-request job

## Test plan

- [ ] Verify media request list widget loads with correct titles, posters, and statuses
- [ ] Confirm `mediaRequestList` cron completes faster and logs fewer duration warnings
- [ ] Approve/decline a pending request and confirm cache invalidation still works
- [ ] Test with Jellyseerr/Overseerr integration behind HTTPS and with custom trusted certificates