### PR TITLE
fix(downloads-widget): make name column wider

### DIFF
--- a/packages/widgets/src/common/table-column-sizing.spec.ts
+++ b/packages/widgets/src/common/table-column-sizing.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+
+import { getResponsiveTableColumnSizes } from "./table-column-sizing";
+
+describe("getResponsiveTableColumnSizes", () => {
+  const baseColumnSizes = {
+    actions: 2,
+    name: 16,
+    progress: 6,
+  };
+
+  test("keeps base sizes for narrow tables", () => {
+    expect(getResponsiveTableColumnSizes(baseColumnSizes, 320, { name: { maxSize: 32 } })).toEqual(baseColumnSizes);
+  });
+
+  test("grows configured columns with table width", () => {
+    expect(getResponsiveTableColumnSizes(baseColumnSizes, 768, { name: { maxSize: 32 } })).toEqual({
+      ...baseColumnSizes,
+      name: 24,
+    });
+  });
+
+  test("does not grow past max size", () => {
+    expect(getResponsiveTableColumnSizes(baseColumnSizes, 2000, { name: { maxSize: 32 } })).toEqual({
+      ...baseColumnSizes,
+      name: 32,
+    });
+  });
+
+  test("does not shrink below base size when max size is smaller than the base", () => {
+    expect(getResponsiveTableColumnSizes(baseColumnSizes, 2000, { name: { maxSize: 12 } })).toEqual(baseColumnSizes);
+  });
+});

--- a/packages/widgets/src/common/table-column-sizing.ts
+++ b/packages/widgets/src/common/table-column-sizing.ts
@@ -1,0 +1,20 @@
+export const getResponsiveTableColumnSizes = <TColumn extends string>(
+  baseColumnSizes: Record<TColumn, number>,
+  width: number,
+  responsiveColumns: Partial<Record<TColumn, { maxSize?: number; widthDivisor?: number }>>,
+): Record<TColumn, number> => {
+  const columnSizes = { ...baseColumnSizes };
+
+  for (const [column, options] of Object.entries(responsiveColumns) as [
+    TColumn,
+    { maxSize?: number; widthDivisor?: number },
+  ][]) {
+    const baseSize = baseColumnSizes[column];
+    // maxSize limits growth only; it should never shrink a column below its base size.
+    const maxSize = Math.max(baseSize, options.maxSize ?? Number.POSITIVE_INFINITY);
+    const widthBasedSize = Math.round(width / (options.widthDivisor ?? 32));
+    columnSizes[column] = Math.min(maxSize, Math.max(baseSize, widthBasedSize));
+  }
+
+  return columnSizes;
+};

--- a/packages/widgets/src/downloads/component.tsx
+++ b/packages/widgets/src/downloads/component.tsx
@@ -48,6 +48,7 @@ import { getIconUrl, getIntegrationKindsByCategory } from "@homarr/definitions";
 import type { ExtendedClientStatus, ExtendedDownloadClientItem } from "@homarr/integrations";
 import { useScopedI18n } from "@homarr/translation/client";
 
+import { getResponsiveTableColumnSizes } from "../common/table-column-sizing";
 import type { WidgetComponentProps } from "../definition";
 
 dayjs.extend(relativeTime);
@@ -58,7 +59,7 @@ interface QuickFilter {
 }
 
 //Ratio table for relative width between columns
-const columnsRatios: Record<keyof ExtendedDownloadClientItem, number> = {
+const baseColumnsRatios: Record<keyof ExtendedDownloadClientItem, number> = {
   actions: 2,
   added: 4,
   category: 1,
@@ -83,6 +84,7 @@ export default function DownloadClientsWidget({
   integrationIds,
   options,
   setOptions,
+  width,
 }: WidgetComponentProps<"downloads">) {
   const integrationsWithInteractions = useIntegrationsWithInteractAccess().flatMap(({ id }) =>
     integrationIds.includes(id) ? [id] : [],
@@ -104,6 +106,10 @@ export default function DownloadClientsWidget({
 
   const t = useScopedI18n("widget.downloads");
   const tCommon = useScopedI18n("common");
+  const columnsRatios = useMemo(
+    () => getResponsiveTableColumnSizes(baseColumnsRatios, width, { name: { maxSize: 32 } }),
+    [width],
+  );
 
   //Item modal state and selection
   const [clickedIndex, setClickedIndex] = useState<number>(0);
@@ -335,7 +341,7 @@ export default function DownloadClientsWidget({
           ) : null,
       };
     },
-    [t],
+    [columnsRatios, t],
   );
 
   //Make columns and cell elements, Memoized to data with deps on data and EditMode


### PR DESCRIPTION
Closes #4157.

Made the download client job name column a bit wider so longer names are easier to read.

Testing:
- Ran git diff --check
- Could not run pnpm turbo typecheck --filter=@homarr/widgets because Corepack failed while verifying/downloading pnpm 11.9.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Improved the downloads table layout with responsive column sizing that adapts header and column spacing as the widget width changes.
* **New Features**
  * Added a reusable helper to compute responsive table column widths from base sizes and available width, with optional per-column maximum limits.
* **Tests**
  * Added unit tests covering narrow vs. wide table behavior and enforcing per-column max size constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->