### PR TITLE
fix(dashdot): normalize /api suffix from integration URL for Dashdot v6 compatibility

### DIFF
--- a/packages/integrations/src/base/integration.ts
+++ b/packages/integrations/src/base/integration.ts
@@ -55,7 +55,7 @@ export abstract class Integration {
     return this.integration.decryptedSecrets.some((secret) => secret.kind === kind);
   }
 
-  private createUrl(
+  protected createUrl(
     inputUrl: string,
     path: `/${string}`,
     queryParams?: Record<string, string | Date | number | boolean | null | undefined>,

--- a/packages/integrations/src/dashdot/dashdot-integration.ts
+++ b/packages/integrations/src/dashdot/dashdot-integration.ts
@@ -16,6 +16,16 @@ import type { ISystemHealthMonitoringIntegration } from "../interfaces/health-mo
 import type { SystemHealthMonitoring } from "../interfaces/health-monitoring/health-monitoring-types";
 
 export class DashDotIntegration extends Integration implements ISystemHealthMonitoringIntegration {
+  /**
+   * Dashdot v5 had endpoints at /api/info, /api/load/* etc.
+   * Dashdot v6 removed the /api prefix. Users who previously configured
+   * their integration URL as http://host:port/api need it normalized.
+   */
+  protected override url(path: `/${string}`, queryParams?: Record<string, string | Date | number | boolean | null | undefined>) {
+    const normalizedUrl = this.integration.url.replace(/\/api\/?$/, "");
+    return this.createUrl(normalizedUrl, path, queryParams);
+  }
+
   protected async testingAsync(input: IntegrationTestingInput): Promise<TestingResult> {
     const response = await input.fetchAsync(this.url("/info"));
     if (!response.ok) return TestConnectionError.StatusResult(response);

--- a/packages/integrations/src/dashdot/dashdot-integration.ts
+++ b/packages/integrations/src/dashdot/dashdot-integration.ts
@@ -21,7 +21,10 @@ export class DashDotIntegration extends Integration implements ISystemHealthMoni
    * Dashdot v6 removed the /api prefix. Users who previously configured
    * their integration URL as http://host:port/api need it normalized.
    */
-  protected override url(path: `/${string}`, queryParams?: Record<string, string | Date | number | boolean | null | undefined>) {
+  protected override url(
+    path: `/${string}`,
+    queryParams?: Record<string, string | Date | number | boolean | null | undefined>,
+  ) {
     const normalizedUrl = this.integration.url.replace(/\/api\/?$/, "");
     return this.createUrl(normalizedUrl, path, queryParams);
   }

--- a/packages/integrations/test/dashdot-unit.spec.ts
+++ b/packages/integrations/test/dashdot-unit.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createDb } from "@homarr/db/test";
+
+import type { IntegrationTestingInput } from "../src/base/integration";
+import { DashDotIntegration } from "../src/dashdot/dashdot-integration";
+
+vi.mock("@homarr/db", async (importActual) => {
+  const actual = await importActual<typeof import("@homarr/db")>();
+  return {
+    ...actual,
+    db: createDb(),
+  };
+});
+
+vi.mock("@homarr/core/infrastructure/certificates", async (importActual) => {
+  const actual = await importActual<typeof import("@homarr/core/infrastructure/certificates")>();
+  return {
+    ...actual,
+    getTrustedCertificateHostnamesAsync: vi.fn().mockResolvedValue([]),
+  };
+});
+
+vi.mock("@homarr/redis", () => ({}));
+
+const createIntegration = (url: string) =>
+  new DashDotIntegration({
+    id: "test",
+    name: "Dashdot",
+    url,
+    decryptedSecrets: [],
+    externalUrl: null,
+  });
+
+describe("DashDot URL normalization", () => {
+  test("url with /api suffix is stripped", async () => {
+    const integration = createIntegration("http://dashdot:3001/api");
+    // Access protected url() via testingAsync which calls this.url("/info")
+    const url = (integration as unknown as { url: (path: string) => URL }).url("/info");
+    expect(url.toString()).toBe("http://dashdot:3001/info");
+  });
+
+  test("url with /api/ trailing slash is stripped", async () => {
+    const integration = createIntegration("http://dashdot:3001/api/");
+    const url = (integration as unknown as { url: (path: string) => URL }).url("/info");
+    expect(url.toString()).toBe("http://dashdot:3001/info");
+  });
+
+  test("url without /api suffix is unchanged", async () => {
+    const integration = createIntegration("http://dashdot:3001");
+    const url = (integration as unknown as { url: (path: string) => URL }).url("/info");
+    expect(url.toString()).toBe("http://dashdot:3001/info");
+  });
+
+  test("url with /api only at end is stripped (not mid-path)", async () => {
+    const integration = createIntegration("http://dashdot:3001/somepath/api");
+    const url = (integration as unknown as { url: (path: string) => URL }).url("/info");
+    expect(url.toString()).toBe("http://dashdot:3001/somepath/info");
+  });
+
+  test("url with path prefix other than /api is preserved", async () => {
+    const integration = createIntegration("http://dashdot:3001/dashdot");
+    const url = (integration as unknown as { url: (path: string) => URL }).url("/load/cpu");
+    expect(url.toString()).toBe("http://dashdot:3001/dashdot/load/cpu");
+  });
+});


### PR DESCRIPTION
## Summary

Dashdot v6 removed the `/api` prefix from all API endpoints. This PR normalizes the stored integration URL by stripping any trailing `/api` suffix before constructing API paths, fixing Dashdot integrations that were configured with the old URL format.

## Root Cause

The integration code in Homarr already uses the correct paths (`/info`, `/load/*`) — without the `/api/` prefix. However, users who configured their Dashdot integration URL as `http://host:port/api` (common with Dashdot v5 setups) end up with paths like `http://host:port/api/info` → 404 in Dashdot v6.

## Fix

| URL stored by user | Before | After |
|---|---|---|
| `http://dashdot:3001/api` | `/api/info` | `/info` |
| `http://dashdot:3001/api/` | `/api/info` | `/info` |
| `http://dashdot:3001` | `/info` | `/info` (unchanged) |
| `http://dashdot:3001/dashdot` | `/dashdot/info` | unchanged |

### Changes
- `packages/integrations/src/base/integration.ts`: Changed `createUrl` from `private` to `protected` to allow subclass reuse
- `packages/integrations/src/dashdot/dashdot-integration.ts`: Added `url()` override that strips trailing `/api` from the stored URL
- `packages/integrations/test/dashdot-unit.spec.ts`: Unit tests for URL normalization

Closes #6027