### PR TITLE
fix(db): crash on MySQL — replace onConflictDoNothing with dialect-neutral pre-filter

### DIFF
--- a/packages/db/migrations/seed.ts
+++ b/packages/db/migrations/seed.ts
@@ -647,9 +647,13 @@ const seedDemoUserAsync = async (db: Database) => {
 
 const seedDefaultCustomWidgetsAsync = async (db: Database) => {
   const seedIds = CUSTOM_WIDGET_SEEDS.map((s) => s.id);
-  const beforeCount = await db.$count(customWidgetDefinitions, inArray(customWidgetDefinitions.id, seedIds));
+  const existing = await db.query.customWidgetDefinitions.findMany({
+    columns: { id: true },
+    where: inArray(customWidgetDefinitions.id, seedIds),
+  });
+  const existingIds = new Set(existing.map((row) => row.id));
 
-  const seedValues = CUSTOM_WIDGET_SEEDS.map((seed) => {
+  const seedValues = CUSTOM_WIDGET_SEEDS.filter((seed) => !existingIds.has(seed.id)).map((seed) => {
     const parsed = customWidgetImportSchema.parse(seed.data);
     return {
       id: seed.id,
@@ -668,22 +672,14 @@ const seedDefaultCustomWidgetsAsync = async (db: Database) => {
     };
   });
 
-  if (seedValues.length === 0) return;
-
-  await db
-    .insert(customWidgetDefinitions)
-    .values(seedValues)
-    .onConflictDoNothing({ target: customWidgetDefinitions.id });
-
-  const afterCount = await db.$count(customWidgetDefinitions, inArray(customWidgetDefinitions.id, seedIds));
-  const createdCount = afterCount - beforeCount;
-
-  if (createdCount === 0) {
+  if (seedValues.length === 0) {
     console.log("Skipping seeding of default custom widgets as they already exist");
     return;
   }
 
-  console.log(`Created ${createdCount} default custom widgets through seeding process`);
+  await db.insert(customWidgetDefinitions).values(seedValues);
+
+  console.log(`Created ${seedValues.length} default custom widgets through seeding process`);
 };
 
 const seedBoardWidgetsAsync = async (db: Database) => {


### PR DESCRIPTION
## Summary

Fixes a startup crash affecting all MySQL/MariaDB installations introduced in **v1.65.0** by #5889. The new `seedDefaultCustomWidgetsAsync` routine called `.onConflictDoNothing()`, a method that only exists on Drizzle's SQLite and Postgres insert builders. On the MySQL dialect the insert builder has no such method, so the migration threw and the container aborted on startup.

Closes #5967

## Problem

```
Migration failed TypeError: db2.insert(...).values(...).onConflictDoNothing is not a function
    at seedDefaultCustomWidgetsAsync (.../migrate.cjs:86839:65)
    at async seedDataAsync (.../migrate.cjs:86382:3)
    at async migrateAsync (.../migrate.cjs:86878:3)
ERROR: DB migrations failed, aborting startup
```

- `onConflictDoNothing` is part of `drizzle-orm/sqlite-core` and `drizzle-orm/pg-core` only.
- The MySQL equivalent is `onDuplicateKeyUpdate`, which has different semantics.
- Because the seed runs through the same code path for all three drivers, MySQL installs hit the missing method and the whole migration aborted — no UI ever came up.

## Fix

Replaced the dialect-specific `.onConflictDoNothing({ target })` call with a **dialect-neutral pre-filter** that:

1. Queries the existing widget IDs once (`db.query.customWidgetDefinitions.findMany` + `inArray`).
2. Filters `CUSTOM_WIDGET_SEEDS` to only the rows whose `id` is **not** already present.
3. Performs a plain `db.insert(...).values(...)` — no conflict resolution required at all.

This mirrors the existing count-first/skip pattern used by every other seed function in the same file (`seedEveryoneGroupAsync`, `seedDefaultAppsAsync`, `seedDefaultIntegrationsAsync`, etc.) and keeps a single code path across SQLite / MySQL / Postgres — no `isMysql()` dialect branch is needed.

I deliberately chose pre-filtering over the `isMysql() → onDuplicateKeyUpdate({ set: { id: sql\`id\` } })` no-op-update trick because:

- It's consistent with the rest of the seed module.
- A single code path is easier to reason about and test.
- No reliance on a side-effecting "no-op update" idiom that future readers would have to puzzle out.

## Verification

**1. Reproduced the crash locally** against a fresh MySQL container (via `@testcontainers/mysql`), running migrations + seed:

```
TypeError: db.insert(...).values(...).onConflictDoNothing is not a function
    at seedDefaultCustomWidgetsAsync (packages/db/migrations/seed.ts:676)
```

Confirmed identical to the issue's stack trace before applying the fix.

**2. Verified the fix end-to-end** with the same containerized MySQL:

- ✅ Migration + seed completes successfully.
- ✅ All 4 default custom widgets are created (`"Created 4 default custom widgets through seeding process"`).
- ✅ Idempotency: a second seed run against the same database correctly skips with `"Skipping seeding of default custom widgets as they already exist"` — no errors, no duplicate rows.

**3. Quality gates:**

- ✅ `tsc --noEmit` (packages/db) — clean.
- ✅ `oxlint` — clean (only pre-existing `SuperJSON.stringify` warnings unrelated to this change).
- ✅ Existing `packages/db/test/mysql-migration.spec.ts` — passes.

## Risk

- **Low.** Behavior on SQLite/Postgres is unchanged: the seed still only inserts rows whose `id` is not already present (previously via `onConflictDoNothing`, now via pre-filter).
- Idempotency is preserved — re-running the seed on an already-seeded DB is a no-op for the custom widgets table.
- No schema, migration, or query changes outside `seedDefaultCustomWidgetsAsync`.

## Checklist

- [x] Reproduced the reported bug locally
- [x] Confirmed fix resolves it (migration + seed succeeds on MySQL)
- [x] Verified idempotency (re-run skips correctly)
- [x] Typecheck passes
- [x] Lint passes
- [x] No new dependencies
