### PR TITLE
feat(config): enable pnpm global virtual store for worktree support

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalog:
   "@dnd-kit/utilities": ^3.2.2
   "@drizzle-team/brocli": ^0.12.0
   "@extractus/feed-extractor": 7.2.1
-  '@gfazioli/mantine-onboarding-tour': ^4.0.5
+  "@gfazioli/mantine-onboarding-tour": ^4.0.5
   "@gitbeaker/rest": ^43.8.0
   "@homarr/gridstack": ^1.12.0
   "@homarr/node-unifi": ^2.6.0
@@ -191,6 +191,7 @@ catalog:
   zod-form-data: ^3.0.2
   zod-validation-error: ^5.0.0
 catalogMode: strict
+enableGlobalVirtualStore: true
 nodeLinker: hoisted
 strictPeerDependencies: false
 engineStrict: true


### PR DESCRIPTION
Enables `enableGlobalVirtualStore: true` in `pnpm-workspace.yaml` so all git worktrees share a single global virtual store.

This means each worktree's `node_modules` contains only symlinks into the shared store — near-zero disk overhead per worktree and instant installs on new worktrees.

See https://pnpm.io/git-worktrees