### PR TITLE
fix(integrations): support truenas json-rpc api, certificate trust, and api key auth

### DIFF
--- a/packages/definitions/src/integration.ts
+++ b/packages/definitions/src/integration.ts
@@ -321,7 +321,7 @@ export const integrationDefs = {
   },
   truenas: {
     name: "TrueNAS",
-    secretKinds: [["username", "password"]],
+    secretKinds: [["username", "password"], ["apiKey"]],
     iconUrl: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/truenas.svg",
     category: ["healthMonitoring"],
     documentationUrl: createDocumentationLink("/docs/integrations/truenas"),

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -47,12 +47,14 @@
     "timezones-ical-library": "catalog:",
     "tsdav": "catalog:",
     "undici": "catalog:",
+    "ws": "catalog:",
     "xml2js": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@homarr/tsconfig": "workspace:^0.1.0",
     "@types/node-unifi": "catalog:",
+    "@types/ws": "catalog:",
     "@types/xml2js": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/integrations/src/base/integration.ts
+++ b/packages/integrations/src/base/integration.ts
@@ -85,6 +85,16 @@ export abstract class Integration {
     return this.createUrl(this.integration.externalUrl ?? this.integration.url, path, queryParams);
   }
 
+  protected webSocketUrl(
+    path: `/${string}`,
+    queryParams?: Record<string, string | Date | number | boolean | null | undefined>,
+  ) {
+    const url = this.url(path, queryParams);
+    // http -> ws, https -> wss
+    url.protocol = url.protocol.replace("http", "ws");
+    return url;
+  }
+
   public async testConnectionAsync(): Promise<TestingResult> {
     try {
       const url = new URL(this.integration.url);

--- a/packages/integrations/src/truenas/test/truenas-api.spec.ts
+++ b/packages/integrations/src/truenas/test/truenas-api.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+
+import { trueNasApis } from "../truenas-api";
+
+describe("trueNasApis descriptors", () => {
+  test("expose the expected endpoints and handshake requirements", () => {
+    expect(trueNasApis.jsonRpc).toMatchObject({
+      kind: "jsonRpc",
+      path: "/api/current",
+      requiresSessionHandshake: false,
+    });
+    expect(trueNasApis.legacy).toMatchObject({
+      kind: "legacy",
+      path: "/websocket",
+      requiresSessionHandshake: true,
+    });
+  });
+});
+
+describe("jsonRpc api", () => {
+  const { buildRequest, matchResponse } = trueNasApis.jsonRpc;
+
+  test("builds a JSON-RPC 2.0 envelope", () => {
+    expect(buildRequest("id-1", "system.info", [])).toStrictEqual({
+      jsonrpc: "2.0",
+      id: "id-1",
+      method: "system.info",
+      params: [],
+    });
+  });
+
+  test("matches a result for the requested id", () => {
+    const result = matchResponse({ jsonrpc: "2.0", id: "id-1", result: true }, "id-1");
+    expect(result).toStrictEqual({ result: true });
+  });
+
+  test("returns the error when the response carries one", () => {
+    const error = { code: -32001, message: "Not authenticated" };
+    expect(matchResponse({ jsonrpc: "2.0", id: "id-1", error }, "id-1")).toStrictEqual({ error });
+  });
+
+  test("ignores responses for a different id", () => {
+    expect(matchResponse({ jsonrpc: "2.0", id: "other", result: true }, "id-1")).toBeUndefined();
+  });
+
+  test("ignores non JSON-RPC messages", () => {
+    expect(matchResponse({ msg: "result", id: "id-1", result: true }, "id-1")).toBeUndefined();
+  });
+});
+
+describe("legacy api", () => {
+  const { buildRequest, matchResponse } = trueNasApis.legacy;
+
+  test("builds a DDP method envelope", () => {
+    expect(buildRequest("id-1", "auth.login", ["user", "pass"])).toStrictEqual({
+      id: "id-1",
+      msg: "method",
+      method: "auth.login",
+      params: ["user", "pass"],
+    });
+  });
+
+  test("matches a result message for the requested id", () => {
+    expect(matchResponse({ msg: "result", id: "id-1", result: false }, "id-1")).toStrictEqual({ result: false });
+  });
+
+  test("returns the error when the result message carries one", () => {
+    const error = { error: 13, reason: "boom" };
+    expect(matchResponse({ msg: "result", id: "id-1", error }, "id-1")).toStrictEqual({ error });
+  });
+
+  test("ignores responses for a different id", () => {
+    expect(matchResponse({ msg: "result", id: "other", result: true }, "id-1")).toBeUndefined();
+  });
+
+  test("ignores non-result messages such as the session handshake", () => {
+    expect(matchResponse({ msg: "connected", session: "abc" }, "id-1")).toBeUndefined();
+  });
+});

--- a/packages/integrations/src/truenas/test/truenas-integration.spec.ts
+++ b/packages/integrations/src/truenas/test/truenas-integration.spec.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { IntegrationRequestError } from "../../base/errors/http/integration-request-error";
+import type { IntegrationSecret } from "../../base/types";
+
+const ws = vi.hoisted(() => {
+  const sentPayloads: Record<string, unknown>[] = [];
+  const constructedUrls: string[] = [];
+  // A failure with a `code` emits a coded TLS-style error; without one it mimics a missing endpoint (HTTP 404).
+  const failures: { path: string; code?: string }[] = [];
+  let responder: (method: string, params: unknown[]) => unknown = () => undefined;
+
+  type Listener = (...args: unknown[]) => void;
+
+  class FakeWebSocket {
+    static readonly OPEN = 1;
+    public readyState = FakeWebSocket.OPEN;
+    private readonly listeners: Record<string, Listener[]> = {};
+
+    constructor(url: URL | string) {
+      constructedUrls.push(url.toString());
+      setTimeout(() => {
+        const failure = failures.find((candidate) => url.toString().includes(candidate.path));
+        if (failure) {
+          const error: Error & { code?: string } = new Error(failure.code ?? "Unexpected server response: 404");
+          if (failure.code) error.code = failure.code;
+          this.dispatch("error", error);
+        } else {
+          this.dispatch("open");
+        }
+      }, 0);
+    }
+
+    on(event: string, listener: Listener) {
+      (this.listeners[event] ??= []).push(listener);
+      return this;
+    }
+
+    once(event: string, listener: Listener) {
+      const wrapper: Listener = (...args) => {
+        this.off(event, wrapper);
+        listener(...args);
+      };
+      return this.on(event, wrapper);
+    }
+
+    off(event: string, listener: Listener) {
+      this.listeners[event] = (this.listeners[event] ?? []).filter((candidate) => candidate !== listener);
+      return this;
+    }
+
+    send(raw: string) {
+      const payload = JSON.parse(raw) as Record<string, unknown>;
+      sentPayloads.push(payload);
+
+      if (payload.msg === "connect") {
+        this.respond(JSON.stringify({ msg: "connected", session: "test-session" }));
+        return;
+      }
+
+      const result = responder(payload.method as string, (payload.params as unknown[] | undefined) ?? []);
+      const envelope =
+        payload.jsonrpc === "2.0"
+          ? { jsonrpc: "2.0", id: payload.id, result }
+          : { msg: "result", id: payload.id, result };
+      this.respond(JSON.stringify(envelope));
+    }
+
+    close() {
+      this.readyState = 3;
+    }
+
+    private respond(message: string) {
+      setTimeout(() => this.dispatch("message", message), 0);
+    }
+
+    private dispatch(event: string, ...args: unknown[]) {
+      // `off` replaces the array rather than mutating it, so iterating it directly is safe.
+      for (const listener of this.listeners[event] ?? []) listener(...args);
+    }
+  }
+
+  return {
+    FakeWebSocket,
+    sentPayloads,
+    constructedUrls,
+    failures,
+    setResponder: (fn: (method: string, params: unknown[]) => unknown) => {
+      responder = fn;
+    },
+  };
+});
+
+vi.mock("ws", () => ({ WebSocket: ws.FakeWebSocket }));
+vi.mock("@homarr/core/infrastructure/certificates", () => ({
+  getAllTrustedCertificatesAsync: vi.fn().mockResolvedValue([]),
+  getTrustedCertificateHostnamesAsync: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("@homarr/core/infrastructure/http", () => ({
+  createCustomCheckServerIdentity: () => () => undefined,
+}));
+
+import { TrueNasIntegration } from "../truenas-integration";
+
+const happyResponder = (method: string) => {
+  switch (method) {
+    case "auth.login":
+    case "auth.login_with_api_key":
+      return true;
+    case "system.info":
+      return {
+        version: "TrueNAS-SCALE-24.10",
+        hostname: "nas",
+        physmem: 16_000_000_000,
+        model: "Intel Xeon",
+        uptime_seconds: 3600,
+      };
+    case "reporting.get_data":
+      return [
+        {
+          name: "cpu",
+          identifier: "cpu",
+          aggregations: emptyAggregations(),
+          start: 0,
+          end: 1,
+          legend: [],
+          data: [[1000, 12]],
+        },
+        {
+          name: "memory",
+          identifier: "memory",
+          aggregations: emptyAggregations(),
+          start: 0,
+          end: 1,
+          legend: [],
+          data: [[1000, 8_000_000_000]],
+        },
+        {
+          name: "cputemp",
+          identifier: "cputemp",
+          aggregations: emptyAggregations(),
+          start: 0,
+          end: 1,
+          legend: [],
+          data: [[1000, 45]],
+        },
+      ];
+    case "pool.query":
+      return [{ name: "tank", status: "ONLINE", healthy: true, free: 500, size: 1000, allocated: 500 }];
+    case "interface.query":
+      return [{ id: "eth0", name: "eth0" }];
+    case "reporting.netdata_get_data":
+      return [{ name: "interface", identifier: "eth0", data: [[1000, 100, 200]] }];
+    default:
+      return null;
+  }
+};
+
+const emptyAggregations = () => ({ min: {}, mean: {}, max: {} });
+
+let integrationCounter = 0;
+const createIntegration = (decryptedSecrets: IntegrationSecret[]) =>
+  new TrueNasIntegration({
+    id: `truenas-${(integrationCounter += 1)}`,
+    name: "TrueNAS Test",
+    url: "https://truenas.local",
+    externalUrl: null,
+    decryptedSecrets,
+  });
+
+const credentials: IntegrationSecret[] = [
+  { kind: "username", value: "root" },
+  { kind: "password", value: "secret" },
+];
+
+describe("TrueNasIntegration", () => {
+  beforeEach(() => {
+    ws.sentPayloads.length = 0;
+    ws.constructedUrls.length = 0;
+    ws.failures.length = 0;
+    ws.setResponder(happyResponder);
+  });
+
+  test("fetches and maps system info over the JSON-RPC API", async () => {
+    const integration = createIntegration(credentials);
+
+    const result = await integration.getSystemInfoAsync();
+
+    expect(ws.constructedUrls).toContain("wss://truenas.local/api/current");
+    // JSON-RPC does not use the legacy "connect" session handshake.
+    expect(ws.sentPayloads.some((payload) => payload.msg === "connect")).toBe(false);
+
+    expect(result).toMatchObject({
+      version: "TrueNAS-SCALE-24.10",
+      cpuModelName: "Intel Xeon",
+      cpuTemp: 45,
+      memAvailableInBytes: 16_000_000_000,
+      memUsedInBytes: 8_000_000_000,
+      uptime: 3600,
+      rebootRequired: false,
+      availablePkgUpdates: 0,
+      loadAverage: null,
+      gpu: [],
+      network: { up: 20_000, down: 10_000 },
+      fileSystem: [{ deviceName: "tank", available: "1000", used: "500", percentage: 50 }],
+      smart: [{ deviceName: "tank", healthy: true, overallStatus: "ONLINE", temperature: null }],
+    });
+  });
+
+  test("authenticates with an API key when one is configured", async () => {
+    const integration = createIntegration([{ kind: "apiKey", value: "api-key-123" }]);
+
+    await integration.getSystemInfoAsync();
+
+    const authPayload = ws.sentPayloads.find((payload) => String(payload.method).startsWith("auth."));
+    expect(authPayload).toMatchObject({ method: "auth.login_with_api_key", params: ["api-key-123"] });
+  });
+
+  test("authenticates with username and password when no API key is configured", async () => {
+    const integration = createIntegration(credentials);
+
+    await integration.getSystemInfoAsync();
+
+    const authPayload = ws.sentPayloads.find((payload) => String(payload.method).startsWith("auth."));
+    expect(authPayload).toMatchObject({ method: "auth.login", params: ["root", "secret"] });
+  });
+
+  test("falls back to the legacy websocket API when the JSON-RPC endpoint is unavailable", async () => {
+    ws.failures.push({ path: "/api/current" });
+    const integration = createIntegration(credentials);
+
+    const result = await integration.getSystemInfoAsync();
+
+    expect(ws.constructedUrls).toContain("wss://truenas.local/api/current");
+    expect(ws.constructedUrls).toContain("wss://truenas.local/websocket");
+    // The legacy API requires the "connect" session handshake before authenticating.
+    expect(ws.sentPayloads[0]).toMatchObject({ msg: "connect" });
+    expect(ws.sentPayloads.find((payload) => String(payload.method).startsWith("auth."))).toMatchObject({
+      msg: "method",
+      method: "auth.login",
+    });
+    expect(result.version).toBe("TrueNAS-SCALE-24.10");
+  });
+
+  test("rejects when authentication is not successful", async () => {
+    ws.setResponder((method) => (method.startsWith("auth.") ? false : happyResponder(method)));
+    const integration = createIntegration(credentials);
+
+    await expect(integration.getSystemInfoAsync()).rejects.toThrow();
+  });
+
+  test("surfaces a self-signed certificate as a certificate request error without falling back", async () => {
+    ws.failures.push({ path: "/api/current", code: "DEPTH_ZERO_SELF_SIGNED_CERT" });
+    ws.failures.push({ path: "/websocket", code: "DEPTH_ZERO_SELF_SIGNED_CERT" });
+    const integration = createIntegration(credentials);
+
+    const error = await integration.getSystemInfoAsync().catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(IntegrationRequestError);
+    expect((error as IntegrationRequestError).cause).toMatchObject({ type: "certificate", reason: "untrusted" });
+    // A certificate failure is endpoint-independent, so the legacy API must not be tried.
+    expect(ws.constructedUrls).not.toContain("wss://truenas.local/websocket");
+  });
+});

--- a/packages/integrations/src/truenas/truenas-api.ts
+++ b/packages/integrations/src/truenas/truenas-api.ts
@@ -1,0 +1,50 @@
+export type TrueNasApiKind = "jsonRpc" | "legacy";
+
+export type TrueNasResponse = { result: unknown } | { error: unknown };
+
+export interface TrueNasApi {
+  kind: TrueNasApiKind;
+  /** Websocket path appended to the integration URL. */
+  path: `/${string}`;
+  /** The legacy DDP API requires a "connect" handshake before authentication, the JSON-RPC API does not. */
+  requiresSessionHandshake: boolean;
+  /** Builds the request envelope for a method call. */
+  buildRequest: (id: string, method: string, params: unknown[]) => Record<string, unknown>;
+  /**
+   * Returns the response payload when `message` is the reply to `id`,
+   * otherwise `undefined` so the caller keeps waiting for a later message.
+   */
+  matchResponse: (message: Record<string, unknown>, id: string) => TrueNasResponse | undefined;
+}
+
+/**
+ * JSON-RPC 2.0 API introduced in TrueNAS SCALE 24.10 (Electric Eel) and the
+ * legacy DDP-style websocket API used before it. Both expose the same
+ * middleware methods, so only the transport envelope differs.
+ * @see https://www.truenas.com/docs/api/scale_rest_api.html
+ * @see https://www.truenas.com/docs/api/scale_websocket_api.html#websocket_protocol
+ */
+export const trueNasApis = {
+  jsonRpc: {
+    kind: "jsonRpc",
+    path: "/api/current",
+    requiresSessionHandshake: false,
+    buildRequest: (id: string, method: string, params: unknown[]) => ({ jsonrpc: "2.0", id, method, params }),
+    matchResponse: (message: Record<string, unknown>, id: string) => {
+      if (message.id !== id || message.jsonrpc !== "2.0") return undefined;
+      if (message.error != null) return { error: message.error };
+      return { result: message.result };
+    },
+  },
+  legacy: {
+    kind: "legacy",
+    path: "/websocket",
+    requiresSessionHandshake: true,
+    buildRequest: (id: string, method: string, params: unknown[]) => ({ id, msg: "method", method, params }),
+    matchResponse: (message: Record<string, unknown>, id: string) => {
+      if (message.id !== id || message.msg !== "result") return undefined;
+      if (message.error != null) return { error: message.error };
+      return { result: message.result };
+    },
+  },
+} satisfies Record<TrueNasApiKind, TrueNasApi>;

--- a/packages/integrations/src/truenas/truenas-client.ts
+++ b/packages/integrations/src/truenas/truenas-client.ts
@@ -1,0 +1,315 @@
+import type { RawData } from "ws";
+import { WebSocket } from "ws";
+import z from "zod";
+
+import { createId } from "@homarr/common";
+import { matchErrorCode, RequestError, ResponseError } from "@homarr/common/server";
+import {
+  getAllTrustedCertificatesAsync,
+  getTrustedCertificateHostnamesAsync,
+} from "@homarr/core/infrastructure/certificates";
+import { createCustomCheckServerIdentity } from "@homarr/core/infrastructure/http";
+import { createLogger } from "@homarr/core/infrastructure/logs";
+
+import type { IntegrationTestingInput } from "../base/integration";
+import type { TrueNasApi } from "./truenas-api";
+import { trueNasApis } from "./truenas-api";
+
+const logger = createLogger({ module: "trueNasClient" });
+
+const REQUEST_TIMEOUT_MS = 5000;
+
+type CertificateOptions = IntegrationTestingInput["options"];
+
+export type TrueNasCredentials = { apiKey: string } | { username: string; password: string };
+
+/**
+ * Handles talking to a TrueNAS server: opening a websocket with Homarr's
+ * trusted certificates, negotiating the API variant, authenticating, and
+ * sending method requests. Connections are reused across the per-request
+ * integration instances and reconnected transparently when the server drops
+ * an idle socket.
+ */
+export class TrueNasClient {
+  // Keyed by integration id. The value is the in-flight connection promise so concurrent
+  // callers reuse a single socket instead of racing to open duplicates.
+  private static readonly connectionMap = new Map<string, Promise<TrueNasSocket>>();
+  private static readonly apiMap = new Map<string, TrueNasApi>();
+
+  constructor(
+    private readonly id: string,
+    private readonly webSocketUrl: (path: `/${string}`) => URL,
+    private readonly credentials: TrueNasCredentials,
+  ) {}
+
+  /** Sends an authenticated request, reusing the cached connection while it is open. */
+  public async requestAsync(method: string, params: unknown[] = []): Promise<unknown> {
+    const socket = await this.getSocketAsync();
+    return socket.requestAsync(method, params);
+  }
+
+  /**
+   * Opens a connection with the provided certificate options, authenticates,
+   * and closes it. Used by the connection test, which may run with updated
+   * credentials, so any cached connection is dropped and the API re-detected.
+   */
+  public async testAsync(certificate: CertificateOptions): Promise<void> {
+    this.evictConnection();
+    TrueNasClient.apiMap.delete(this.id);
+
+    const socket = await this.openSocketAsync(certificate);
+    try {
+      await this.authenticateAsync(socket);
+    } finally {
+      socket.close();
+    }
+  }
+
+  private getSocketAsync(): Promise<TrueNasSocket> {
+    let connection = TrueNasClient.connectionMap.get(this.id);
+    if (!connection) {
+      connection = this.connectAndAuthenticateAsync();
+      TrueNasClient.connectionMap.set(this.id, connection);
+
+      const evict = () => {
+        if (TrueNasClient.connectionMap.get(this.id) === connection) {
+          TrueNasClient.connectionMap.delete(this.id);
+        }
+      };
+      // Reconnect on the next request once this attempt fails or the server drops the socket.
+      connection.then((socket) => socket.onClose(evict), evict);
+    }
+
+    return connection;
+  }
+
+  private async connectAndAuthenticateAsync(): Promise<TrueNasSocket> {
+    const socket = await this.openSocketAsync(await resolveCertificateOptionsAsync());
+    try {
+      await this.authenticateAsync(socket);
+    } catch (error) {
+      // Never keep an unauthenticated socket, it would be reused without re-authenticating.
+      socket.close();
+      throw error;
+    }
+    return socket;
+  }
+
+  private evictConnection() {
+    const connection = TrueNasClient.connectionMap.get(this.id);
+    if (!connection) return;
+
+    TrueNasClient.connectionMap.delete(this.id);
+    connection.then((socket) => socket.close()).catch(() => undefined);
+  }
+
+  /**
+   * Connects using the JSON-RPC API (TrueNAS 24.10+) when available and falls
+   * back to the legacy websocket API otherwise. A missing JSON-RPC endpoint
+   * surfaces as a plain protocol error; certificate, connection, DNS and
+   * timeout errors are endpoint-independent and are never retried.
+   */
+  private async openSocketAsync(certificate: CertificateOptions): Promise<TrueNasSocket> {
+    const cachedApi = TrueNasClient.apiMap.get(this.id);
+    if (cachedApi) {
+      return openTrueNasSocketAsync(this.webSocketUrl(cachedApi.path), cachedApi, certificate);
+    }
+
+    try {
+      const socket = await openTrueNasSocketAsync(
+        this.webSocketUrl(trueNasApis.jsonRpc.path),
+        trueNasApis.jsonRpc,
+        certificate,
+      );
+      TrueNasClient.apiMap.set(this.id, trueNasApis.jsonRpc);
+      return socket;
+    } catch (error) {
+      if (error instanceof RequestError) throw error;
+
+      logger.debug("JSON-RPC API unavailable, falling back to the legacy websocket API", {
+        error: error instanceof Error ? error.message : undefined,
+      });
+      const socket = await openTrueNasSocketAsync(
+        this.webSocketUrl(trueNasApis.legacy.path),
+        trueNasApis.legacy,
+        certificate,
+      );
+      TrueNasClient.apiMap.set(this.id, trueNasApis.legacy);
+      return socket;
+    }
+  }
+
+  /**
+   * Authenticates with an API key when one is configured, otherwise with the
+   * username and password. Both methods work on either API.
+   * @see https://www.truenas.com/docs/api/scale_websocket_api.html#websocket_protocol
+   */
+  private async authenticateAsync(socket: TrueNasSocket): Promise<void> {
+    const response =
+      "apiKey" in this.credentials
+        ? await socket.requestAsync("auth.login_with_api_key", [this.credentials.apiKey])
+        : await socket.requestAsync("auth.login", [this.credentials.username, this.credentials.password]);
+
+    const success = await z.boolean().parseAsync(response);
+    if (!success) throw new ResponseError({ status: 401 });
+  }
+}
+
+/**
+ * Wraps a single websocket connection and speaks whichever TrueNAS API
+ * ({@link trueNasApis}) was negotiated when it was opened.
+ */
+class TrueNasSocket {
+  constructor(
+    private readonly webSocket: WebSocket,
+    private readonly api: TrueNasApi,
+  ) {}
+
+  public close() {
+    this.webSocket.close();
+  }
+
+  public onClose(listener: () => void) {
+    this.webSocket.once("close", listener);
+  }
+
+  /**
+   * The legacy DDP API requires a "connect" handshake to obtain a session
+   * before any method can be called.
+   * @see https://www.truenas.com/docs/api/scale_websocket_api.html#websocket_protocol
+   */
+  public registerSessionAsync(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const handler = (raw: RawData) => {
+        const message = parseMessage(raw);
+        if (message?.msg === "connected") {
+          this.webSocket.off("message", handler);
+          resolve();
+        } else if (message?.msg === "failed") {
+          this.webSocket.off("message", handler);
+          reject(new Error("Unable to establish TrueNAS session"));
+        }
+      };
+
+      this.webSocket.on("message", handler);
+      this.webSocket.send(JSON.stringify({ msg: "connect", version: "1", support: ["1"] }));
+    });
+  }
+
+  /**
+   * Sends a method request and resolves with its result. Rejects after
+   * {@link REQUEST_TIMEOUT_MS} when no matching response was received.
+   */
+  public requestAsync(method: string, params: unknown[] = []): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = createId();
+
+      const cleanup = () => {
+        clearTimeout(timeoutId);
+        this.webSocket.off("message", handler);
+        this.webSocket.off("close", onClose);
+        this.webSocket.off("error", onError);
+      };
+
+      const handler = (raw: RawData) => {
+        const message = parseMessage(raw);
+        if (!message) return;
+
+        const response = this.api.matchResponse(message, id);
+        if (!response) return;
+
+        cleanup();
+        if ("error" in response) {
+          reject(new Error(`TrueNAS method "${method}" failed: ${JSON.stringify(response.error)}`));
+          return;
+        }
+        logger.debug("Received method response", { id, method, api: this.api.kind });
+        resolve(response.result);
+      };
+
+      // A dropped connection would otherwise leave the request hanging until the timeout below.
+      const onClose = () => {
+        cleanup();
+        reject(
+          new RequestError(
+            { type: "connection", reason: "reset", code: "ECONNRESET" },
+            { cause: new Error("Connection closed before a response was received") },
+          ),
+        );
+      };
+      const onError = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+
+      const timeoutId = setTimeout(() => {
+        cleanup();
+        reject(
+          new RequestError(
+            {
+              type: "timeout",
+              reason: "aborted",
+              code: "ECONNABORTED",
+            },
+            { cause: new Error("Canceled request after 5 seconds") },
+          ),
+        );
+      }, REQUEST_TIMEOUT_MS);
+
+      this.webSocket.on("message", handler);
+      this.webSocket.once("close", onClose);
+      this.webSocket.once("error", onError);
+      logger.debug("Sending method request", { id, method, api: this.api.kind });
+      this.webSocket.send(JSON.stringify(this.api.buildRequest(id, method, params)));
+    });
+  }
+}
+
+/**
+ * Opens a websocket using Homarr's trusted certificates and performs the
+ * session handshake when the API requires it. TLS, connection, DNS and timeout
+ * failures are translated into {@link RequestError}s so the connection test can
+ * offer to trust a self-signed certificate, exactly like the HTTP integrations.
+ */
+const openTrueNasSocketAsync = async (
+  url: URL,
+  api: TrueNasApi,
+  certificate: CertificateOptions,
+): Promise<TrueNasSocket> => {
+  logger.debug("Connecting to TrueNAS websocket", { url: url.toString(), api: api.kind });
+
+  const webSocket = await new Promise<WebSocket>((resolve, reject) => {
+    const socket = new WebSocket(url, {
+      ca: certificate.ca,
+      // The @types/ws contract types this as returning a boolean, but ws forwards it to
+      // tls.connect which uses Node's `Error | undefined` contract that our helper follows.
+      checkServerIdentity: certificate.checkServerIdentity as never,
+    });
+
+    socket.once("open", () => resolve(socket));
+    socket.once("error", (error: Error & { code?: string }) => {
+      const matched = error.code ? matchErrorCode(error.code) : undefined;
+      reject(matched ? new RequestError(matched, { cause: error }) : error);
+    });
+  });
+
+  const socket = new TrueNasSocket(webSocket, api);
+  if (api.requiresSessionHandshake) await socket.registerSessionAsync();
+  return socket;
+};
+
+const resolveCertificateOptionsAsync = async (): Promise<CertificateOptions> => ({
+  ca: await getAllTrustedCertificatesAsync(),
+  checkServerIdentity: createCustomCheckServerIdentity(await getTrustedCertificateHostnamesAsync()),
+});
+
+const parseMessage = (raw: RawData): Record<string, unknown> | undefined => {
+  try {
+    const parsed: unknown = JSON.parse(raw.toString());
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};

--- a/packages/integrations/src/truenas/truenas-integration.ts
+++ b/packages/integrations/src/truenas/truenas-integration.ts
@@ -309,7 +309,7 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
 
     return {
       cpuUtilization: cpuData.reduce((acc, item) => acc + (item > 100 ? 0 : item), 0) / cpuData.length,
-      cpuTemp: Math.max(...cpuTempData.filter((_item, i) => i > 0)),
+      cpuTemp: Math.max(...cpuTempData.filter((_item, index) => index > 0)),
       memAvailableInBytes: systemInformation.physmem,
       memUsedInBytes: memoryData[1] ?? 0, // Index 0 is UNIX timestamp, Index 1 is free space in bytes
       fileSystem: datasets.map((dataset) => ({

--- a/packages/integrations/src/truenas/truenas-integration.ts
+++ b/packages/integrations/src/truenas/truenas-integration.ts
@@ -1,15 +1,6 @@
 import dayjs from "dayjs";
-import type { RawData } from "ws";
-import { WebSocket } from "ws";
 import z from "zod";
 
-import { createId } from "@homarr/common";
-import { matchErrorCode, RequestError, ResponseError } from "@homarr/common/server";
-import {
-  getAllTrustedCertificatesAsync,
-  getTrustedCertificateHostnamesAsync,
-} from "@homarr/core/infrastructure/certificates";
-import { createCustomCheckServerIdentity } from "@homarr/core/infrastructure/http";
 import { createLogger } from "@homarr/core/infrastructure/logs";
 
 import type { IntegrationTestingInput } from "../base/integration";
@@ -17,148 +8,80 @@ import { Integration } from "../base/integration";
 import type { TestingResult } from "../base/test-connection/test-connection-service";
 import type { ISystemHealthMonitoringIntegration } from "../interfaces/health-monitoring/health-monitoring-integration";
 import type { SystemHealthMonitoring } from "../interfaces/health-monitoring/health-monitoring-types";
-import type { TrueNasApi } from "./truenas-api";
-import { trueNasApis } from "./truenas-api";
+import type { TrueNasCredentials } from "./truenas-client";
+import { TrueNasClient } from "./truenas-client";
 
 const logger = createLogger({ module: "trueNasIntegration" });
 
 const NETWORK_MULTIPLIER = 100;
-const REQUEST_TIMEOUT_MS = 5000;
-
-type CertificateOptions = IntegrationTestingInput["options"];
 
 export class TrueNasIntegration extends Integration implements ISystemHealthMonitoringIntegration {
-  // Keyed by integration id and shared across the per-request integration instances. The value is
-  // the in-flight connection promise so concurrent callers reuse a single socket instead of racing.
-  private static readonly connectionMap = new Map<string, Promise<TrueNasSocket>>();
-  private static readonly apiMap = new Map<string, TrueNasApi>();
-
-  private wsUrl(path: `/${string}`) {
-    const url = super.url(path);
-    url.protocol = url.protocol.replace("http", "ws");
-    return url;
-  }
+  private client?: TrueNasClient;
 
   protected async testingAsync(input: IntegrationTestingInput): Promise<TestingResult> {
-    // A successful test may use new credentials, so drop any cached connection and detect the API afresh.
-    this.evictConnection();
-    TrueNasIntegration.apiMap.delete(this.integration.id);
-
-    const socket = await this.openSocketAsync(input.options);
-    try {
-      await this.authenticateAsync(socket);
-    } finally {
-      socket.close();
-    }
-
+    await this.getClient().testAsync(input.options);
     return { success: true };
   }
 
-  /**
-   * Returns an authenticated socket, reusing the cached connection while it is
-   * open. TrueNAS closes idle sockets, so the cache is evicted on close and the
-   * next caller transparently reconnects.
-   */
-  private getSocketAsync(): Promise<TrueNasSocket> {
-    const id = this.integration.id;
+  public async getSystemInfoAsync(): Promise<SystemHealthMonitoring> {
+    const systemInformation = await this.getSystemInformationAsync();
+    const reporting = await this.getReportingAsync();
 
-    let connection = TrueNasIntegration.connectionMap.get(id);
-    if (!connection) {
-      connection = this.connectAndAuthenticateAsync();
-      TrueNasIntegration.connectionMap.set(id, connection);
+    const cpuData = this.extractLatestReportingData(reporting, "cpu");
+    const cpuTempData = this.extractLatestReportingData(reporting, "cputemp");
+    const memoryData = this.extractLatestReportingData(reporting, "memory");
+    const datasets = await this.getPoolsAsync();
 
-      const evict = () => {
-        if (TrueNasIntegration.connectionMap.get(id) === connection) {
-          TrueNasIntegration.connectionMap.delete(id);
-        }
-      };
-      // Reconnect on the next request once this attempt fails or the server drops the socket.
-      connection.then((socket) => socket.onClose(evict), evict);
-    }
+    const netdata = await this.getReportingNetdataAsync();
 
-    return connection;
-  }
+    const upload = this.extractNetworkTrafficData(netdata, 2); // Index 2 is "sent"
+    const download = this.extractNetworkTrafficData(netdata, 1); // Index 1 is "received"
 
-  private async connectAndAuthenticateAsync(): Promise<TrueNasSocket> {
-    const socket = await this.openSocketAsync(await this.resolveCertificateOptionsAsync());
-    try {
-      await this.authenticateAsync(socket);
-    } catch (error) {
-      // Never keep an unauthenticated socket, it would be reused without re-authenticating.
-      socket.close();
-      throw error;
-    }
-    return socket;
-  }
-
-  private evictConnection() {
-    const id = this.integration.id;
-    const connection = TrueNasIntegration.connectionMap.get(id);
-    if (!connection) return;
-
-    TrueNasIntegration.connectionMap.delete(id);
-    connection.then((socket) => socket.close()).catch(() => undefined);
-  }
-
-  /**
-   * Connects using the JSON-RPC API (TrueNAS 24.10+) when available and falls
-   * back to the legacy websocket API otherwise. A missing JSON-RPC endpoint
-   * surfaces as a plain protocol error; certificate, connection, DNS and
-   * timeout errors are endpoint-independent and are never retried.
-   */
-  private async openSocketAsync(certificate: CertificateOptions): Promise<TrueNasSocket> {
-    const cachedApi = TrueNasIntegration.apiMap.get(this.integration.id);
-    if (cachedApi) {
-      return openTrueNasSocketAsync(this.wsUrl(cachedApi.path), cachedApi, certificate);
-    }
-
-    try {
-      const socket = await openTrueNasSocketAsync(
-        this.wsUrl(trueNasApis.jsonRpc.path),
-        trueNasApis.jsonRpc,
-        certificate,
-      );
-      TrueNasIntegration.apiMap.set(this.integration.id, trueNasApis.jsonRpc);
-      return socket;
-    } catch (error) {
-      if (error instanceof RequestError) throw error;
-
-      logger.debug("JSON-RPC API unavailable, falling back to the legacy websocket API", {
-        url: this.integration.url,
-        error: error instanceof Error ? error.message : undefined,
-      });
-      const socket = await openTrueNasSocketAsync(this.wsUrl(trueNasApis.legacy.path), trueNasApis.legacy, certificate);
-      TrueNasIntegration.apiMap.set(this.integration.id, trueNasApis.legacy);
-      return socket;
-    }
-  }
-
-  /**
-   * Authenticates with an API key when one is configured, otherwise with the
-   * username and password. Both methods work on either API.
-   * @see https://www.truenas.com/docs/api/scale_websocket_api.html#websocket_protocol
-   */
-  private async authenticateAsync(socket: TrueNasSocket): Promise<void> {
-    logger.debug("Authenticating", { url: this.integration.url });
-    const response = this.hasSecretValue("apiKey")
-      ? await socket.requestAsync("auth.login_with_api_key", [this.getSecretValue("apiKey")])
-      : await socket.requestAsync("auth.login", [this.getSecretValue("username"), this.getSecretValue("password")]);
-
-    const success = await z.boolean().parseAsync(response);
-    if (!success) throw new ResponseError({ status: 401 });
-    logger.debug("Authenticated successfully", { url: this.integration.url });
-  }
-
-  private async resolveCertificateOptionsAsync(): Promise<CertificateOptions> {
     return {
-      ca: await getAllTrustedCertificatesAsync(),
-      checkServerIdentity: createCustomCheckServerIdentity(await getTrustedCertificateHostnamesAsync()),
+      cpuUtilization: cpuData.reduce((acc, item) => acc + (item > 100 ? 0 : item), 0) / cpuData.length,
+      cpuTemp: Math.max(...cpuTempData.filter((_item, index) => index > 0)),
+      memAvailableInBytes: systemInformation.physmem,
+      memUsedInBytes: memoryData[1] ?? 0, // Index 0 is UNIX timestamp, Index 1 is free space in bytes
+      fileSystem: datasets.map((dataset) => ({
+        deviceName: dataset.name,
+        available: `${dataset.size}`, // TODO: can we use number instead of string here?
+        used: `${dataset.allocated}`,
+        percentage: (dataset.allocated / dataset.size) * 100,
+      })),
+      availablePkgUpdates: 0,
+      network: {
+        up: upload * NETWORK_MULTIPLIER,
+        down: download * NETWORK_MULTIPLIER,
+      },
+      loadAverage: null,
+      smart: datasets.map((dataset) => ({
+        deviceName: dataset.name,
+        healthy: dataset.healthy,
+        overallStatus: dataset.status,
+        temperature: null,
+      })),
+      uptime: systemInformation.uptime_seconds,
+      version: systemInformation.version,
+      cpuModelName: systemInformation.model,
+      rebootRequired: false,
+      gpu: [],
     };
   }
 
+  private getClient(): TrueNasClient {
+    return (this.client ??= this.createClient());
+  }
+
+  private createClient(): TrueNasClient {
+    const credentials: TrueNasCredentials = this.hasSecretValue("apiKey")
+      ? { apiKey: this.getSecretValue("apiKey") }
+      : { username: this.getSecretValue("username"), password: this.getSecretValue("password") };
+
+    return new TrueNasClient(this.integration.id, (path) => this.webSocketUrl(path), credentials);
+  }
+
   private async requestAsync(method: string, params: unknown[] = []): Promise<unknown> {
-    const socket = await this.getSocketAsync();
-    return socket.requestAsync(method, params);
+    return this.getClient().requestAsync(method, params);
   }
 
   private async getPoolsAsync() {
@@ -293,221 +216,18 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
     return result;
   }
 
-  public async getSystemInfoAsync(): Promise<SystemHealthMonitoring> {
-    const systemInformation = await this.getSystemInformationAsync();
-    const reporting = await this.getReportingAsync();
-
-    const cpuData = this.extractLatestReportingData(reporting, "cpu");
-    const cpuTempData = this.extractLatestReportingData(reporting, "cputemp");
-    const memoryData = this.extractLatestReportingData(reporting, "memory");
-    const datasets = await this.getPoolsAsync();
-
-    const netdata = await this.getReportingNetdataAsync();
-
-    const upload = this.extractNetworkTrafficData(netdata, 2); // Index 2 is "sent"
-    const download = this.extractNetworkTrafficData(netdata, 1); // Index 1 is "received"
-
-    return {
-      cpuUtilization: cpuData.reduce((acc, item) => acc + (item > 100 ? 0 : item), 0) / cpuData.length,
-      cpuTemp: Math.max(...cpuTempData.filter((_item, index) => index > 0)),
-      memAvailableInBytes: systemInformation.physmem,
-      memUsedInBytes: memoryData[1] ?? 0, // Index 0 is UNIX timestamp, Index 1 is free space in bytes
-      fileSystem: datasets.map((dataset) => ({
-        deviceName: dataset.name,
-        available: `${dataset.size}`, // TODO: can we use number instead of string here?
-        used: `${dataset.allocated}`,
-        percentage: (dataset.allocated / dataset.size) * 100,
-      })),
-      availablePkgUpdates: 0,
-      network: {
-        up: upload * NETWORK_MULTIPLIER,
-        down: download * NETWORK_MULTIPLIER,
-      },
-      loadAverage: null,
-      smart: datasets.map((dataset) => ({
-        deviceName: dataset.name,
-        healthy: dataset.healthy,
-        overallStatus: dataset.status,
-        temperature: null,
-      })),
-      uptime: systemInformation.uptime_seconds,
-      version: systemInformation.version,
-      cpuModelName: systemInformation.model,
-      rebootRequired: false,
-      gpu: [],
-    };
-  }
-
   private extractNetworkTrafficData = (data: z.infer<typeof reportingNetDataSchema>, index: 1 | 2) => {
     return data.reduce((acc, current) => acc + (current.data.at(-1)?.at(index) ?? 0), 0);
   };
 
-  private extractLatestReportingData(data: ReportingItem[], key: ReportingItem["identifier"]) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const dataObject = data.find((item) => item.identifier === key)!;
-    // TODO: check why the below sorting is done, because right now it compares number[] with number[]?
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return dataObject.data.sort((item1, item2) => (item1 > item2 ? -1 : 1))[0]!;
+  private extractLatestReportingData(data: ReportingItem[], identifier: ReportingItem["identifier"]) {
+    const item = data.find((reportingItem) => reportingItem.identifier === identifier);
+    // Reporting rows are [timestamp, ...values] in ascending time order, so the last row is the most recent reading.
+    const latest = item?.data.at(-1);
+    if (!latest) throw new Error(`TrueNAS returned no "${identifier}" reporting data`);
+    return latest;
   }
 }
-
-/**
- * Wraps a single websocket connection and speaks whichever TrueNAS API
- * ({@link trueNasApis}) was negotiated when it was opened.
- */
-class TrueNasSocket {
-  constructor(
-    private readonly webSocket: WebSocket,
-    private readonly api: TrueNasApi,
-  ) {}
-
-  public get isOpen() {
-    return this.webSocket.readyState === WebSocket.OPEN;
-  }
-
-  public close() {
-    this.webSocket.close();
-  }
-
-  public onClose(listener: () => void) {
-    this.webSocket.once("close", listener);
-  }
-
-  /**
-   * The legacy DDP API requires a "connect" handshake to obtain a session
-   * before any method can be called.
-   * @see https://www.truenas.com/docs/api/scale_websocket_api.html#websocket_protocol
-   */
-  public registerSessionAsync(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const handler = (raw: RawData) => {
-        const message = parseMessage(raw);
-        if (message?.msg === "connected") {
-          this.webSocket.off("message", handler);
-          resolve();
-        } else if (message?.msg === "failed") {
-          this.webSocket.off("message", handler);
-          reject(new Error("Unable to establish TrueNAS session"));
-        }
-      };
-
-      this.webSocket.on("message", handler);
-      this.webSocket.send(JSON.stringify({ msg: "connect", version: "1", support: ["1"] }));
-    });
-  }
-
-  /**
-   * Sends a method request and resolves with its result. Rejects after
-   * {@link REQUEST_TIMEOUT_MS} when no matching response was received.
-   */
-  public requestAsync(method: string, params: unknown[] = []): Promise<unknown> {
-    return new Promise((resolve, reject) => {
-      const id = createId();
-
-      const cleanup = () => {
-        clearTimeout(timeoutId);
-        this.webSocket.off("message", handler);
-        this.webSocket.off("close", onClose);
-        this.webSocket.off("error", onError);
-      };
-
-      const handler = (raw: RawData) => {
-        const message = parseMessage(raw);
-        if (!message) return;
-
-        const response = this.api.matchResponse(message, id);
-        if (!response) return;
-
-        cleanup();
-        if ("error" in response) {
-          reject(new Error(`TrueNAS method "${method}" failed: ${JSON.stringify(response.error)}`));
-          return;
-        }
-        logger.debug("Received method response", { id, method, api: this.api.kind });
-        resolve(response.result);
-      };
-
-      // A dropped connection would otherwise leave the request hanging until the timeout below.
-      const onClose = () => {
-        cleanup();
-        reject(
-          new RequestError(
-            { type: "connection", reason: "reset", code: "ECONNRESET" },
-            { cause: new Error("Connection closed before a response was received") },
-          ),
-        );
-      };
-      const onError = (error: Error) => {
-        cleanup();
-        reject(error);
-      };
-
-      const timeoutId = setTimeout(() => {
-        cleanup();
-        reject(
-          new RequestError(
-            {
-              type: "timeout",
-              reason: "aborted",
-              code: "ECONNABORTED",
-            },
-            { cause: new Error("Canceled request after 5 seconds") },
-          ),
-        );
-      }, REQUEST_TIMEOUT_MS);
-
-      this.webSocket.on("message", handler);
-      this.webSocket.once("close", onClose);
-      this.webSocket.once("error", onError);
-      logger.debug("Sending method request", { id, method, api: this.api.kind });
-      this.webSocket.send(JSON.stringify(this.api.buildRequest(id, method, params)));
-    });
-  }
-}
-
-/**
- * Opens a websocket using Homarr's trusted certificates and performs the
- * session handshake when the API requires it. TLS, connection, DNS and timeout
- * failures are translated into {@link RequestError}s so the connection test can
- * offer to trust a self-signed certificate, exactly like the HTTP integrations.
- */
-const openTrueNasSocketAsync = async (
-  url: URL,
-  api: TrueNasApi,
-  certificate: CertificateOptions,
-): Promise<TrueNasSocket> => {
-  logger.debug("Connecting to TrueNAS websocket", { url: url.toString(), api: api.kind });
-
-  const webSocket = await new Promise<WebSocket>((resolve, reject) => {
-    const socket = new WebSocket(url, {
-      ca: certificate.ca,
-      // The @types/ws contract types this as returning a boolean, but ws forwards it to
-      // tls.connect which uses Node's `Error | undefined` contract that our helper follows.
-      checkServerIdentity: certificate.checkServerIdentity as never,
-    });
-
-    socket.once("open", () => resolve(socket));
-    socket.once("error", (error: Error & { code?: string }) => {
-      const matched = error.code ? matchErrorCode(error.code) : undefined;
-      reject(matched ? new RequestError(matched, { cause: error }) : error);
-    });
-  });
-
-  const socket = new TrueNasSocket(webSocket, api);
-  if (api.requiresSessionHandshake) await socket.registerSessionAsync();
-  return socket;
-};
-
-const parseMessage = (raw: RawData): Record<string, unknown> | undefined => {
-  try {
-    const parsed: unknown = JSON.parse(raw.toString());
-    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : undefined;
-  } catch {
-    return undefined;
-  }
-};
 
 const reportingItemSchema = z.object({
   name: z.enum(["cpu", "memory", "cputemp"]),

--- a/packages/integrations/src/truenas/truenas-integration.ts
+++ b/packages/integrations/src/truenas/truenas-integration.ts
@@ -1,8 +1,15 @@
 import dayjs from "dayjs";
+import type { RawData } from "ws";
+import { WebSocket } from "ws";
 import z from "zod";
 
 import { createId } from "@homarr/common";
-import { RequestError, ResponseError } from "@homarr/common/server";
+import { matchErrorCode, RequestError, ResponseError } from "@homarr/common/server";
+import {
+  getAllTrustedCertificatesAsync,
+  getTrustedCertificateHostnamesAsync,
+} from "@homarr/core/infrastructure/certificates";
+import { createCustomCheckServerIdentity } from "@homarr/core/infrastructure/http";
 import { createLogger } from "@homarr/core/infrastructure/logs";
 
 import type { IntegrationTestingInput } from "../base/integration";
@@ -10,112 +17,152 @@ import { Integration } from "../base/integration";
 import type { TestingResult } from "../base/test-connection/test-connection-service";
 import type { ISystemHealthMonitoringIntegration } from "../interfaces/health-monitoring/health-monitoring-integration";
 import type { SystemHealthMonitoring } from "../interfaces/health-monitoring/health-monitoring-types";
+import type { TrueNasApi } from "./truenas-api";
+import { trueNasApis } from "./truenas-api";
 
 const logger = createLogger({ module: "trueNasIntegration" });
 
 const NETWORK_MULTIPLIER = 100;
+const REQUEST_TIMEOUT_MS = 5000;
+
+type CertificateOptions = IntegrationTestingInput["options"];
 
 export class TrueNasIntegration extends Integration implements ISystemHealthMonitoringIntegration {
-  private static webSocketMap = new Map<string, WebSocket>();
+  // Keyed by integration id and shared across the per-request integration instances. The value is
+  // the in-flight connection promise so concurrent callers reuse a single socket instead of racing.
+  private static readonly connectionMap = new Map<string, Promise<TrueNasSocket>>();
+  private static readonly apiMap = new Map<string, TrueNasApi>();
 
-  private wsUrl() {
-    const url = super.url("/websocket");
+  private wsUrl(path: `/${string}`) {
+    const url = super.url(path);
     url.protocol = url.protocol.replace("http", "ws");
     return url;
   }
 
-  private get webSocket() {
-    return TrueNasIntegration.webSocketMap.get(this.integration.id) ?? null;
-  }
+  protected async testingAsync(input: IntegrationTestingInput): Promise<TestingResult> {
+    // A successful test may use new credentials, so drop any cached connection and detect the API afresh.
+    this.evictConnection();
+    TrueNasIntegration.apiMap.delete(this.integration.id);
 
-  protected async testingAsync(_input: IntegrationTestingInput): Promise<TestingResult> {
-    const webSocket = await this.connectWebSocketAsync();
-    await this.registerSessionAsync(webSocket);
-    await this.authenticateWebSocketAsync(webSocket);
-
-    // Remove current socket connection so we can authenticate with updated credentials
-    TrueNasIntegration.webSocketMap.delete(this.integration.id);
+    const socket = await this.openSocketAsync(input.options);
+    try {
+      await this.authenticateAsync(socket);
+    } finally {
+      socket.close();
+    }
 
     return { success: true };
   }
 
   /**
-   * TrueNAS API uses WebSocket. This function connects to the socket
-   * and resolves the promise if the connection was successful.
-   * @see https://www.truenas.com/docs/api/scale_websocket_api.html
+   * Returns an authenticated socket, reusing the cached connection while it is
+   * open. TrueNAS closes idle sockets, so the cache is evicted on close and the
+   * next caller transparently reconnects.
    */
-  private async connectWebSocketAsync(): Promise<WebSocket> {
-    logger.debug("Connecting to websocket server", {
-      url: this.wsUrl(),
-    });
-    const webSocket = new WebSocket(this.wsUrl());
+  private getSocketAsync(): Promise<TrueNasSocket> {
+    const id = this.integration.id;
 
-    return new Promise((resolve, reject) => {
-      webSocket.onopen = () => {
-        logger.debug("Connected to websocket server", {
-          url: this.wsUrl(),
-        });
-        resolve(webSocket);
-      };
+    let connection = TrueNasIntegration.connectionMap.get(id);
+    if (!connection) {
+      connection = this.connectAndAuthenticateAsync();
+      TrueNasIntegration.connectionMap.set(id, connection);
 
-      webSocket.onerror = () => {
-        reject(new Error("Failed to connect"));
-      };
-    });
-  }
-
-  /**
-   * Before authentication, a session must be obtained from the server using the "connect" event.
-   * @see https://www.truenas.com/docs/api/scale_websocket_api.html#websocket_protocol
-   */
-  private async registerSessionAsync(webSocket: WebSocket): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const subscribe = (event: MessageEvent<string>) => {
-        const data = JSON.parse(event.data) as { msg: string };
-        if (data.msg === "connected") {
-          webSocket.removeEventListener("message", subscribe);
-          resolve();
-        } else if (data.msg === "failed") {
-          webSocket.removeEventListener("message", subscribe);
-          reject(new Error("Unable to establish connection"));
+      const evict = () => {
+        if (TrueNasIntegration.connectionMap.get(id) === connection) {
+          TrueNasIntegration.connectionMap.delete(id);
         }
       };
+      // Reconnect on the next request once this attempt fails or the server drops the socket.
+      connection.then((socket) => socket.onClose(evict), evict);
+    }
 
-      webSocket.addEventListener("message", subscribe);
-      webSocket.send(
-        JSON.stringify({
-          msg: "connect",
-          version: "1", // this must be number, not string
-          support: ["1"], // this must be number, not string
-        }),
-      );
-    });
+    return connection;
+  }
+
+  private async connectAndAuthenticateAsync(): Promise<TrueNasSocket> {
+    const socket = await this.openSocketAsync(await this.resolveCertificateOptionsAsync());
+    try {
+      await this.authenticateAsync(socket);
+    } catch (error) {
+      // Never keep an unauthenticated socket, it would be reused without re-authenticating.
+      socket.close();
+      throw error;
+    }
+    return socket;
+  }
+
+  private evictConnection() {
+    const id = this.integration.id;
+    const connection = TrueNasIntegration.connectionMap.get(id);
+    if (!connection) return;
+
+    TrueNasIntegration.connectionMap.delete(id);
+    connection.then((socket) => socket.close()).catch(() => undefined);
   }
 
   /**
-   * After a session was obtained, the session can be authenticated.
+   * Connects using the JSON-RPC API (TrueNAS 24.10+) when available and falls
+   * back to the legacy websocket API otherwise. A missing JSON-RPC endpoint
+   * surfaces as a plain protocol error; certificate, connection, DNS and
+   * timeout errors are endpoint-independent and are never retried.
+   */
+  private async openSocketAsync(certificate: CertificateOptions): Promise<TrueNasSocket> {
+    const cachedApi = TrueNasIntegration.apiMap.get(this.integration.id);
+    if (cachedApi) {
+      return openTrueNasSocketAsync(this.wsUrl(cachedApi.path), cachedApi, certificate);
+    }
+
+    try {
+      const socket = await openTrueNasSocketAsync(
+        this.wsUrl(trueNasApis.jsonRpc.path),
+        trueNasApis.jsonRpc,
+        certificate,
+      );
+      TrueNasIntegration.apiMap.set(this.integration.id, trueNasApis.jsonRpc);
+      return socket;
+    } catch (error) {
+      if (error instanceof RequestError) throw error;
+
+      logger.debug("JSON-RPC API unavailable, falling back to the legacy websocket API", {
+        url: this.integration.url,
+        error: error instanceof Error ? error.message : undefined,
+      });
+      const socket = await openTrueNasSocketAsync(this.wsUrl(trueNasApis.legacy.path), trueNasApis.legacy, certificate);
+      TrueNasIntegration.apiMap.set(this.integration.id, trueNasApis.legacy);
+      return socket;
+    }
+  }
+
+  /**
+   * Authenticates with an API key when one is configured, otherwise with the
+   * username and password. Both methods work on either API.
    * @see https://www.truenas.com/docs/api/scale_websocket_api.html#websocket_protocol
    */
-  private async authenticateWebSocketAsync(webSocket?: WebSocket): Promise<void> {
-    logger.debug("Authenticating with username and password", {
-      url: this.wsUrl(),
-    });
-    const response = await this.requestAsync(
-      "auth.login",
-      [this.getSecretValue("username"), this.getSecretValue("password")],
-      webSocket,
-    );
-    const result = await z.boolean().parseAsync(response);
-    if (!result) throw new ResponseError({ status: 401 });
-    logger.debug("Authenticated successfully with username and password", {
-      url: this.wsUrl(),
-    });
+  private async authenticateAsync(socket: TrueNasSocket): Promise<void> {
+    logger.debug("Authenticating", { url: this.integration.url });
+    const response = this.hasSecretValue("apiKey")
+      ? await socket.requestAsync("auth.login_with_api_key", [this.getSecretValue("apiKey")])
+      : await socket.requestAsync("auth.login", [this.getSecretValue("username"), this.getSecretValue("password")]);
+
+    const success = await z.boolean().parseAsync(response);
+    if (!success) throw new ResponseError({ status: 401 });
+    logger.debug("Authenticated successfully", { url: this.integration.url });
+  }
+
+  private async resolveCertificateOptionsAsync(): Promise<CertificateOptions> {
+    return {
+      ca: await getAllTrustedCertificatesAsync(),
+      checkServerIdentity: createCustomCheckServerIdentity(await getTrustedCertificateHostnamesAsync()),
+    };
+  }
+
+  private async requestAsync(method: string, params: unknown[] = []): Promise<unknown> {
+    const socket = await this.getSocketAsync();
+    return socket.requestAsync(method, params);
   }
 
   private async getPoolsAsync() {
-    logger.debug("Retrieving pools", {
-      url: this.wsUrl(),
-    });
+    logger.debug("Retrieving pools", { url: this.integration.url });
 
     const response = await this.requestAsync("pool.query", [
       [],
@@ -143,7 +190,7 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
       })
       .filter((pool) => pool !== null);
     logger.debug("Retrieved pools", {
-      url: this.wsUrl(),
+      url: this.integration.url,
       totalCount: result.length,
       activeCount: activePools.length,
     });
@@ -155,9 +202,7 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
    * @see https://www.truenas.com/docs/api/scale_websocket_api.html#reporting
    */
   private async getReportingAsync(): Promise<ReportingItem[]> {
-    logger.debug("Retrieving reporting data", {
-      url: this.wsUrl(),
-    });
+    logger.debug("Retrieving reporting data", { url: this.integration.url });
 
     const response = await this.requestAsync("reporting.get_data", [
       [
@@ -180,7 +225,7 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
     const result = await z.array(reportingItemSchema).parseAsync(response);
 
     logger.debug("Retrieved reporting data", {
-      url: this.wsUrl(),
+      url: this.integration.url,
       count: result.length,
     });
     return result;
@@ -191,9 +236,7 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
    * @see https://www.truenas.com/docs/core/13.0/api/core_websocket_api.html#interface
    */
   private async getNetworkInterfacesAsync(): Promise<z.infer<typeof networkInterfaceSchema>> {
-    logger.debug("Retrieving available network-interfaces", {
-      url: this.wsUrl(),
-    });
+    logger.debug("Retrieving available network-interfaces", { url: this.integration.url });
 
     const response = await this.requestAsync("interface.query", [
       [], // no filters
@@ -202,7 +245,7 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
     const result = await networkInterfaceSchema.parseAsync(response);
 
     logger.debug("Retrieved available network-interfaces", {
-      url: this.wsUrl(),
+      url: this.integration.url,
       count: result.length,
     });
     return result;
@@ -215,9 +258,7 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
   private async getReportingNetdataAsync(): Promise<z.infer<typeof reportingNetDataSchema>> {
     const networkInterfaces = await this.getNetworkInterfacesAsync();
 
-    logger.debug("Retrieving reporting network data", {
-      url: this.wsUrl(),
-    });
+    logger.debug("Retrieving reporting network data", { url: this.integration.url });
 
     const response = await this.requestAsync("reporting.netdata_get_data", [
       networkInterfaces.map((networkInterface) => ({
@@ -232,7 +273,7 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
     const result = await reportingNetDataSchema.parseAsync(response);
 
     logger.debug("Retrieved reporting-network-data", {
-      url: this.wsUrl(),
+      url: this.integration.url,
       count: result.length,
     });
     return result;
@@ -243,16 +284,12 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
    * @see https://www.truenas.com/docs/api/scale_websocket_api.html#system
    */
   private async getSystemInformationAsync(): Promise<z.infer<typeof systemInfoSchema>> {
-    logger.debug("Retrieving system-information", {
-      url: this.wsUrl(),
-    });
+    logger.debug("Retrieving system-information", { url: this.integration.url });
 
     const response = await this.requestAsync("system.info");
     const result = await systemInfoSchema.parseAsync(response);
 
-    logger.debug("Retrieved system-information", {
-      url: this.wsUrl(),
-    });
+    logger.debug("Retrieved system-information", { url: this.integration.url });
     return result;
   }
 
@@ -301,78 +338,7 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
     };
   }
 
-  /**
-   * Send a request through websocket and return response
-   * Times out after 5 seconds when no response was received.
-   * @param method json-rpc method to call
-   * @param params array of parameters
-   * @param webSocketOverride override of webSocket, helpful for not storing the connection
-   * @returns result of json-rpc call
-   */
-  private async requestAsync(method: string, params: unknown[] = [], webSocketOverride?: WebSocket) {
-    let webSocket = webSocketOverride ?? this.webSocket;
-    if (webSocket?.readyState !== WebSocket.OPEN) {
-      logger.debug("Connecting to websocket", {
-        url: this.wsUrl(),
-      });
-      // We can only land here with static webSocket
-      webSocket = await this.connectWebSocketAsync();
-      await this.registerSessionAsync(webSocket);
-
-      TrueNasIntegration.webSocketMap.set(this.integration.id, webSocket);
-      await this.authenticateWebSocketAsync();
-    }
-
-    return await new Promise((resolve, reject) => {
-      const id = createId();
-      const handler = (event: MessageEvent<string>) => {
-        const data = JSON.parse(event.data) as Record<string, unknown>;
-        if (data.msg !== "result") return;
-        if (data.id !== id) return;
-
-        clearTimeout(timeoutId);
-        webSocket.removeEventListener("message", handler);
-        logger.debug("Received method response", {
-          id,
-          method,
-          url: this.wsUrl(),
-        });
-        resolve(data.result);
-      };
-      const timeoutId = setTimeout(() => {
-        webSocket.removeEventListener("message", handler);
-        reject(
-          new RequestError(
-            {
-              type: "timeout",
-              reason: "aborted",
-              code: "ECONNABORTED",
-            },
-            { cause: new Error("Canceled request after 5 seconds") },
-          ),
-        );
-      }, 5000);
-
-      webSocket.addEventListener("message", handler);
-
-      logger.debug("Sending method request", {
-        id,
-        method,
-        url: this.wsUrl(),
-      });
-
-      webSocket.send(
-        JSON.stringify({
-          id,
-          msg: "method",
-          method,
-          params,
-        }),
-      );
-    });
-  }
-
-  private extractNetworkTrafficData = (data: z.infer<typeof reportingNetDataSchema>, index = 1 | 2) => {
+  private extractNetworkTrafficData = (data: z.infer<typeof reportingNetDataSchema>, index: 1 | 2) => {
     return data.reduce((acc, current) => acc + (current.data.at(-1)?.at(index) ?? 0), 0);
   };
 
@@ -384,6 +350,164 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
     return dataObject.data.sort((item1, item2) => (item1 > item2 ? -1 : 1))[0]!;
   }
 }
+
+/**
+ * Wraps a single websocket connection and speaks whichever TrueNAS API
+ * ({@link trueNasApis}) was negotiated when it was opened.
+ */
+class TrueNasSocket {
+  constructor(
+    private readonly webSocket: WebSocket,
+    private readonly api: TrueNasApi,
+  ) {}
+
+  public get isOpen() {
+    return this.webSocket.readyState === WebSocket.OPEN;
+  }
+
+  public close() {
+    this.webSocket.close();
+  }
+
+  public onClose(listener: () => void) {
+    this.webSocket.once("close", listener);
+  }
+
+  /**
+   * The legacy DDP API requires a "connect" handshake to obtain a session
+   * before any method can be called.
+   * @see https://www.truenas.com/docs/api/scale_websocket_api.html#websocket_protocol
+   */
+  public registerSessionAsync(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const handler = (raw: RawData) => {
+        const message = parseMessage(raw);
+        if (message?.msg === "connected") {
+          this.webSocket.off("message", handler);
+          resolve();
+        } else if (message?.msg === "failed") {
+          this.webSocket.off("message", handler);
+          reject(new Error("Unable to establish TrueNAS session"));
+        }
+      };
+
+      this.webSocket.on("message", handler);
+      this.webSocket.send(JSON.stringify({ msg: "connect", version: "1", support: ["1"] }));
+    });
+  }
+
+  /**
+   * Sends a method request and resolves with its result. Rejects after
+   * {@link REQUEST_TIMEOUT_MS} when no matching response was received.
+   */
+  public requestAsync(method: string, params: unknown[] = []): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = createId();
+
+      const cleanup = () => {
+        clearTimeout(timeoutId);
+        this.webSocket.off("message", handler);
+        this.webSocket.off("close", onClose);
+        this.webSocket.off("error", onError);
+      };
+
+      const handler = (raw: RawData) => {
+        const message = parseMessage(raw);
+        if (!message) return;
+
+        const response = this.api.matchResponse(message, id);
+        if (!response) return;
+
+        cleanup();
+        if ("error" in response) {
+          reject(new Error(`TrueNAS method "${method}" failed: ${JSON.stringify(response.error)}`));
+          return;
+        }
+        logger.debug("Received method response", { id, method, api: this.api.kind });
+        resolve(response.result);
+      };
+
+      // A dropped connection would otherwise leave the request hanging until the timeout below.
+      const onClose = () => {
+        cleanup();
+        reject(
+          new RequestError(
+            { type: "connection", reason: "reset", code: "ECONNRESET" },
+            { cause: new Error("Connection closed before a response was received") },
+          ),
+        );
+      };
+      const onError = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+
+      const timeoutId = setTimeout(() => {
+        cleanup();
+        reject(
+          new RequestError(
+            {
+              type: "timeout",
+              reason: "aborted",
+              code: "ECONNABORTED",
+            },
+            { cause: new Error("Canceled request after 5 seconds") },
+          ),
+        );
+      }, REQUEST_TIMEOUT_MS);
+
+      this.webSocket.on("message", handler);
+      this.webSocket.once("close", onClose);
+      this.webSocket.once("error", onError);
+      logger.debug("Sending method request", { id, method, api: this.api.kind });
+      this.webSocket.send(JSON.stringify(this.api.buildRequest(id, method, params)));
+    });
+  }
+}
+
+/**
+ * Opens a websocket using Homarr's trusted certificates and performs the
+ * session handshake when the API requires it. TLS, connection, DNS and timeout
+ * failures are translated into {@link RequestError}s so the connection test can
+ * offer to trust a self-signed certificate, exactly like the HTTP integrations.
+ */
+const openTrueNasSocketAsync = async (
+  url: URL,
+  api: TrueNasApi,
+  certificate: CertificateOptions,
+): Promise<TrueNasSocket> => {
+  logger.debug("Connecting to TrueNAS websocket", { url: url.toString(), api: api.kind });
+
+  const webSocket = await new Promise<WebSocket>((resolve, reject) => {
+    const socket = new WebSocket(url, {
+      ca: certificate.ca,
+      // The @types/ws contract types this as returning a boolean, but ws forwards it to
+      // tls.connect which uses Node's `Error | undefined` contract that our helper follows.
+      checkServerIdentity: certificate.checkServerIdentity as never,
+    });
+
+    socket.once("open", () => resolve(socket));
+    socket.once("error", (error: Error & { code?: string }) => {
+      const matched = error.code ? matchErrorCode(error.code) : undefined;
+      reject(matched ? new RequestError(matched, { cause: error }) : error);
+    });
+  });
+
+  const socket = new TrueNasSocket(webSocket, api);
+  if (api.requiresSessionHandshake) await socket.registerSessionAsync();
+  return socket;
+};
+
+const parseMessage = (raw: RawData): Record<string, unknown> | undefined => {
+  try {
+    const parsed: unknown = JSON.parse(raw.toString());
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 const reportingItemSchema = z.object({
   name: z.enum(["cpu", "memory", "cputemp"]),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1767,6 +1767,9 @@ importers:
       undici:
         specifier: 'catalog:'
         version: 7.24.6
+      ws:
+        specifier: 'catalog:'
+        version: 8.21.0
       xml2js:
         specifier: 'catalog:'
         version: 0.6.2
@@ -1780,6 +1783,9 @@ importers:
       '@types/node-unifi':
         specifier: 'catalog:'
         version: 2.5.1(patch_hash=5e6ae51e2a17a7f9729bfa30b0eb3d0842a5810ac6db47603ab4a6efa1ed84c5)
+      '@types/ws':
+        specifier: 'catalog:'
+        version: 8.18.1
       '@types/xml2js':
         specifier: 'catalog:'
         version: 0.4.14
@@ -10571,7 +10577,7 @@ snapshots:
       eventemitter2: 6.4.9
       http-cookie-agent: 6.0.8(tough-cookie@5.1.2)(undici@7.24.6)
       tough-cookie: 5.1.2
-      ws: 8.20.1
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - debug


### PR DESCRIPTION
## Summary

The TrueNAS integration could not connect to current TrueNAS installs. Two root causes:

1. **Self-signed certificates were never trusted.** The integration opened a raw `WebSocket` that performed default TLS verification with no access to Homarr's trusted certificates, so the handshake failed against the default TrueNAS self-signed certificate (close `1006`). The underlying `WebSocket` also swallowed the TLS error, so the existing "trust this certificate" prompt never fired.
2. **Only the legacy DDP `/websocket` protocol was supported.** TrueNAS 24.10+ moved to a JSON-RPC 2.0 API (`/api/current`) and is removing the legacy protocol, so newer versions could not be reached.

## Changes

- Connect with the `ws` client so the socket carries Homarr's trusted CA and custom `checkServerIdentity`, exactly like the HTTP integrations. TLS failures now map to a certificate request error, so the existing "trust certificate" flow works for TrueNAS.
- Speak both the JSON-RPC 2.0 API (`/api/current`, TrueNAS 24.10+) and the legacy `/websocket` API, auto-detecting per server (JSON-RPC first, legacy fallback). Certificate, connection, DNS, and timeout errors are endpoint-independent and are never retried against the other API.
- Add API key authentication (`auth.login_with_api_key`) as an alternative to username/password — the method recommended for recent TrueNAS versions and one that does not depend on the removed `auxiliary_administrator` group.
- Harden the connection lifecycle: in-flight connection de-duplication so concurrent callers share one socket, eviction on close, sockets cached only after successful authentication, and per-request close/error handling so a dropped socket fails fast instead of waiting out the timeout.

## Testing

- Unit tests covering protocol envelope/response matching (JSON-RPC and legacy), auto-detection and fallback, auth-method selection, and certificate-error mapping.
- Verified live against a real **TrueNAS 25.04** server with **both username/password and an API key** - each authenticates over auto-detected JSON-RPC 2.0 with the self-signed certificate trusted, and returns valid pool, CPU, memory, and network data.
- `tsc --noEmit`, `oxlint`, and `oxfmt` are clean on the touched packages.

> Verified on 25.04; 25.10 was not available to test, but JSON-RPC is the API 25.10 requires. The integration documentation was also updated to recommend API key authentication in https://github.com/homarr-labs/documentation/pull/559

---

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [ ] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

Closes #4206
