### PR TITLE
fix(integrations): make Emby Studios field optional

### DIFF
--- a/packages/integrations/src/emby/emby-integration.ts
+++ b/packages/integrations/src/emby/emby-integration.ts
@@ -38,7 +38,7 @@ const itemSchema = z.object({
   ServerId: z.string(),
   Name: z.string(),
   Taglines: z.array(z.string()),
-  Studios: z.array(z.object({ Name: z.string() })),
+  Studios: z.array(z.object({ Name: z.string() })).optional(),
   Overview: z.string().optional(),
   PremiereDate: z
     .string()
@@ -172,7 +172,7 @@ export class EmbyIntegration extends Integration implements IMediaServerIntegrat
         poster: super.externalUrl(`/Items/${item.Id}/Images/Primary?maxHeight=492&maxWidth=328&quality=90`).toString(),
         backdrop: super.externalUrl(`/Items/${item.Id}/Images/Backdrop/0?maxWidth=960&quality=70`).toString(),
       },
-      producer: item.Studios.at(0)?.Name,
+      producer: item.Studios?.at(0)?.Name,
       rating: item.CommunityRating?.toFixed(1),
       tags: item.Genres,
       href: super.externalUrl(`/web/index.html#!/item?id=${item.Id}&serverId=${item.ServerId}`).toString(),


### PR DESCRIPTION
## Summary

Makes the Emby integration parser resilient to items that omit the `Studios` field, fixing the Emby "Media Releases" widget which currently fails to load entirely. `Studios` in the Zod `itemSchema` becomes `.optional()`, and the consumer reads `item.Studios?.at(0)?.Name`, so `producer` resolves to `undefined` when `Studios` is absent instead of throwing. This mirrors the existing Jellyfin integration, which already handles the field optionally.

## Why this matters

The Emby "Media Releases" widget fails with `TRPCClientError: Failed to parse integration data`. The maintainer posted the underlying Zod error: `Invalid input: expected array, received undefined at "[1].Studios"`. Emby returns items where `Studios` is omitted (undefined) rather than sent as an empty array, but `itemSchema` declares `Studios` as a required array, so `z.array(itemSchema).parse(...)` throws on the first item that lacks the field and breaks the entire widget. Because the failure happens during array parsing, a single item without `Studios` takes down all releases. The "Current media server streams" item is unaffected since it uses a different code path.

## Changes

- `Studios` in `itemSchema` is now `.optional()`.
- The consuming map reads `item.Studios?.at(0)?.Name` instead of `item.Studios.at(0)?.Name`.

## Testing

- Populated `Studios` array: still parses, `producer` resolves to the first studio name.
- `Studios` omitted (the reported failure): parses successfully, `producer` is `undefined`.
- Empty `Studios: []`: parses, `producer` is `undefined`.
- Mixed response where some items lack `Studios`: the full array parses instead of failing on the first offending item.

Verified locally with the repo's own tooling: `oxfmt --check` clean, `oxlint` clean, `tsc --noEmit` on `packages/integrations` reports no errors.

Fixes #5624

---

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).
