### PR TITLE
fix(auth): isolate session cookies from other Auth.js apps on same host

### DIFF
--- a/apps/docs/docs/advanced/single-sign-on/index.mdx
+++ b/apps/docs/docs/advanced/single-sign-on/index.mdx
@@ -23,6 +23,7 @@ Homarr supports multiple authentication options, from internal userbase (credent
 | AUTH_PROVIDERS             | Select Which provider to use between *credentials*, *ldap* and *oidc*. <br /> Multiple providers can be enabled with by separating them with `,`, (ex. `AUTH_PROVIDERS=credentials,oidc`, it is highly recommended to just enable one provider).  |  credentials  |
 | AUTH_LOGOUT_REDIRECT_URL  | URL to redirect to after clicking logging out.  | --- |
 | AUTH_SESSION_EXPIRY_TIME  | Time for the session to time out. Can be set as pure number, which will automatically be used in seconds, or followed by s, m, h or d for seconds, minutes, hours or days. (ex: "30m") | "30d"  |
+| AUTH_COOKIE_PREFIX  | Prefix used for all authentication cookies (session, csrf, callback, pkce, state, nonce). Change this if you run another Auth.js/NextAuth app on the same hostname as Homarr (browsers scope cookies by host, not by port) to avoid cookie name collisions. Only letters, numbers, hyphens and underscores are allowed. | `homarr`  |
 
 <Tabs>
   <TabItem value="credentials" label="Credentials Provider" default>

--- a/apps/docs/docs/getting-started/installation/helm.md
+++ b/apps/docs/docs/getting-started/installation/helm.md
@@ -395,6 +395,7 @@ All available values are listed on the [artifacthub](https://artifacthub.io/pack
 | env.AUTH_LDAP_USERNAME_FILTER_EXTRA_ARG | string | `nil` | Extra arguments for user search filter (& based) |
 | env.AUTH_LDAP_USER_MAIL_ATTRIBUTE | string | `"mail"` | Attribute used for mail field |
 | env.AUTH_LOGOUT_REDIRECT_URL | string | `nil` | URL to redirect to after clicking logging out. |
+| env.AUTH_COOKIE_PREFIX | string | `"homarr"` | Prefix used for all authentication cookies. Change if you run another Auth.js/NextAuth app on the same hostname to avoid cookie name collisions. Only letters, numbers, hyphens and underscores. |
 | env.AUTH_OIDC_AUTO_LOGIN | string | `"false"` | Automatically redirect to OIDC login |
 | env.AUTH_OIDC_CLIENT_NAME | string | `"OIDC"` | Display name of provider (in login screen) |
 | env.AUTH_OIDC_GROUPS_ATTRIBUTE | string | `"groups"` | Attribute used for groups (roles) claim |

--- a/packages/auth/configuration.ts
+++ b/packages/auth/configuration.ts
@@ -20,6 +20,24 @@ import { expireDateAfter, generateSessionToken, sessionTokenCookieName } from ".
 
 const logger = createLogger({ module: "authConfiguration" });
 
+// All Auth.js cookies are prefixed with AUTH_COOKIE_PREFIX (default "homarr") so
+// Homarr's cookie jar is isolated from any other Auth.js/NextAuth app on the
+// same hostname (browsers scope cookies by host, not by port).
+// See https://github.com/homarr-labs/homarr/issues/5773
+const createCookies = (useSecureCookies: boolean) => {
+  const prefix = env.AUTH_COOKIE_PREFIX;
+  const securePrefix = useSecureCookies ? "__Secure-" : "";
+  const hostPrefix = useSecureCookies ? "__Host-" : "";
+  return {
+    sessionToken: { name: sessionTokenCookieName },
+    csrfToken: { name: `${hostPrefix}${prefix}.csrf-token` },
+    callbackUrl: { name: `${securePrefix}${prefix}.callback-url` },
+    pkceCodeVerifier: { name: `${securePrefix}${prefix}.pkce.cooldown` },
+    state: { name: `${securePrefix}${prefix}.state` },
+    nonce: { name: `${securePrefix}${prefix}.nonce` },
+  };
+};
+
 // See why it's unknown in the [...nextauth]/route.ts file
 export const createConfiguration = (
   provider: SupportedAuthProvider | "unknown",
@@ -41,11 +59,7 @@ export const createConfiguration = (
       },
     },
     trustHost: true,
-    cookies: {
-      sessionToken: {
-        name: sessionTokenCookieName,
-      },
-    },
+    cookies: createCookies(useSecureCookies),
     adapter,
     providers: filterProviders([
       Credentials(createCredentialsConfiguration(db)),

--- a/packages/auth/env.ts
+++ b/packages/auth/env.ts
@@ -28,6 +28,11 @@ export const env = createEnv({
     AUTH_LOGOUT_REDIRECT_URL: z.string().url().optional(),
     AUTH_SESSION_EXPIRY_TIME: createDurationSchema("30d"),
     AUTH_PROVIDERS: authProvidersSchema,
+    AUTH_COOKIE_PREFIX: z
+      .string()
+      .min(1)
+      .regex(/^[a-zA-Z0-9-_]+$/, "AUTH_COOKIE_PREFIX must only contain letters, numbers, hyphens and underscores")
+      .default("homarr"),
     ...(authProviders.includes("oidc")
       ? {
           AUTH_OIDC_ISSUER: z.string().url(),

--- a/packages/auth/session.ts
+++ b/packages/auth/session.ts
@@ -4,9 +4,11 @@ import { generateSecureRandomToken } from "@homarr/common/server";
 import type { Database } from "@homarr/db";
 
 import { getCurrentUserPermissionsAsync } from "./callbacks";
+import { env } from "./env";
 
-// Default of authjs
-export const sessionTokenCookieName = "authjs.session-token";
+// Prefixed (AUTH_COOKIE_PREFIX, default "homarr") to avoid cookie collisions
+// with other Auth.js apps on the same host. See https://github.com/homarr-labs/homarr/issues/5773
+export const sessionTokenCookieName = `${env.AUTH_COOKIE_PREFIX}.session-token`;
 
 export const expireDateAfter = (seconds: number) => {
   return new Date(Date.now() + seconds * 1000);


### PR DESCRIPTION
Closes #5773

## Problem

Browsers scope cookies by **hostname, not by port**. When an iframe widget in Homarr loads another Auth.js/NextAuth app running on the same host IP (different port — e.g. PEANUT), the embedded app's `Set-Cookie` headers land in the same cookie jar as Homarr's. Because Homarr used Auth.js's default cookie names (`authjs.session-token`, `__Host-authjs.csrf-token`, ...), the embedded app overwrote Homarr's session cookie, causing `board.saveBoard` to fail with `TRPCError: UNAUTHORIZED` and a silent logout on refresh.

Nothing in the UI hints that the iframe caused the problem — the user just sees an opaque error and gets logged out on refresh. Multi-app same-host setups are the default in the self-hosting community.

## Fix

Add a new `AUTH_COOKIE_PREFIX` env var (default `homarr`) that prefixes **every** Auth.js cookie, isolating Homarr's cookie jar from any other Auth.js app on the same hostname:

| cookie | before | after (HTTP) | after (HTTPS) |
| --- | --- | --- | --- |
| session | `authjs.session-token` | `homarr.session-token` | `homarr.session-token` |
| csrf | `authjs.csrf-token` | `homarr.csrf-token` | `__Host-homarr.csrf-token` |
| callback | `authjs.callback-url` | `homarr.callback-url` | `__Secure-homarr.callback-url` |
| pkce | `authjs.pkce.cooldown` | `homarr.pkce.cooldown` | `__Secure-homarr.pkce.cooldown` |
| state | `authjs.state` | `homarr.state` | `__Secure-homarr.state` |
| nonce | `authjs.nonce` | `homarr.nonce` | `__Secure-homarr.nonce` |

The `__Secure-` / `__Host-` prefixes Auth.js applies for HTTPS deployments are preserved.

Multiple Homarr instances on the same host can set distinct `AUTH_COOKIE_PREFIX` values.

## Breaking change

Changing the session cookie name logs out every user **once** on upgrade (their old `authjs.session-token` cookie is no longer read). Users simply need to sign in again. This is unavoidable for fixing the collision.

## Files

- `packages/auth/env.ts` — new `AUTH_COOKIE_PREFIX` env var (validated `^[a-zA-Z0-9-_]+$`)
- `packages/auth/session.ts` — `sessionTokenCookieName` now `${AUTH_COOKIE_PREFIX}.session-token`
- `packages/auth/configuration.ts` — `createCookies()` overrides all Auth.js cookies
- `apps/docs/docs/advanced/single-sign-on/index.mdx` — env var doc row
- `apps/docs/docs/getting-started/installation/helm.md` — helm values row

## Verification

- `pnpm turbo typecheck --filter=@homarr/auth --force` ✅
- `pnpm turbo typecheck --filter=@homarr/websocket --filter=@homarr/api` ✅
- `pnpm lint` ✅ (0 errors)

## Notes

- `@homarr/auth` is only imported server-side at runtime (api routes, websocket, cli); every client import is `import type` only, so the module-load env read in `session.ts` is safe.
- No regression test added — `packages/auth/test/session.spec.ts` is pre-existing broken under the repo's jsdom vitest environment (several `@homarr/common` / `@homarr/core` modules read server-side env vars at module load). Flagged for a separate cleanup.