### PR TITLE
fix(unraid): report disk free space instead of total size

### DIFF
--- a/packages/integrations/src/unraid/unraid-integration.ts
+++ b/packages/integrations/src/unraid/unraid-integration.ts
@@ -59,8 +59,8 @@ export class UnraidIntegration extends Integration implements ISystemHealthMonit
       cpuTemp: undefined, // Not implemented, see https://github.com/unraid/api/issues/1597
       fileSystem: systemInfo.array.disks.map((disk) => ({
         deviceName: disk.name,
-        used: humanFileSize(disk.fsUsed * 1024), // API is in KiB (kibibytes), covert to bytes
-        available: `${disk.size * 1024}`, // API is in KiB (kibibytes), covert to bytes
+        used: humanFileSize(disk.fsUsed * 1024), // API is in KiB (kibibytes), convert to bytes
+        available: `${(disk.size - disk.fsUsed) * 1024}`, // free space left on the disk, API is in KiB (kibibytes)
         percentage: (disk.fsUsed / disk.size) * 100, // The units are the same, therefore the actual unit is irrelevant
       })),
       smart: systemInfo.array.disks.map((disk) => ({


### PR DESCRIPTION
## Summary

Unraid reported each disk's **total** size as the "available" value used by the health monitoring and system disks widgets (`available: disk.size * 1024`), so "Available" showed the full disk size instead of free space. Fixed to report free space (`(disk.size - disk.fsUsed) * 1024`), matching the other integrations (Glances, dashdot, TrueNAS) and the widget's "Available" label.

Not tested against a live Unraid instance, but it mirrors the equivalent TrueNAS fix. 

### Before

<img width="319" height="101" alt="image" src="https://github.com/user-attachments/assets/fe4aa3f0-ed0e-40e4-920f-434c106c5265" />
<img width="287" height="103" alt="image" src="https://github.com/user-attachments/assets/3b54d558-95d3-422a-8fc7-91f11cc13cea" />

### After

<img width="259" height="203" alt="image" src="https://github.com/user-attachments/assets/57735c29-46be-4491-95ac-b101bf49e7f1" />

## Checklist
- [x] Targets `dev`
- [x] Conventional commits
