### PR TITLE
fix(immich): respect app color scheme in server-stats widget

### DIFF
--- a/packages/widgets/src/immich/server-stats/component.module.css
+++ b/packages/widgets/src/immich/server-stats/component.module.css
@@ -1,20 +1,10 @@
 .statItem {
   padding: 12px;
   border-radius: var(--mantine-radius-md);
-  background-color: var(--mantine-color-gray-0);
+  background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
   transition: all 0.2s ease;
 
   &:hover {
-    background-color: var(--mantine-color-gray-1);
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .statItem {
-    background-color: var(--mantine-color-dark-6);
-
-    &:hover {
-      background-color: var(--mantine-color-dark-5);
-    }
+    background-color: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
   }
 }


### PR DESCRIPTION
The Immich server-stats widget styled its dark variant with `@media (prefers-color-scheme: dark)`, which follows the operating system appearance rather than Homarr's own light/dark toggle, so the stat cards stayed light-gray when the app was switched to dark mode on a light-mode OS. This swaps the OS-keyed media query for the `light-dark()` CSS function (already the pattern used in `widget-integration-select.module.css`), so the widget resolves its background from the active Mantine color scheme. No behavior change beyond correct theme adaptation.

| Before | After |
|--------|--------|
| <img width="345" height="357" alt="image" src="https://github.com/user-attachments/assets/becc593e-9471-4d23-bc05-2f94535288e3" /> | <img width="342" height="353" alt="image" src="https://github.com/user-attachments/assets/4f4b2e48-cdd1-4a82-8355-d067ba8f34c0" /> |

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).
