### PR TITLE
fix(truenas): report actual memory usage and pool free space

### DIFF
--- a/packages/integrations/src/truenas/test/truenas-integration.spec.ts
+++ b/packages/integrations/src/truenas/test/truenas-integration.spec.ts
@@ -132,8 +132,9 @@ const happyResponder = (method: string) => {
           aggregations: emptyAggregations(),
           start: 0,
           end: 1,
-          legend: [],
-          data: [[1000, 8_000_000_000]],
+          // The "memory" graph reports available (free) memory: legend is ["time", "available"].
+          legend: ["time", "available"],
+          data: [[1000, 6_000_000_000]],
         },
         {
           name: "cputemp",
@@ -194,15 +195,17 @@ describe("TrueNasIntegration", () => {
       version: "TrueNAS-SCALE-24.10",
       cpuModelName: "Intel Xeon",
       cpuTemp: 45,
-      memAvailableInBytes: 16_000_000_000,
-      memUsedInBytes: 8_000_000_000,
+      // physmem (16 GB) minus the reported available 6 GB leaves 10 GB used.
+      memAvailableInBytes: 6_000_000_000,
+      memUsedInBytes: 10_000_000_000,
       uptime: 3600,
       rebootRequired: false,
       availablePkgUpdates: 0,
       loadAverage: null,
       gpu: [],
       network: { up: 20_000, down: 10_000 },
-      fileSystem: [{ deviceName: "tank", available: "1000", used: "500", percentage: 50 }],
+      // `available` is the free space left on the pool (free = 500), not its total size.
+      fileSystem: [{ deviceName: "tank", available: "500", used: "500", percentage: 50 }],
       smart: [{ deviceName: "tank", healthy: true, overallStatus: "ONLINE", temperature: null }],
     });
   });

--- a/packages/integrations/src/truenas/truenas-integration.ts
+++ b/packages/integrations/src/truenas/truenas-integration.ts
@@ -37,14 +37,19 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
     const upload = this.extractNetworkTrafficData(netdata, 2); // Index 2 is "sent"
     const download = this.extractNetworkTrafficData(netdata, 1); // Index 1 is "received"
 
+    // The "memory" reporting graph reports available (free) memory, its legend is ["time", "available"].
+    // Used memory is therefore the physical total minus what is still available (clamped against timing skew).
+    const memAvailableInBytes = memoryData[1] ?? 0; // Index 0 is the UNIX timestamp, Index 1 is available bytes
+    const memUsedInBytes = Math.max(systemInformation.physmem - memAvailableInBytes, 0);
+
     return {
       cpuUtilization: cpuData.reduce((acc, item) => acc + (item > 100 ? 0 : item), 0) / cpuData.length,
       cpuTemp: Math.max(...cpuTempData.filter((_item, index) => index > 0)),
-      memAvailableInBytes: systemInformation.physmem,
-      memUsedInBytes: memoryData[1] ?? 0, // Index 0 is UNIX timestamp, Index 1 is free space in bytes
+      memAvailableInBytes,
+      memUsedInBytes,
       fileSystem: datasets.map((dataset) => ({
         deviceName: dataset.name,
-        available: `${dataset.size}`, // TODO: can we use number instead of string here?
+        available: `${dataset.free}`, // free space left on the pool
         used: `${dataset.allocated}`,
         percentage: (dataset.allocated / dataset.size) * 100,
       })),


### PR DESCRIPTION
## Summary

The TrueNAS health monitoring widget reported memory and pool space incorrectly.

- **Memory was inverted.** The `reporting.get_data` `"memory"` graph reports *available (free)* memory (legend `["time", "available"]`), but the code assigned that free value to `memUsedInBytes` and the physical total to `memAvailableInBytes`. Memory showed ~10% used on a box that was actually ~88% used (ZFS ARC). Now `memAvailableInBytes` = free and `memUsedInBytes` = `physmem - free`.
- **Pool "available" was the total size.** `fileSystem.available` was set to `dataset.size` (total) rather than `dataset.free`, so the widget's "Available" showed the pool's total size. Fixed to `dataset.free`.

Verified against a live TrueNAS server over the JSON-RPC API: a 31 GiB box now reads ~27.8 GiB used, and a pool reads 62.9 TiB used / 19.0 TiB available.

### Before

<img width="159" height="110" alt="image" src="https://github.com/user-attachments/assets/0a91a0f4-3e00-4e99-8c54-1f90270b8946" />

### After

<img width="147" height="109" alt="image" src="https://github.com/user-attachments/assets/1a457f7e-ec7e-4c63-8821-be5e5bed1264" />

> Yes, I need to buy more RAM

### Before

<img width="319" height="101" alt="image" src="https://github.com/user-attachments/assets/fe4aa3f0-ed0e-40e4-920f-434c106c5265" />
<img width="287" height="103" alt="image" src="https://github.com/user-attachments/assets/3b54d558-95d3-422a-8fc7-91f11cc13cea" />

### After

<img width="259" height="203" alt="image" src="https://github.com/user-attachments/assets/57735c29-46be-4491-95ac-b101bf49e7f1" />


## Checklist
- [x] Targets `dev`
- [x] Conventional commits
- [x] Tests updated (`truenas-integration.spec.ts`)
