### PR TITLE
fix(widgets): make downloads widget table background transparent

### DIFF
--- a/packages/widgets/src/downloads/component.tsx
+++ b/packages/widgets/src/downloads/component.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import "../widgets-common.css";
+import "./styles.css";
 
 import { useCallback, useMemo, useState } from "react";
 import type { MantineStyleProp } from "@mantine/core";
@@ -577,7 +578,7 @@ export default function DownloadClientsWidget({
     enableColumnOrdering: isEditMode,
     enableRowVirtualization: true,
     rowVirtualizerOptions: { overscan: 5 },
-    mantinePaperProps: { flex: 1, withBorder: false, shadow: undefined },
+    mantinePaperProps: { flex: 1, withBorder: false, shadow: undefined, bg: "transparent" },
     mantineTableContainerProps: { style: { height: "100%" } },
     mantineTableProps: {
       className: "downloads-widget-table",

--- a/packages/widgets/src/downloads/styles.css
+++ b/packages/widgets/src/downloads/styles.css
@@ -1,0 +1,12 @@
+/* Make the MantineReactTable transparent so the board card's opacity-controlled
+   background shows through. MRT defaults to var(--mantine-color-body) which is opaque. */
+.downloads-widget-table,
+.downloads-widget-table .mantine-Table-table,
+.downloads-widget-table .mantine-Table-thead,
+.downloads-widget-table .mantine-Table-tbody,
+.downloads-widget-table .mantine-Table-tfoot,
+.downloads-widget-table .mantine-Table-tr,
+.downloads-widget-table th,
+.downloads-widget-table td {
+  background-color: transparent !important;
+}


### PR DESCRIPTION
## Problem
The downloads (torrent/qBittorrent) widget's table had an opaque background, blocking the board's background from showing through. The footer was already transparent, but the main table area was not.

<img width="1488" height="736" alt="CleanShot 2026-06-20 at 13 50 12" src="https://github.com/user-attachments/assets/72d6f9e3-5c5e-4d7b-bb23-f0b2889d29e3" />


## Root Cause
MantineReactTable table cells default to `var(--mantine-color-body)` which is opaque. This is the same issue the beszel-system-table widget faced.

## Fix
1. Added `bg="transparent"` to the `mantinePaperProps` for the Paper wrapper
2. Added `styles.css` that forces `background-color: transparent !important` on all table elements (thead, tbody, tr, th, td)

This follows the same pattern used in `packages/widgets/src/beszel-system-table/styles.css`.

## Files Changed
- `packages/widgets/src/downloads/component.tsx` — Added CSS import + `bg: "transparent"` to Paper props
- `packages/widgets/src/downloads/styles.css` — New stylesheet targeting table elements

## Verification
- Typecheck passes
- Lint passes (0 errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the downloads widget to blend more naturally with its container by using transparent backgrounds for the table and related elements.
  * Preserved the existing table layout and border/shadow behavior while improving visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->