### PR TITLE
fix(image-proxy): use ArrayBuffer instead of Blob to prevent OOM on Node v24

### DIFF
--- a/packages/image-proxy/src/index.ts
+++ b/packages/image-proxy/src/index.ts
@@ -10,6 +10,8 @@ import { createGetSetChannel } from "@homarr/redis";
 
 const logger = createLogger({ module: "imageProxy" });
 
+export const IMAGE_PROXY_REDIS_TTL_SECONDS = 86400;
+
 const createHmacChannel = (hmac: `${string}.${string}`) => createGetSetChannel<string>(`image-proxy:hmac:${hmac}`);
 const createUrlByIdChannel = (id: string) =>
   createGetSetChannel<{
@@ -45,7 +47,7 @@ export class ImageProxy {
     return this.createImageUrl(id);
   }
 
-  public async forwardImageAsync(id: string): Promise<Blob | null> {
+  public async forwardImageAsync(id: string): Promise<ArrayBuffer | null> {
     const urlAndHeaders = await this.getImageUrlAndHeadersAsync(id);
     if (!urlAndHeaders) {
       return null;
@@ -69,16 +71,16 @@ export class ImageProxy {
       return null;
     }
 
-    const blob = (await response.blob()) as Blob;
+    const arrayBuffer = await response.arrayBuffer();
     logger.debug("Forwarding image succeeded", {
       id,
       url: this.redactUrl(urlAndHeaders.url),
       headers: this.redactHeaders(urlAndHeaders.headers),
       proxyUrl,
-      size: `${(blob.size / 1024).toFixed(1)}KB`,
+      size: `${(arrayBuffer.byteLength / 1024).toFixed(1)}KB`,
     });
 
-    return blob;
+    return arrayBuffer;
   }
 
   private createImageUrl(id: string): string {
@@ -113,11 +115,14 @@ export class ImageProxy {
 
     const hashChannel = createHmacChannel(`${urlHash}.${headerHash}`);
     const urlHeaderChannel = createUrlByIdChannel(id);
-    await urlHeaderChannel.setAsync({
-      url: encryptSecret(url),
-      headers: encryptSecret(JSON.stringify(headers ?? null)),
-    });
-    await hashChannel.setAsync(id);
+    await urlHeaderChannel.setAsync(
+      {
+        url: encryptSecret(url),
+        headers: encryptSecret(JSON.stringify(headers ?? null)),
+      },
+      { ttlSeconds: IMAGE_PROXY_REDIS_TTL_SECONDS },
+    );
+    await hashChannel.setAsync(id, { ttlSeconds: IMAGE_PROXY_REDIS_TTL_SECONDS });
 
     logger.debug("Stored image in the proxy", {
       id,

--- a/packages/redis/src/lib/channel.ts
+++ b/packages/redis/src/lib/channel.ts
@@ -112,9 +112,13 @@ export const createGetSetChannel = <TData>(name: string) => {
     /**
      * Set data in the channel
      * @param data data to be stored in the channel
+     * @param options optional TTL in seconds
      */
-    setAsync: async (data: TData) => {
+    setAsync: async (data: TData, options?: { ttlSeconds?: number }) => {
       await getSetClient.set(name, superjson.stringify(data));
+      if (options?.ttlSeconds) {
+        await getSetClient.expire(name, options.ttlSeconds);
+      }
     },
     /**
      * Remove data from the channel


### PR DESCRIPTION
## Summary

Fixes #5831 — Homarr container OOM / unbounded memory growth.

On Node v24, `new Response(blob)` internally calls `Blob.prototype.stream()` which **never releases the backing ArrayBuffer memory**, even after GC. Every image-proxy request leaked ~0.75 MB permanently.

<img width="986" height="658" alt="CleanShot 2026-06-11 at 00 28 06" src="https://github.com/user-attachments/assets/030d483a-5cbe-41fd-bcfa-514d5474994c" />


**This PR:**
- Changes `forwardImageAsync()` to use `response.arrayBuffer()` instead of `response.blob()`
- Adds 24h TTL to image-proxy Redis keys (previously infinite)
- Adds optional `{ ttlSeconds }` parameter to `createGetSetChannel.setAsync` (backward-compatible)

### Upstream references
- https://github.com/nodejs/node/issues/60482 — memory regression Node 24 vs 22
- https://github.com/nodejs/node/issues/42264 — blob.stream() memory behavior

## Diff

**2 files changed, 19 insertions, 10 deletions.**

## Test plan

<details>
<summary><strong>Reproduce the leak locally (standalone script, no server needed)</strong></summary>

Save this as `scripts/image-proxy-leak-confirm.mts` and run with:

```bash
NODE_OPTIONS='--expose-gc' npx tsx scripts/image-proxy-leak-confirm.mts
```

> **Warning:** This will consume ~24 GB of real RAM on the leak path. Reduce `TOTAL` if you have less than 32 GB. You can Ctrl+C once you've seen enough.

```typescript
import { randomBytes } from "node:crypto";

const BLOB_SIZE = 768 * 1024;
const TOTAL = 32_000; // 32k × 0.75 MB ≈ 24 GB retained on leak path
const LOG_EVERY = 200;

function formatMB(bytes: number): string {
  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
}

function gc(): void {
  global.gc?.();
}

function bar(fraction: number, width = 40): string {
  const filled = Math.round(fraction * width);
  return "█".repeat(filled) + "░".repeat(width - filled);
}

async function runPath(name: string, buildResponse: (blob: Blob) => Promise<Response>): Promise<number> {
  console.log(`\n  ${name}`);
  console.log(`  ${"─".repeat(70)}`);

  gc();
  const baseline = process.memoryUsage().arrayBuffers;
  let peak = 0;

  for (let i = 1; i <= TOTAL; i++) {
    const blob = new Blob([randomBytes(BLOB_SIZE)]);
    const res = await buildResponse(blob);
    await res.arrayBuffer();

    if (i % LOG_EVERY === 0 || i === TOTAL) {
      gc();
      gc();
      const current = process.memoryUsage().arrayBuffers;
      const delta = current - baseline;
      if (delta > peak) peak = delta;

      const progress = i / TOTAL;
      const calls = String(i).padStart(6);
      const mem = formatMB(delta).padStart(10);

      process.stdout.write(`\r  ${bar(progress)} ${calls}/${TOTAL}  arrayBuffers: ${mem}`);
    }
  }

  gc();
  gc();
  const finalDelta = process.memoryUsage().arrayBuffers - baseline;
  process.stdout.write("\n");
  console.log(`  peak: ${formatMB(peak)}  final: ${formatMB(finalDelta)}`);
  return finalDelta;
}

console.log(`\n  Node ${process.version} | gc: ${typeof global.gc === "function"} | blob: ${formatMB(BLOB_SIZE)} | calls: ${TOTAL.toLocaleString()}\n`);

const leakDelta = await runPath("LEAK:  new Response(blob)", async (blob) => new Response(blob));
const fixDelta = await runPath("FIXED: new Response(await blob.arrayBuffer())", async (blob) => new Response(await blob.arrayBuffer()));

console.log(`\n  ${"─".repeat(70)}`);
console.log(`  LEAK retained:  ${formatMB(leakDelta)}`);
console.log(`  FIX  retained:  ${formatMB(fixDelta)}`);
console.log(`  Ratio:          ${(leakDelta / Math.max(fixDelta, 1)).toFixed(0)}x`);
console.log();
```

**Expected output (Node v24.16.0):**

```
LEAK retained:  24000.75 MB
FIX  retained:  2.25 MB
Ratio:          10667x
```

</details>

<details>
<summary><strong>Run the vitest memory regression tests</strong></summary>

Save these files locally and run:

```bash
NODE_OPTIONS='--expose-gc' pnpm exec vitest run --coverage.enabled=false \
  packages/image-proxy/src/test/memory-regression.spec.ts
```

For the extreme ~1GB variant:

```bash
EXTREME_MEMORY_TEST=1 NODE_OPTIONS='--expose-gc' pnpm exec vitest run --coverage.enabled=false \
  packages/image-proxy/src/test/memory-regression.spec.ts
```

Test files are available on the `experiments/try-fix-leak` branch.

</details>

<details>
<summary><strong>Verify Redis TTL</strong></summary>

After running a dev instance:

```bash
redis-cli --scan --pattern 'image-proxy:*' | head -5 | while read key; do
  echo "$key TTL=$(redis-cli TTL "$key")"
done
```

Should show `TTL=86400` (24h) instead of `-1` (infinite).

</details>

## Results

| Metric | Before (Blob) | After (ArrayBuffer) |
|--------|--------------|---------------------|
| Memory per call | 0.75 MB retained permanently | 0 MB retained |
| 32k calls | **24 GB** leaked | **2.25 MB** total |
| Ratio | — | **10,667x improvement** |
| Redis key TTL | infinite (`-1`) | 24h (`86400`) |