### PR TITLE
feat: ship source maps for readable production stack traces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,9 @@ ENV DB_DRIVER='better-sqlite3'
 ENV AUTH_PROVIDERS='credentials'
 ENV REDIS_IS_EXTERNAL='false'
 ENV NODE_ENV='production'
+# Tell Node to symbolicate stack traces using the shipped .map files so production logs
+# show original source locations instead of minified frames, see https://github.com/homarr-labs/homarr/issues/5891
+ENV NODE_OPTIONS='--enable-source-maps'
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]
 CMD ["sh", "run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,17 @@ ARG DISABLE_REDIS_LOGS='true'
 
 RUN corepack enable pnpm && pnpm build
 
+# The standalone output tracing omits server chunk source maps (.next/server/**/*.map), which is
+# where production Node stack frames point. Copy the .map files into the standalone tree (preserving
+# directory structure) so the existing standalone COPY ships them, keeping traces readable.
+# See https://github.com/homarr-labs/homarr/issues/5891
+RUN cd apps/nextjs/.next/server && \
+    find . -name '*.map' | while IFS= read -r map; do \
+      dest="../standalone/apps/nextjs/.next/server/$map"; \
+      mkdir -p "$(dirname "$dest")"; \
+      cp "$map" "$dest"; \
+    done
+
 FROM base AS runner
 WORKDIR /app
 

--- a/apps/nextjs/next.config.ts
+++ b/apps/nextjs/next.config.ts
@@ -31,6 +31,8 @@ const nextConfig: NextConfig = {
   },
   output: "standalone",
   reactStrictMode: true,
+  // Ship browser source maps so production client stack traces are readable, see https://github.com/homarr-labs/homarr/issues/5891
+  productionBrowserSourceMaps: true,
   // react compiler breaks mantine-react-table, so disabled for now
   //reactCompiler: true,
   /** We already do typechecking as separate tasks in CI */
@@ -41,6 +43,8 @@ const nextConfig: NextConfig = {
    */
   serverExternalPackages: ["dockerode", "isomorphic-dompurify", "jsdom", "better-sqlite3"],
   experimental: {
+    // Ship server source maps so production Node stack traces in logs reference original source, see https://github.com/homarr-labs/homarr/issues/5891
+    serverSourceMaps: true,
     optimizePackageImports: ["@mantine/core", "@mantine/hooks", "@tabler/icons-react"],
     turbopackFileSystemCacheForDev: true,
     preloadEntriesOnStart: false,


### PR DESCRIPTION
## Summary

Production server logs and runtime error traces now resolve to original source files and line numbers instead of minified output. Maintainers debugging a crash in a deployed container can read a stack frame like `apps/nextjs/src/.../route.ts:42` instead of an opaque minified chunk reference.

## Why this matters

Issue #5891 asks that source maps be shipped so original (non-minified) error locations appear in logs. Three things are required for that to work in the standalone Docker image, and all three are addressed:

1. Generate the maps. `apps/nextjs/next.config.ts` now sets `productionBrowserSourceMaps: true` for client bundles and `experimental.serverSourceMaps: true` for server bundles. Both keys are part of the Next.js 16 config schema (the version pinned in `pnpm-workspace.yaml`).
2. Ship the server maps. The image uses `output: "standalone"`, and Next's standalone output tracing does not include `.next/server/**/*.map` (the maps server stack frames point at), even though the existing `COPY .next/standalone` and `COPY .next/static` lines cover everything else. The `Dockerfile` builder stage now copies the server `.map` files into the standalone tree, preserving directory structure, so the existing standalone `COPY` ships them. Only `.map` files are copied, keeping the image-size increase bounded.
3. Use the maps at runtime. `node apps/nextjs/server.js` (see `scripts/run.sh`) only symbolicates stack traces when Node's source-map support is on, so the runner stage sets `ENV NODE_OPTIONS='--enable-source-maps'`.

No runtime behavior, CSP, or output mode is changed.

## Testing

- Verified `productionBrowserSourceMaps` and `serverSourceMaps` are valid keys in the installed `next` config type definitions.
- Verified against a Next.js 16 standalone build that `.next/server/**/*.map` files are generated but absent from the standalone trace, and that browser maps land in `.next/static`.
- Verified the map-copy shell loop preserves the nested `.next/server` directory structure and copies only `.map` files (not the `.js` bundles).

Fixes #5891
