### PR TITLE
fix: dns-hole widgets showing stale disconnected state

### DIFF
--- a/packages/widgets/src/dns-hole/controls/component.tsx
+++ b/packages/widgets/src/dns-hole/controls/component.tsx
@@ -57,6 +57,7 @@ export default function DnsHoleControlsWidget({
     },
     {
       staleTime: 5 * 1000,
+      refetchInterval: 5 * 1000,
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
       retry: false,

--- a/packages/widgets/src/dns-hole/summary/component.tsx
+++ b/packages/widgets/src/dns-hole/summary/component.tsx
@@ -26,6 +26,7 @@ export default function DnsHoleSummaryWidget({ options, integrationIds }: Widget
     },
     {
       staleTime: 5 * 1000,
+      refetchInterval: 5 * 1000,
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
       retry: false,


### PR DESCRIPTION
## Problem
The DNS hole controls widget shows "disconnected" after ~30 seconds even when the Pi-hole/AdGuard Home integration is working. Clicking a button temporarily fixes it.

**Reported:** https://www.reddit.com/r/homarr/comments/1ubx1f7/dns_hole_controls_pihole_showing_disconnected/

## Root Cause
The `useQuery` had `staleTime: 5000` but no `refetchInterval`. With `refetchOnWindowFocus: false` + `refetchOnReconnect: false`, the query never refetched. Without refetches, the Redis pub/sub cache isn't refreshed, so the subscription never fires, `updatedAt` stays stale, and `useIntegrationConnected` times out after 30s.

## Fix
Added `refetchInterval: 5 * 1000` to both dns-hole widgets, matching the existing `staleTime` and server cache TTL.

## Changes
- `packages/widgets/src/dns-hole/controls/component.tsx`
- `packages/widgets/src/dns-hole/summary/component.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DNS hole summary information now refreshes automatically every 5 seconds, keeping the widget more up to date.
  * The DNS hole controls view also updates its displayed summary periodically, reducing the need for manual refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->