### PR TITLE
fix(integrations): prevent certificate trust button from submitting the form

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/integrations/_components/test-connection/test-connection-certificate.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/integrations/_components/test-connection/test-connection-certificate.tsx
@@ -131,6 +131,7 @@ export const CertificateErrorDetails = ({ error, url }: CertificateErrorDetailsP
       {(error.data.reason === "untrusted" && rootCertificate.isSelfSigned) ||
       error.data.reason === "hostnameMismatch" ? (
         <Button
+          type="button"
           variant="default"
           fullWidth
           onClick={error.data.reason === "hostnameMismatch" ? handleTrustHostname : handleTrustSelfSigned}
@@ -140,6 +141,7 @@ export const CertificateErrorDetails = ({ error, url }: CertificateErrorDetailsP
       ) : null}
       {error.data.reason === "untrusted" && !rootCertificate.isSelfSigned ? (
         <Button
+          type="button"
           variant="default"
           fullWidth
           onClick={() =>


### PR DESCRIPTION
## Summary

On the integration form, the certificate **"Trust"** and **"Upload"** buttons had no `type`, so inside the `<form>` they defaulted to `type="submit"` and submitted the form on click — tearing down the confirmation modal before the user could confirm. Added `type="button"` to both (the "Retry" button intentionally stays `type="submit"`).

Verified live: triggering a self-signed + hostname-mismatch certificate now opens the confirm modal and trusts the certificate as expected, instead of dismissing the dialog.

## Checklist
- [x] Targets `dev`
- [x] Conventional commits
