### PR TITLE
fix: keep bookmark app cards borderless

### DIFF
--- a/packages/widgets/src/bookmarks/component.tsx
+++ b/packages/widgets/src/bookmarks/component.tsx
@@ -106,7 +106,15 @@ const FlexLayout = ({
             key={app.id}
             w="100%"
           >
-            <Card radius={board.itemRadius} className={classes.card} w="100%" display="flex" p={4} h="100%">
+            <Card
+              radius={board.itemRadius}
+              className={classes.card}
+              w="100%"
+              display="flex"
+              p={4}
+              h="100%"
+              withBorder={false}
+            >
               {direction === "row" ? (
                 <VerticalItem
                   app={app}
@@ -168,6 +176,7 @@ const GridLayout = ({
             h="100%"
             className={combineClasses(classes.card, classes["card-grid"])}
             radius={board.itemRadius}
+            withBorder={false}
             p="xs"
           >
             {itemDirection === "horizontal" ? (


### PR DESCRIPTION
## Summary

Fixes #5840

This keeps the bookmark widget's inner app cards borderless when the global Mantine card default enables borders.

## Validation

- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @homarr/widgets typecheck`
- `pnpm -F @homarr/widgets lint` (passes with existing warnings)
- `git diff --check`

## Checklist

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`) — targeted widget typecheck/lint passed
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. No documentation changes needed for this bug fix.
