### PR TITLE
fix(widgets): correct TrueNAS memory/pool display and certificate trust button

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/integrations/_components/test-connection/test-connection-certificate.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/integrations/_components/test-connection/test-connection-certificate.tsx
@@ -131,6 +131,7 @@ export const CertificateErrorDetails = ({ error, url }: CertificateErrorDetailsP
       {(error.data.reason === "untrusted" && rootCertificate.isSelfSigned) ||
       error.data.reason === "hostnameMismatch" ? (
         <Button
+          type="button"
           variant="default"
           fullWidth
           onClick={error.data.reason === "hostnameMismatch" ? handleTrustHostname : handleTrustSelfSigned}
@@ -140,6 +141,7 @@ export const CertificateErrorDetails = ({ error, url }: CertificateErrorDetailsP
       ) : null}
       {error.data.reason === "untrusted" && !rootCertificate.isSelfSigned ? (
         <Button
+          type="button"
           variant="default"
           fullWidth
           onClick={() =>

--- a/packages/integrations/src/truenas/test/truenas-integration.spec.ts
+++ b/packages/integrations/src/truenas/test/truenas-integration.spec.ts
@@ -132,8 +132,9 @@ const happyResponder = (method: string) => {
           aggregations: emptyAggregations(),
           start: 0,
           end: 1,
-          legend: [],
-          data: [[1000, 8_000_000_000]],
+          // The "memory" graph reports available (free) memory: legend is ["time", "available"].
+          legend: ["time", "available"],
+          data: [[1000, 6_000_000_000]],
         },
         {
           name: "cputemp",
@@ -194,15 +195,17 @@ describe("TrueNasIntegration", () => {
       version: "TrueNAS-SCALE-24.10",
       cpuModelName: "Intel Xeon",
       cpuTemp: 45,
-      memAvailableInBytes: 16_000_000_000,
-      memUsedInBytes: 8_000_000_000,
+      // physmem (16 GB) minus the reported available 6 GB leaves 10 GB used.
+      memAvailableInBytes: 6_000_000_000,
+      memUsedInBytes: 10_000_000_000,
       uptime: 3600,
       rebootRequired: false,
       availablePkgUpdates: 0,
       loadAverage: null,
       gpu: [],
       network: { up: 20_000, down: 10_000 },
-      fileSystem: [{ deviceName: "tank", available: "1000", used: "500", percentage: 50 }],
+      // `available` is the free space left on the pool (free = 500), not its total size.
+      fileSystem: [{ deviceName: "tank", available: "500", used: "500", percentage: 50 }],
       smart: [{ deviceName: "tank", healthy: true, overallStatus: "ONLINE", temperature: null }],
     });
   });

--- a/packages/integrations/src/truenas/truenas-integration.ts
+++ b/packages/integrations/src/truenas/truenas-integration.ts
@@ -37,14 +37,19 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
     const upload = this.extractNetworkTrafficData(netdata, 2); // Index 2 is "sent"
     const download = this.extractNetworkTrafficData(netdata, 1); // Index 1 is "received"
 
+    // The "memory" reporting graph reports available (free) memory, its legend is ["time", "available"].
+    // Used memory is therefore the physical total minus what is still available (clamped against timing skew).
+    const memAvailableInBytes = memoryData[1] ?? 0; // Index 0 is the UNIX timestamp, Index 1 is available bytes
+    const memUsedInBytes = Math.max(systemInformation.physmem - memAvailableInBytes, 0);
+
     return {
       cpuUtilization: cpuData.reduce((acc, item) => acc + (item > 100 ? 0 : item), 0) / cpuData.length,
       cpuTemp: Math.max(...cpuTempData.filter((_item, index) => index > 0)),
-      memAvailableInBytes: systemInformation.physmem,
-      memUsedInBytes: memoryData[1] ?? 0, // Index 0 is UNIX timestamp, Index 1 is free space in bytes
+      memAvailableInBytes,
+      memUsedInBytes,
       fileSystem: datasets.map((dataset) => ({
         deviceName: dataset.name,
-        available: `${dataset.size}`, // TODO: can we use number instead of string here?
+        available: `${dataset.free}`, // free space left on the pool
         used: `${dataset.allocated}`,
         percentage: (dataset.allocated / dataset.size) * 100,
       })),

--- a/packages/integrations/src/unraid/unraid-integration.ts
+++ b/packages/integrations/src/unraid/unraid-integration.ts
@@ -59,8 +59,8 @@ export class UnraidIntegration extends Integration implements ISystemHealthMonit
       cpuTemp: undefined, // Not implemented, see https://github.com/unraid/api/issues/1597
       fileSystem: systemInfo.array.disks.map((disk) => ({
         deviceName: disk.name,
-        used: humanFileSize(disk.fsUsed * 1024), // API is in KiB (kibibytes), covert to bytes
-        available: `${disk.size * 1024}`, // API is in KiB (kibibytes), covert to bytes
+        used: humanFileSize(disk.fsUsed * 1024), // API is in KiB (kibibytes), convert to bytes
+        available: `${(disk.size - disk.fsUsed) * 1024}`, // free space left on the disk, API is in KiB (kibibytes)
         percentage: (disk.fsUsed / disk.size) * 100, // The units are the same, therefore the actual unit is irrelevant
       })),
       smart: systemInfo.array.disks.map((disk) => ({

--- a/packages/widgets/src/health-monitoring/index.ts
+++ b/packages/widgets/src/health-monitoring/index.ts
@@ -95,6 +95,12 @@ export const { definition, componentLoader } = createWidgetDefinition("healthMon
             return !integrationKinds.includes("proxmox");
           },
         },
+        defaultTab: {
+          shouldHide(_, integrationKinds) {
+            // The system/cluster tabs only render for Proxmox, so the default tab choice does nothing otherwise
+            return !integrationKinds.includes("proxmox");
+          },
+        },
       },
     );
   },

--- a/packages/widgets/src/health-monitoring/system-health.tsx
+++ b/packages/widgets/src/health-monitoring/system-health.tsx
@@ -13,7 +13,6 @@ import {
   Progress,
   Stack,
   Text,
-  Tooltip,
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import {
@@ -33,6 +32,7 @@ import duration from "dayjs/plugin/duration";
 
 import { clientApi } from "@homarr/api/client";
 import { useRequiredBoard } from "@homarr/boards/context";
+import { humanFileSize } from "@homarr/common";
 import type { TranslationFunction } from "@homarr/translation";
 import { useI18n } from "@homarr/translation/client";
 
@@ -91,7 +91,7 @@ export const SystemHealthMonitoring = ({
 
   return (
     <Stack h="100%" gap="sm" className="health-monitoring">
-      {healthData.map(({ integrationId, integrationName, healthInfo, updatedAt }) => {
+      {healthData.map(({ integrationId, integrationName, healthInfo }) => {
         const disksData = matchFileSystemAndSmart(healthInfo.fileSystem, healthInfo.smart);
         const memoryUsage = formatMemoryUsage(healthInfo.memAvailableInBytes, healthInfo.memUsedInBytes);
         return (
@@ -196,11 +196,6 @@ export const SystemHealthMonitoring = ({
                   <GpuRing key={gpu.gpuId} gpu={gpu} isTiny={isTiny} fahrenheit={options.fahrenheit} />
                 ))}
             </Flex>
-            {
-              <Text className="health-monitoring-status-update-time" c="dimmed" size="xs" ta="center">
-                {t("widget.healthMonitoring.popover.lastSeen", { lastSeen: dayjs(updatedAt).fromNow() })}
-              </Text>
-            }
             {options.fileSystem &&
               disksData.map((disk) => {
                 return (
@@ -214,7 +209,7 @@ export const SystemHealthMonitoring = ({
                     radius={board.itemRadius}
                     p="xs"
                   >
-                    <Stack gap="sm">
+                    <Stack gap="xs">
                       <Group
                         className="health-monitoring-disk-status"
                         justify="space-between"
@@ -228,14 +223,16 @@ export const SystemHealthMonitoring = ({
                             {disk.deviceName}
                           </Text>
                         </Group>
-                        <Group gap={4} wrap="nowrap">
-                          <IconTemperature className="health-monitoring-disk-temperature-icon" size="1rem" />
-                          <Text className="health-monitoring-disk-temperature-value" size="xs">
-                            {options.fahrenheit
-                              ? `${(disk.temperature * 1.8 + 32).toFixed(1)}°F`
-                              : `${disk.temperature}°C`}
-                          </Text>
-                        </Group>
+                        {disk.temperature !== null && (
+                          <Group gap={4} wrap="nowrap">
+                            <IconTemperature className="health-monitoring-disk-temperature-icon" size="1rem" />
+                            <Text className="health-monitoring-disk-temperature-value" size="xs">
+                              {options.fahrenheit
+                                ? `${(disk.temperature * 1.8 + 32).toFixed(1)}°F`
+                                : `${disk.temperature}°C`}
+                            </Text>
+                          </Group>
+                        )}
                         <Group gap={4} wrap="nowrap">
                           <IconFileReport className="health-monitoring-disk-status-icon" size="1rem" />
                           <Text className="health-monitoring-disk-status-value" size="xs">
@@ -243,37 +240,26 @@ export const SystemHealthMonitoring = ({
                           </Text>
                         </Group>
                       </Group>
-                      <Progress.Root className="health-monitoring-disk-use" radius={board.itemRadius} h="md">
-                        <Tooltip label={disk.used}>
-                          <Progress.Section
-                            value={disk.percentage}
-                            color={progressColor(disk.percentage)}
-                            className="health-monitoring-disk-use-percentage"
-                          >
-                            <Progress.Label className="health-monitoring-disk-use-value" fz="xs">
-                              {t("widget.healthMonitoring.popover.used")}
-                            </Progress.Label>
-                          </Progress.Section>
-                        </Tooltip>
-
-                        <Tooltip
-                          label={
-                            Number(disk.available) / 1024 ** 4 >= 1
-                              ? `${(Number(disk.available) / 1024 ** 4).toFixed(2)} TiB`
-                              : `${(Number(disk.available) / 1024 ** 3).toFixed(2)} GiB`
-                          }
-                        >
-                          <Progress.Section
-                            className="health-monitoring-disk-available-percentage"
-                            value={100 - disk.percentage}
-                            color="default"
-                          >
-                            <Progress.Label className="health-monitoring-disk-available-value" fz="xs">
-                              {t("widget.healthMonitoring.popover.available")}
-                            </Progress.Label>
-                          </Progress.Section>
-                        </Tooltip>
+                      <Progress.Root className="health-monitoring-disk-use" radius={board.itemRadius} size="lg">
+                        <Progress.Section
+                          value={disk.percentage}
+                          color={progressColor(disk.percentage)}
+                          className="health-monitoring-disk-use-percentage"
+                        />
+                        <Progress.Section
+                          className="health-monitoring-disk-available-percentage"
+                          value={100 - disk.percentage}
+                          color="default"
+                        />
                       </Progress.Root>
+                      <Group justify="space-between" gap={8} wrap="nowrap">
+                        <Text className="health-monitoring-disk-use-value" size="xs" c="dimmed">
+                          {t("widget.healthMonitoring.popover.used")} {formatFileSize(disk.used)}
+                        </Text>
+                        <Text className="health-monitoring-disk-available-value" size="xs" c="dimmed">
+                          {formatFileSize(disk.available)} {t("widget.healthMonitoring.popover.available")}
+                        </Text>
+                      </Group>
                     </Stack>
                   </Card>
                 );
@@ -307,6 +293,13 @@ export const progressColor = (percentage: number) => {
   else return "red";
 };
 
+// Some integrations report file sizes as raw bytes (e.g. TrueNAS, Glances) while others pre-format
+// them (e.g. Unraid, dashdot). Format the former and pass the latter through untouched.
+const formatFileSize = (value: string) => {
+  const bytes = Number(value);
+  return Number.isFinite(bytes) ? humanFileSize(Math.round(bytes)) : value;
+};
+
 interface FileSystem {
   deviceName: string;
   used: string;
@@ -331,7 +324,7 @@ export const matchFileSystemAndSmart = (fileSystems: FileSystem[], smartData: Sm
         used: fileSystem.used,
         available: fileSystem.available,
         percentage: fileSystem.percentage,
-        temperature: smartDisk?.temperature ?? 0,
+        temperature: smartDisk?.temperature ?? null,
         overallStatus: smartDisk?.overallStatus ?? "",
       };
     })

--- a/packages/widgets/src/system-disks/component.tsx
+++ b/packages/widgets/src/system-disks/component.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Box, Card, Group, Stack, useMantineColorScheme } from "@mantine/core";
+import { useEffect, useRef, useState } from "react";
+import { Box, Card, Group, Stack, Tooltip, useMantineColorScheme } from "@mantine/core";
 
 import { clientApi } from "@homarr/api/client";
 import { useRequiredBoard } from "@homarr/boards/context";
@@ -31,16 +32,96 @@ const getDisplayText = (item: { used: string; available: string; percentage: num
   }
 };
 
+interface SystemDiskCardProps {
+  deviceName: string;
+  percentage: number;
+  displayText: string;
+  temperature: number | null | undefined;
+  healthy: boolean;
+  showBackgroundBar: boolean;
+}
+
+const SystemDiskCard = ({
+  deviceName,
+  percentage,
+  displayText,
+  temperature,
+  healthy,
+  showBackgroundBar,
+}: SystemDiskCardProps) => {
+  const board = useRequiredBoard();
+  const scheme = useMantineColorScheme();
+  const t = useI18n();
+  const valueRef = useRef<HTMLParagraphElement>(null);
+  const [valueFits, setValueFits] = useState(true);
+
+  // When the card is squeezed (small widget), the value line is clipped by the card's `overflow: hidden`.
+  // Detect that and hide it, surfacing the value in a tooltip instead. The value keeps its layout space
+  // (visibility, not display) so toggling it does not change the measurement and flap. The ref lives on
+  // the value (not the Card) so the Tooltip can attach its own ref to the Card.
+  useEffect(() => {
+    const value = valueRef.current;
+    const card = value?.offsetParent as HTMLElement | null; // the position:relative Card
+    if (!value || !card) return;
+    const measure = () => {
+      setValueFits(value.getBoundingClientRect().bottom <= card.getBoundingClientRect().bottom + 1);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(card);
+    return () => observer.disconnect();
+  }, [displayText, healthy]);
+
+  const unhealthyLabel = t("widget.systemDisks.status.unhealthy");
+
+  return (
+    <Tooltip
+      label={healthy ? displayText : `${displayText} (${unhealthyLabel})`}
+      disabled={valueFits}
+      position="top"
+      withinPortal
+    >
+      <Card
+        radius={board.itemRadius}
+        py={"xs"}
+        bg={scheme.colorScheme === "dark" ? "dark.7" : "gray.1"}
+        style={{ overflow: "hidden", position: "relative" }}
+      >
+        <Group justify="space-between" style={{ zIndex: 1 }}>
+          <div>
+            <p style={{ margin: 0 }}>
+              <b>{deviceName}</b>
+            </p>
+            <p ref={valueRef} style={{ margin: 0, visibility: valueFits ? "visible" : "hidden" }}>
+              <span>{displayText}</span>
+              {!healthy && <span style={{ marginLeft: 5 }}>{unhealthyLabel}</span>}
+            </p>
+          </div>
+          <div>{temperature ? <p style={{ margin: 0 }}>{temperature}°C</p> : null}</div>
+        </Group>
+        <Box
+          bg={healthy ? "green" : "red"}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: `${percentage}%`,
+            height: "100%",
+            zIndex: 0,
+            display: showBackgroundBar ? "block" : "none",
+          }}
+        ></Box>
+      </Card>
+    </Tooltip>
+  );
+};
+
 export default function SystemResources({ integrationIds, options }: WidgetComponentProps<"systemDisks">) {
   const queryInput = { integrationIds };
   const { data = [] } = clientApi.widget.healthMonitoring.getSystemHealthStatus.useQuery(queryInput, {
     staleTime: 5 * 1000,
   });
   const utils = clientApi.useUtils();
-
-  const board = useRequiredBoard();
-  const scheme = useMantineColorScheme();
-  const t = useI18n();
 
   clientApi.widget.healthMonitoring.subscribeSystemHealthStatus.useSubscription(queryInput, {
     onData(data) {
@@ -63,45 +144,17 @@ export default function SystemResources({ integrationIds, options }: WidgetCompo
     <Stack gap="xs" p="xs" h="100%">
       {fileSystem.map((item) => {
         const smartItem = smart.find((smart) => smart.deviceName === item.deviceName);
-        const healthy = smartItem?.healthy ?? true; // fall back to healthy if no information is available
 
         return (
-          <Card
-            radius={board.itemRadius}
-            py={"xs"}
-            bg={scheme.colorScheme === "dark" ? "dark.7" : "gray.1"}
+          <SystemDiskCard
             key={`disk-${item.deviceName}`}
-            style={{ overflow: "hidden", position: "relative" }}
-          >
-            <Group justify="space-between" style={{ zIndex: 1 }}>
-              <div>
-                <p style={{ margin: 0 }}>
-                  <b>{item.deviceName}</b>
-                </p>
-                <p style={{ margin: 0 }}>
-                  <span>{getDisplayText(item, options.displayMode)}</span>
-                  {!healthy && <span style={{ marginLeft: 5 }}>{t("widget.systemDisks.status.unhealthy")}</span>}
-                </p>
-              </div>
-              <div>
-                {smartItem?.temperature && options.showTemperatureIfAvailable ? (
-                  <p style={{ margin: 0 }}>{smartItem.temperature}°C</p>
-                ) : null}
-              </div>
-            </Group>
-            <Box
-              bg={healthy ? "green" : "red"}
-              style={{
-                position: "absolute",
-                top: 0,
-                left: 0,
-                width: `${item.percentage}%`,
-                height: "100%",
-                zIndex: 0,
-                display: options.showBackgroundBar ? "block" : "none",
-              }}
-            ></Box>
-          </Card>
+            deviceName={item.deviceName}
+            percentage={item.percentage}
+            displayText={getDisplayText(item, options.displayMode)}
+            temperature={options.showTemperatureIfAvailable ? smartItem?.temperature : undefined}
+            healthy={smartItem?.healthy ?? true} // fall back to healthy if no information is available
+            showBackgroundBar={options.showBackgroundBar}
+          />
         );
       })}
     </Stack>


### PR DESCRIPTION
## Summary

Fixes several display bugs in the health monitoring widget when used with TrueNAS (and a related certificate-flow bug), found while setting up a TrueNAS integration.

### TrueNAS memory usage was inverted
The `reporting.get_data` `"memory"` graph reports **available (free)** memory (legend is `["time", "available"]`), but the code assigned that free value to `memUsedInBytes` and the physical total to `memAvailableInBytes`. Memory therefore showed ~10% used on a box that was actually ~88% used (ZFS ARC). Now `memAvailableInBytes` = free and `memUsedInBytes` = `physmem - free`.

### Pool "Available" showed total size, not free space
The integration set `fileSystem.available` to `dataset.size` (the pool's total size) rather than `dataset.free`, so the widget's "Available" label/value displayed the total. Fixed to use `dataset.free`. Unraid had the same latent bug (`available` = total disk size) and is fixed to report free space too.

### Health monitoring widget polish
- **Hide temperature for pools/disks without a reading.** Pools have no SMART temperature, but the widget defaulted `null` to `0` and rendered "0°C". Temperature now stays `null` and the element is only shown when a real reading exists.
- **Show used/available sizes as readable text.** Sizes were hidden in hover tooltips, only "available" was formatted (the "used" tooltip showed raw bytes). They are now formatted consistently below the bar via a helper that handles both raw-byte and pre-formatted integrations.
- **Fix the cramped progress-bar labels** that truncated to "Us…"/"Avail…" by moving them out of the bar segments.
- **Remove the "Last status update: in a few seconds" line**, which was noise given the 5s subscription refresh.

### Certificate "Trust" button closed the modal
On the integration form, the "Trust"/"Upload" certificate buttons had no `type`, so inside the `<form>` they defaulted to `type="submit"` and submitted the form on click (tearing down the confirm modal). Added `type="button"` (the "Retry" button intentionally stays `type="submit"`).

## Verification
- Verified the corrected memory and pool values against a live TrueNAS server over the JSON-RPC API.
- TrueNAS integration tests updated and passing.
- `oxfmt` and `oxlint` clean on the changed files.

## Checklist
- [x] Pull request targets `dev` branch
- [x] Commits follow the conventional commits guideline
- [x] No shorthand variable names are used
- [x] `oxfmt`/`oxlint` pass on changed files; tests pass
