### PR TITLE
fix: show app first in add item modal

### DIFF
--- a/apps/nextjs/src/components/board/items/item-select-modal.tsx
+++ b/apps/nextjs/src/components/board/items/item-select-modal.tsx
@@ -41,7 +41,12 @@ export const ItemSelectModal = createModal<void>(({ actions }) => {
           name: t(`widget.${kind}.name`),
           description: t(`widget.${kind}.description`),
         }))
-        .sort((itemA, itemB) => itemA.name.localeCompare(itemB.name)),
+        .sort((itemA, itemB) => {
+          if (itemA.kind === "app") return -1;
+          if (itemB.kind === "app") return 1;
+
+          return itemA.name.localeCompare(itemB.name);
+        }),
     [t],
   );
 


### PR DESCRIPTION
## Summary
- Pin the app widget to the top of the dashboard add item modal
- Keep all other widgets sorted alphabetically

## Validation
- pnpm exec oxlint apps/nextjs/src/components/board/items/item-select-modal.tsx