### PR TITLE
fix(downloads): sort stalled torrents last when sorting by finish time

### DIFF
--- a/packages/widgets/src/downloads/component.tsx
+++ b/packages/widgets/src/downloads/component.tsx
@@ -529,6 +529,16 @@ export default function DownloadClientsWidget({
       },
       {
         ...columnsDefBase({ key: "time", showHeader: true }),
+        sortingFn: (rowA, rowB) => {
+          const timeA = rowA.getValue<ExtendedDownloadClientItem["time"]>("time");
+          const timeB = rowB.getValue<ExtendedDownloadClientItem["time"]>("time");
+          // Map time values to canonical sort keys:
+          // positive = ETA in ms (sort as-is, smaller = sooner)
+          // 0 = stalled/infinite (sort last in ascending = Infinity)
+          // negative = time since completion in ms (sort first in ascending = very negative)
+          const toSortKey = (time: number) => (time === 0 ? Infinity : time);
+          return toSortKey(timeA) - toSortKey(timeB);
+        },
         Cell: ({ cell }) => {
           const time = cell.getValue<ExtendedDownloadClientItem["time"]>();
           return time === 0 ? <IconInfinity size={16} /> : <Text size="xs">{dayjs().add(time).fromNow()}</Text>;


### PR DESCRIPTION
**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [ ] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

---

## Summary

The download client widget sorts the finish time column incorrectly for stalled torrents. The `time` field uses the convention: positive = ETA in ms, `0` = stalled/infinite, negative = time since completion in ms. Raw numeric comparison places `0` between negative and positive values, so stalled torrents appear in the middle of the sorted list instead of at the end.

This adds a custom `sortingFn` to the `time` column definition that maps `0` to `Infinity`, so stalled torrents sort last in ascending order (completing-soon first, active next, stalled last) and first in descending order. Completed items (negative time values) continue to sort by recency. No other columns or behaviors are affected.

Fixes #5416
