### PR TITLE
fix(widgets): hide health monitoring default tab option for non-proxmox integrations

### DIFF
--- a/packages/widgets/src/health-monitoring/index.ts
+++ b/packages/widgets/src/health-monitoring/index.ts
@@ -95,6 +95,12 @@ export const { definition, componentLoader } = createWidgetDefinition("healthMon
             return !integrationKinds.includes("proxmox");
           },
         },
+        defaultTab: {
+          shouldHide(_, integrationKinds) {
+            // The system/cluster tabs only render for Proxmox, so the default tab choice does nothing otherwise
+            return !integrationKinds.includes("proxmox");
+          },
+        },
       },
     );
   },


### PR DESCRIPTION
## Summary

The health monitoring widget's **"Default tab"** option only affects the System/Cluster tabs, which render only for Proxmox. For every other integration (TrueNAS, Unraid, Glances, …) it was a dead setting shown in the widget options. Added a `shouldHide` guard so it only appears when a Proxmox integration is selected, consistent with the sibling cluster-only options (`visibleClusterSections`, `showUptime`, `sectionIndicatorRequirement`).

<img width="108" height="80" alt="image" src="https://github.com/user-attachments/assets/afe0dbb7-6413-42a4-82b4-a623180c260f" />

## Checklist
- [x] Targets `dev`
- [x] Conventional commits
