### PR TITLE
fix(beszel): use 480m interval for 1w/30d stats views

### DIFF
--- a/packages/request-handler/src/beszel.ts
+++ b/packages/request-handler/src/beszel.ts
@@ -115,8 +115,8 @@ const timePeriodConfig: Record<string, { type: string; perPage: number; cacheSec
   "1h": { type: "1m", perPage: 60, cacheSeconds: 60 },
   "12h": { type: "10m", perPage: 72, cacheSeconds: 300 },
   "24h": { type: "20m", perPage: 72, cacheSeconds: 600 },
-  "1w": { type: "1440m", perPage: 9, cacheSeconds: 1800 },
-  "30d": { type: "1440m", perPage: 32, cacheSeconds: 3600 },
+  "1w": { type: "480m", perPage: 21, cacheSeconds: 1800 },
+  "30d": { type: "480m", perPage: 90, cacheSeconds: 3600 },
 };
 
 export interface BeszelStatsData {


### PR DESCRIPTION
## Problem
The Beszel System Stats widget showed no data for 1W and 30D time periods.

## Root Cause
`timePeriodConfig` mapped 1w/30d to `type: "1440m"`, but Beszel only stores stats at intervals: `1m, 10m, 20m, 120m, 480m` (per `beszel-types.ts:93`). The `1440m` type doesn't exist in PocketBase, so the filter `type='1440m'` matched zero records.

## Fix
Use `"480m"` (8-hour intervals) for both periods:
- **1w**: 7 days × 3 records/day = `perPage: 21`
- **30d**: 30 days × 3 records/day = `perPage: 90`

The mock integration already supports `480m` in its `typeToMinutes` map, so both mock and real instances now return data.

## Testing
- Typecheck passes
- Mock data generates correct 8h-spaced time series for 1w/30d