### PR TITLE
feat(app): support path-only hrefs for multi-hostname access

### DIFF
--- a/apps/docs/docs/management/apps/index.mdx
+++ b/apps/docs/docs/management/apps/index.mdx
@@ -38,13 +38,17 @@ An optional description that can be shown as tooltip on the app widget.
 
 ### URL
 
-The URL to the website you want to link to. Clicking on the app widget or bookmark will open this URL.
+The URL to the website you want to link to. Clicking on the app widget or bookmark will open this URL. This can be a full address or a path like `/grafana/`, which resolves against the hostname you're currently using — handy when Homarr answers on more than one hostname.
 
 ### Ping URL
 
 When you want to use another url for the simple status check you can set it here. 
 This will allow you to set a different URL for the ping than the URL that is opened when clicking on the app widget.
 It's useful when you want to ping the service internally for example with a custom ip but open the website externally.
+
+:::note
+The status check can't use a path-only URL. Set a full Ping URL here if you want the indicator for such an app.
+:::
 
 ## List of apps
 

--- a/packages/api/src/router/test/widgets/app.spec.ts
+++ b/packages/api/src/router/test/widgets/app.spec.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from "@trpc/server";
 import { describe, expect, test, vi } from "vitest";
 
 import type { Session } from "@homarr/auth";
@@ -67,10 +68,51 @@ describe("ping should call sendPingRequestAsync with url and return result", () 
   });
 });
 
-const createApp = ({ url }: { url: string }) =>
+const createApp = ({ url, pingUrl }: { url: string | null; pingUrl?: string | null }) =>
   ({
     id: createId(),
     iconUrl: "",
     name: "Test App",
     href: url,
+    pingUrl: pingUrl ?? null,
   }) satisfies InferInsertModel<typeof apps>;
+
+describe("ping resolution under path-only hrefs", () => {
+  test("path-only href without pingUrl throws CONFLICT (no server-side host synthesis)", async () => {
+    const sendSpy = vi.spyOn(ping, "sendPingRequestAsync");
+    const db = createDb();
+    const app = createApp({ url: "/cockpit/" });
+    await db.insert(apps).values(app);
+    const caller = appRouter.createCaller({ db, deviceType: undefined, session: null });
+
+    await expect(caller.ping({ id: app.id })).rejects.toThrow(TRPCError);
+    await expect(caller.ping({ id: app.id })).rejects.toMatchObject({ code: "CONFLICT" });
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  test("path-only href with explicit pingUrl uses pingUrl", async () => {
+    const expectedUrl = "https://host.docker.internal/cockpit/";
+    vi.spyOn(ping, "sendPingRequestAsync").mockResolvedValueOnce({ statusCode: 204, durationMs: 7 });
+    const db = createDb();
+    const app = createApp({ url: "/cockpit/", pingUrl: expectedUrl });
+    await db.insert(apps).values(app);
+    const caller = appRouter.createCaller({ db, deviceType: undefined, session: null });
+
+    const result = await caller.ping({ id: app.id });
+
+    expect(result.url).toBe(expectedUrl);
+  });
+
+  test("absolute href without pingUrl pings the href", async () => {
+    const expectedUrl = "https://docs.halos.fi";
+    vi.spyOn(ping, "sendPingRequestAsync").mockResolvedValueOnce({ statusCode: 200, durationMs: 11 });
+    const db = createDb();
+    const app = createApp({ url: expectedUrl });
+    await db.insert(apps).values(app);
+    const caller = appRouter.createCaller({ db, deviceType: undefined, session: null });
+
+    const result = await caller.ping({ id: app.id });
+
+    expect(result.url).toBe(expectedUrl);
+  });
+});

--- a/packages/api/src/router/widgets/app.ts
+++ b/packages/api/src/router/widgets/app.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod/v4";
 
+import { resolveServerUrl } from "@homarr/common";
 import { getServerSettingByKeyAsync } from "@homarr/db/queries";
 import { sendPingRequestAsync } from "@homarr/ping";
 
@@ -27,7 +28,7 @@ export const appRouter = createTRPCRouter({
       });
     }
 
-    const pingUrl = app.pingUrl ?? app.href;
+    const pingUrl = resolveServerUrl(app);
 
     if (!pingUrl) {
       throw new TRPCError({

--- a/packages/common/src/test/url.spec.ts
+++ b/packages/common/src/test/url.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { getPortFromUrl, isAbsoluteUrl } from "../url.js";
+import { getPortFromUrl, isAbsoluteUrl, resolveServerUrl } from "../url.js";
 
 describe("getPortFromUrl", () => {
   test.each([
@@ -54,5 +54,31 @@ describe("isAbsoluteUrl", () => {
 
     // Assert
     expect(result).toBe(expected);
+  });
+});
+
+describe("resolveServerUrl", () => {
+  test("returns explicit pingUrl when set", () => {
+    expect(resolveServerUrl({ pingUrl: "http://x.local/ping", href: "/anything/" })).toBe("http://x.local/ping");
+  });
+
+  test("returns absolute href as-is when no pingUrl", () => {
+    expect(resolveServerUrl({ pingUrl: null, href: "https://abs.example.com/x" })).toBe("https://abs.example.com/x");
+  });
+
+  test("returns null for path-only href (no server-side expansion)", () => {
+    expect(resolveServerUrl({ pingUrl: null, href: "/cockpit/" })).toBeNull();
+  });
+
+  test("returns null when both pingUrl and href are null", () => {
+    expect(resolveServerUrl({ pingUrl: null, href: null })).toBeNull();
+  });
+
+  test("path-only href with explicit pingUrl returns the pingUrl", () => {
+    // The HaLOS-shipped-card scenario: adapter sets explicit pingUrl while
+    // href stays path-only for browser-side multi-hostname resolution.
+    expect(resolveServerUrl({ pingUrl: "https://host.docker.internal/cockpit/", href: "/cockpit/" })).toBe(
+      "https://host.docker.internal/cockpit/",
+    );
   });
 });

--- a/packages/common/src/url.ts
+++ b/packages/common/src/url.ts
@@ -26,6 +26,29 @@ export const extractBaseUrlFromHeaders = (
   return `${protocol}://${host}`;
 };
 
+/**
+ * Resolves an app to the absolute URL the server should use, or null.
+ *   1. explicit `pingUrl`        -> as-is
+ *   2. absolute `href`           -> as-is
+ *   3. path-only or null `href`  -> null
+ *
+ * Path-only hrefs are intentionally null server-side: synthesizing them from
+ * request headers would be a header-spoofing vector, and the browser already
+ * resolves them against the current origin natively. Apps that need
+ * server-side ping coverage should carry an explicit `pingUrl`.
+ */
+export const resolveServerUrl = (app: { href: string | null; pingUrl: string | null }): string | null => {
+  if (app.pingUrl) {
+    return app.pingUrl;
+  }
+
+  if (app.href && !app.href.startsWith("/")) {
+    return app.href;
+  }
+
+  return null;
+};
+
 export const getPortFromUrl = (url: URL): number => {
   const port = url.port;
   if (port) {

--- a/packages/translation/src/lang/ca.json
+++ b/packages/translation/src/lang/ca.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "",
           "fileTooLarge": "",
           "invalidConfiguration": "",
-          "groupNameTaken": ""
+          "groupNameTaken": "",
+          "appHrefInvalid": "",
+          "appHrefConsecutiveSlashes": ""
         }
       }
     },

--- a/packages/translation/src/lang/cn.json
+++ b/packages/translation/src/lang/cn.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "文件名无效",
           "fileTooLarge": "文件太大，最大大小为 {maxSize}",
           "invalidConfiguration": "无效配置",
-          "groupNameTaken": "用户组名称已存在"
+          "groupNameTaken": "用户组名称已存在",
+          "appHrefInvalid": "必须为绝对网址（https://example.com）或以 / 开头的路径（例如 /cockpit/）",
+          "appHrefConsecutiveSlashes": "路径不得包含连续的斜杠"
         }
       }
     },

--- a/packages/translation/src/lang/cs.json
+++ b/packages/translation/src/lang/cs.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "",
           "fileTooLarge": "Soubor je příliš velký, maximální velikost je {maxSize}",
           "invalidConfiguration": "Neplatná konfigurace",
-          "groupNameTaken": "Název skupiny je již používán"
+          "groupNameTaken": "Název skupiny je již používán",
+          "appHrefInvalid": "Musí být absolutní URL (https://example.com) nebo cesta začínající znakem / (např. /cockpit/)",
+          "appHrefConsecutiveSlashes": "Cesta nesmí obsahovat po sobě jdoucí lomítka"
         }
       }
     },

--- a/packages/translation/src/lang/da.json
+++ b/packages/translation/src/lang/da.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Ugyldigt filnavn",
           "fileTooLarge": "Filen er for stor, maksimal størrelse er {maxSize}",
           "invalidConfiguration": "Ugyldig konfiguration",
-          "groupNameTaken": "Gruppenavn allerede taget"
+          "groupNameTaken": "Gruppenavn allerede taget",
+          "appHrefInvalid": "Skal være en absolut URL (https://example.com) eller en sti, der begynder med / (f.eks. /cockpit/)",
+          "appHrefConsecutiveSlashes": "Stien må ikke indeholde fortløbende skråstreger"
         }
       }
     },

--- a/packages/translation/src/lang/de-CH.json
+++ b/packages/translation/src/lang/de-CH.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Ungültiger Dateiname",
           "fileTooLarge": "Datei ist zu groß, maximale Größe ist {maxSize}",
           "invalidConfiguration": "Ungültige Konfiguration",
-          "groupNameTaken": "Gruppenname bereits vergeben"
+          "groupNameTaken": "Gruppenname bereits vergeben",
+          "appHrefInvalid": "Muss eine absolute URL (https://example.com) oder ein Pfad sein, der mit / beginnt (z. B. /cockpit/)",
+          "appHrefConsecutiveSlashes": "Pfad darf keine aufeinanderfolgenden Schrägstriche enthalten"
         }
       }
     },

--- a/packages/translation/src/lang/de.json
+++ b/packages/translation/src/lang/de.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Ungültiger Dateiname",
           "fileTooLarge": "Datei ist zu groß, maximale Größe ist {maxSize}",
           "invalidConfiguration": "Ungültige Konfiguration",
-          "groupNameTaken": "Gruppenname bereits vergeben"
+          "groupNameTaken": "Gruppenname bereits vergeben",
+          "appHrefInvalid": "Muss eine absolute URL (https://example.com) oder ein Pfad sein, der mit / beginnt (z. B. /cockpit/)",
+          "appHrefConsecutiveSlashes": "Pfad darf keine aufeinanderfolgenden Schrägstriche enthalten"
         }
       }
     },

--- a/packages/translation/src/lang/el.json
+++ b/packages/translation/src/lang/el.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "",
           "fileTooLarge": "",
           "invalidConfiguration": "",
-          "groupNameTaken": ""
+          "groupNameTaken": "",
+          "appHrefInvalid": "",
+          "appHrefConsecutiveSlashes": ""
         }
       }
     },

--- a/packages/translation/src/lang/en-gb.json
+++ b/packages/translation/src/lang/en-gb.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Invalid file name provided",
           "fileTooLarge": "The file is too large, the maximum size is {maxSize}",
           "invalidConfiguration": "Configuration is invalid",
-          "groupNameTaken": "An existing group already has this name"
+          "groupNameTaken": "An existing group already has this name",
+          "appHrefInvalid": "Must be an absolute URL (https://example.com) or a path starting with / (e.g. /cockpit/)",
+          "appHrefConsecutiveSlashes": "Path must not contain consecutive slashes"
         }
       }
     },

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Invalid file name",
           "fileTooLarge": "File is too large, maximum size is {maxSize}",
           "invalidConfiguration": "Invalid configuration",
-          "groupNameTaken": "Group name already taken"
+          "groupNameTaken": "Group name already taken",
+          "appHrefInvalid": "Must be an absolute URL (https://example.com) or a path starting with / (e.g. /cockpit/)",
+          "appHrefConsecutiveSlashes": "Path must not contain consecutive slashes"
         }
       }
     },

--- a/packages/translation/src/lang/es.json
+++ b/packages/translation/src/lang/es.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Nombre de archivo no válido",
           "fileTooLarge": "El archivo es demasiado grande, el tamaño máximo es {maxSize}",
           "invalidConfiguration": "Configuración no válida",
-          "groupNameTaken": "Nombre del grupo en uso"
+          "groupNameTaken": "Nombre del grupo en uso",
+          "appHrefInvalid": "Debe ser una URL absoluta (https://example.com) o una ruta que comience con / (p. ej. /cockpit/)",
+          "appHrefConsecutiveSlashes": "La ruta no debe contener barras consecutivas"
         }
       }
     },

--- a/packages/translation/src/lang/et.json
+++ b/packages/translation/src/lang/et.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "",
           "fileTooLarge": "",
           "invalidConfiguration": "",
-          "groupNameTaken": ""
+          "groupNameTaken": "",
+          "appHrefInvalid": "",
+          "appHrefConsecutiveSlashes": ""
         }
       }
     },

--- a/packages/translation/src/lang/fr.json
+++ b/packages/translation/src/lang/fr.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Nom de fichier invalide",
           "fileTooLarge": "Le fichier est trop volumineux, la taille maximale est {maxSize}",
           "invalidConfiguration": "Configuration invalide",
-          "groupNameTaken": "Nom de groupe déjà utilisé"
+          "groupNameTaken": "Nom de groupe déjà utilisé",
+          "appHrefInvalid": "Doit être une URL absolue (https://example.com) ou un chemin commençant par / (par ex. /cockpit/)",
+          "appHrefConsecutiveSlashes": "Le chemin ne doit pas contenir de barres obliques consécutives"
         }
       }
     },

--- a/packages/translation/src/lang/he.json
+++ b/packages/translation/src/lang/he.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "שם קובץ לא חוקי",
           "fileTooLarge": "הקובץ גדול מדי, הגודל המרבי הוא {maxSize}",
           "invalidConfiguration": "תצורה לא חוקית",
-          "groupNameTaken": "שם הקבוצה כבר תפוס"
+          "groupNameTaken": "שם הקבוצה כבר תפוס",
+          "appHrefInvalid": "חייב להיות כתובת URL מוחלטת (https://example.com) או נתיב שמתחיל ב-/ (לדוגמה /cockpit/)",
+          "appHrefConsecutiveSlashes": "הנתיב לא יכול להכיל קווים נטויים עוקבים"
         }
       }
     },

--- a/packages/translation/src/lang/hr.json
+++ b/packages/translation/src/lang/hr.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "",
           "fileTooLarge": "",
           "invalidConfiguration": "",
-          "groupNameTaken": ""
+          "groupNameTaken": "",
+          "appHrefInvalid": "",
+          "appHrefConsecutiveSlashes": ""
         }
       }
     },

--- a/packages/translation/src/lang/hu.json
+++ b/packages/translation/src/lang/hu.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Érvénytelen fájlnév",
           "fileTooLarge": "A fájl túl nagy, a maximális méret {maxSize}",
           "invalidConfiguration": "Érvénytelen konfiguráció",
-          "groupNameTaken": "A felhasználónév már foglalt"
+          "groupNameTaken": "A felhasználónév már foglalt",
+          "appHrefInvalid": "Abszolút URL (https://example.com) vagy / jellel kezdődő útvonal (pl. /cockpit/) szükséges",
+          "appHrefConsecutiveSlashes": "Az útvonal nem tartalmazhat egymást követő perjeleket"
         }
       }
     },

--- a/packages/translation/src/lang/it.json
+++ b/packages/translation/src/lang/it.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Nome file non valido",
           "fileTooLarge": "Il file è troppo grande, la dimensione massima è {maxSize}",
           "invalidConfiguration": "Configurazione non valida",
-          "groupNameTaken": "Nome gruppo già preso"
+          "groupNameTaken": "Nome gruppo già preso",
+          "appHrefInvalid": "Deve essere un URL assoluto (https://example.com) o un percorso che inizia con / (es. /cockpit/)",
+          "appHrefConsecutiveSlashes": "Il percorso non deve contenere barre consecutive"
         }
       }
     },

--- a/packages/translation/src/lang/ja.json
+++ b/packages/translation/src/lang/ja.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "無効なファイル名です",
           "fileTooLarge": "ファイルが大きすぎます。最大サイズは {maxSize} です",
           "invalidConfiguration": "無効な設定",
-          "groupNameTaken": "グループ名は、既に使用されています"
+          "groupNameTaken": "グループ名は、既に使用されています",
+          "appHrefInvalid": "絶対URL（https://example.com）または / で始まるパス（例: /cockpit/）を指定してください",
+          "appHrefConsecutiveSlashes": "パスに連続するスラッシュを含めることはできません"
         }
       }
     },

--- a/packages/translation/src/lang/ko.json
+++ b/packages/translation/src/lang/ko.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "",
           "fileTooLarge": "",
           "invalidConfiguration": "",
-          "groupNameTaken": ""
+          "groupNameTaken": "",
+          "appHrefInvalid": "",
+          "appHrefConsecutiveSlashes": ""
         }
       }
     },

--- a/packages/translation/src/lang/lt.json
+++ b/packages/translation/src/lang/lt.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "",
           "fileTooLarge": "",
           "invalidConfiguration": "",
-          "groupNameTaken": ""
+          "groupNameTaken": "",
+          "appHrefInvalid": "",
+          "appHrefConsecutiveSlashes": ""
         }
       }
     },

--- a/packages/translation/src/lang/lv.json
+++ b/packages/translation/src/lang/lv.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "",
           "fileTooLarge": "",
           "invalidConfiguration": "",
-          "groupNameTaken": ""
+          "groupNameTaken": "",
+          "appHrefInvalid": "",
+          "appHrefConsecutiveSlashes": ""
         }
       }
     },

--- a/packages/translation/src/lang/nl.json
+++ b/packages/translation/src/lang/nl.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Ongeldige bestandsnaam",
           "fileTooLarge": "Bestand is te groot, maximale grootte is {maxSize}",
           "invalidConfiguration": "Ongeldige configuratie",
-          "groupNameTaken": "Groepsnaam al in gebruik"
+          "groupNameTaken": "Groepsnaam al in gebruik",
+          "appHrefInvalid": "Moet een absolute URL zijn (https://example.com) of een pad dat begint met / (bijv. /cockpit/)",
+          "appHrefConsecutiveSlashes": "Pad mag geen opeenvolgende schuine strepen bevatten"
         }
       }
     },

--- a/packages/translation/src/lang/no.json
+++ b/packages/translation/src/lang/no.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Ugyldig filnavn",
           "fileTooLarge": "Filen er for stor, maks størrelse er {maxSize}",
           "invalidConfiguration": "Ugyldig konfigurasjon",
-          "groupNameTaken": "Gruppenavn allerede tatt"
+          "groupNameTaken": "Gruppenavn allerede tatt",
+          "appHrefInvalid": "Må være en absolutt URL (https://example.com) eller en sti som begynner med / (f.eks. /cockpit/)",
+          "appHrefConsecutiveSlashes": "Stien kan ikke inneholde påfølgende skråstreker"
         }
       }
     },

--- a/packages/translation/src/lang/pl.json
+++ b/packages/translation/src/lang/pl.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Nieprawidłowa nazwa pliku",
           "fileTooLarge": "Plik jest zbyt duży, maksymalny rozmiar to {maxSize}",
           "invalidConfiguration": "Nieprawidłowa konfiguracja",
-          "groupNameTaken": "Nazwa użytkownika jest już zajęta"
+          "groupNameTaken": "Nazwa użytkownika jest już zajęta",
+          "appHrefInvalid": "Musi być pełnym adresem URL (https://example.com) lub ścieżką zaczynającą się od / (np. /cockpit/)",
+          "appHrefConsecutiveSlashes": "Ścieżka nie może zawierać następujących po sobie ukośników"
         }
       }
     },

--- a/packages/translation/src/lang/ro.json
+++ b/packages/translation/src/lang/ro.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "",
           "fileTooLarge": "",
           "invalidConfiguration": "",
-          "groupNameTaken": ""
+          "groupNameTaken": "",
+          "appHrefInvalid": "",
+          "appHrefConsecutiveSlashes": ""
         }
       }
     },

--- a/packages/translation/src/lang/ru.json
+++ b/packages/translation/src/lang/ru.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Недопустимое имя файла",
           "fileTooLarge": "Файл слишком большой, максимальный размер {maxSize}",
           "invalidConfiguration": "Неверная конфигурация",
-          "groupNameTaken": "Имя группы уже занято"
+          "groupNameTaken": "Имя группы уже занято",
+          "appHrefInvalid": "Должен быть абсолютный URL (https://example.com) или путь, начинающийся с / (например, /cockpit/)",
+          "appHrefConsecutiveSlashes": "Путь не должен содержать подряд идущих слешей"
         }
       }
     },

--- a/packages/translation/src/lang/sk.json
+++ b/packages/translation/src/lang/sk.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Neplatný názov súboru",
           "fileTooLarge": "Súbor je príliš veľký, maximálna veľkosť je {maxSize}",
           "invalidConfiguration": "Neplatná konfigurácia",
-          "groupNameTaken": "Názov skupiny je už obsadený"
+          "groupNameTaken": "Názov skupiny je už obsadený",
+          "appHrefInvalid": "Musí byť absolútna URL (https://example.com) alebo cesta začínajúca znakom / (napr. /cockpit/)",
+          "appHrefConsecutiveSlashes": "Cesta nesmie obsahovať po sebe nasledujúce lomky"
         }
       }
     },

--- a/packages/translation/src/lang/sl.json
+++ b/packages/translation/src/lang/sl.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "",
           "fileTooLarge": "",
           "invalidConfiguration": "",
-          "groupNameTaken": ""
+          "groupNameTaken": "",
+          "appHrefInvalid": "",
+          "appHrefConsecutiveSlashes": ""
         }
       }
     },

--- a/packages/translation/src/lang/sv.json
+++ b/packages/translation/src/lang/sv.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "",
           "fileTooLarge": "",
           "invalidConfiguration": "",
-          "groupNameTaken": ""
+          "groupNameTaken": "",
+          "appHrefInvalid": "",
+          "appHrefConsecutiveSlashes": ""
         }
       }
     },

--- a/packages/translation/src/lang/tr.json
+++ b/packages/translation/src/lang/tr.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "Geçersiz dosya adı",
           "fileTooLarge": "Dosya çok büyük, azami boyut {maxSize}",
           "invalidConfiguration": "Geçersiz yapılandırma",
-          "groupNameTaken": "Grup adı zaten alınmış"
+          "groupNameTaken": "Grup adı zaten alınmış",
+          "appHrefInvalid": "Mutlak bir URL (https://example.com) veya / ile başlayan bir yol (ör. /cockpit/) olmalıdır",
+          "appHrefConsecutiveSlashes": "Yol ardışık eğik çizgiler içermemelidir"
         }
       }
     },

--- a/packages/translation/src/lang/uk.json
+++ b/packages/translation/src/lang/uk.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "",
           "fileTooLarge": "Файл завеликий, максимальний розмір становить {maxSize}",
           "invalidConfiguration": "Невірна конфігурація",
-          "groupNameTaken": "Назва групи вже зайнята"
+          "groupNameTaken": "Назва групи вже зайнята",
+          "appHrefInvalid": "Має бути абсолютний URL (https://example.com) або шлях, що починається з / (наприклад, /cockpit/)",
+          "appHrefConsecutiveSlashes": "Шлях не повинен містити підряд кілька скісних рисок"
         }
       }
     },

--- a/packages/translation/src/lang/vi.json
+++ b/packages/translation/src/lang/vi.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "",
           "fileTooLarge": "",
           "invalidConfiguration": "",
-          "groupNameTaken": ""
+          "groupNameTaken": "",
+          "appHrefInvalid": "",
+          "appHrefConsecutiveSlashes": ""
         }
       }
     },

--- a/packages/translation/src/lang/zh.json
+++ b/packages/translation/src/lang/zh.json
@@ -1513,7 +1513,9 @@
           "invalidFileName": "無效的檔案名稱",
           "fileTooLarge": "檔案太大，最大大小為 {maxSize}",
           "invalidConfiguration": "無效設定",
-          "groupNameTaken": "用戶組名稱已存在"
+          "groupNameTaken": "用戶組名稱已存在",
+          "appHrefInvalid": "必須為絕對網址（https://example.com）或以 / 開頭的路徑（例如 /cockpit/）",
+          "appHrefConsecutiveSlashes": "路徑不得包含連續斜線"
         }
       }
     },

--- a/packages/validation/src/app.ts
+++ b/packages/validation/src/app.ts
@@ -1,10 +1,65 @@
 import { z } from "zod/v4";
 
-export const appHrefSchema = z
+import { createCustomErrorParams } from "./form/i18n";
+
+// `appHrefSchema` accepts:
+//   - empty string -> null
+//   - absolute URL with http/https scheme (or any non-javascript scheme)
+//   - path-only URL starting with "/" followed by a non-"/" character
+//
+// Path-only hrefs are resolved against the current origin in the browser, and
+// against the request origin server-side via `resolveServerUrl`. This lets a
+// single dashboard work across multiple hostnames (mDNS, VPN FQDN, DHCP DNS).
+//
+// Rejects: javascript: scheme, protocol-relative ("//host/..."), single-slash
+// root ("/"), bare strings without scheme or leading slash.
+const absoluteHrefSchema = z
   .string()
   .trim()
   .url()
-  .regex(/^(?!javascript)[a-zA-Z]*:\/\//i) // javascript: is not allowed, i for case insensitive (so Javascript: is also not allowed)
+  .regex(/^(?!javascript)[a-zA-Z]*:\/\//i);
+
+// Disallowed characters anywhere in a path-only href:
+//   - "/" past the leading position would either produce protocol-relative
+//     "//host" (already rejected outright) or run-on slashes "/foo//bar"
+//     (cosmetic, also rejected for consistency).
+//   - "\" — WHATWG URL parser normalizes backslash to forward slash for
+//     http(s), so "/\evil.example.com" rendered into <a href> navigates
+//     cross-origin. JS regex \s does not catch this; explicit reject.
+//   - JS \s whitespace.
+//   - C0 / C1 control bytes (U+0000-U+001F, U+007F-U+009F) — invisible in
+//     admin UI, may survive into the DOM.
+//   - Bidi / zero-width / formatting characters (U+200B-U+200F, U+2028-U+202F,
+//     U+2066-U+2069, U+FEFF). These bypass `\s` and enable display-spoofing
+//     in the rendered sub-label without affecting the resolved navigation
+//     target — admin-confusion / phishing of secondary navigation.
+const PATH_DISALLOWED = "\\\\\\s\\u0000-\\u001F\\u007F-\\u009F\\u200B-\\u200F\\u2028-\\u202F\\u2066-\\u2069\\uFEFF";
+
+const PATH_ONLY_REGEX = new RegExp(`^/[^/${PATH_DISALLOWED}][^${PATH_DISALLOWED}]*$`);
+
+const pathOnlyHrefSchema = z
+  .string()
+  .trim()
+  // Leading "/" followed by at least one non-"/" / non-disallowed char,
+  // then any mix of allowed chars (including "/" for internal segments).
+  .refine((value) => PATH_ONLY_REGEX.test(value), {
+    params: createCustomErrorParams({
+      key: "appHrefInvalid",
+      params: {},
+    }),
+  })
+  // Reject consecutive slashes anywhere ("/foo//bar"). Cosmetic on its own
+  // but keeps the rendered sub-label canonical and matches the leading-"/"
+  // exclusion of "//host/...".
+  .refine((value) => !value.includes("//"), {
+    params: createCustomErrorParams({
+      key: "appHrefConsecutiveSlashes",
+      params: {},
+    }),
+  });
+
+export const appHrefSchema = absoluteHrefSchema
+  .or(pathOnlyHrefSchema)
   .or(z.literal(""))
   .transform((value) => (value.length === 0 ? null : value))
   .nullable();

--- a/packages/validation/src/test/app.spec.ts
+++ b/packages/validation/src/test/app.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+
+import { appHrefSchema } from "../app";
+
+describe("appHrefSchema", () => {
+  test.each([
+    "https://example.com/path",
+    "http://example.com/path",
+    "https://example.com",
+    "/cockpit/",
+    "/signalk-server/@signalk/freeboard-sk/",
+    "/x",
+  ])("accepts %s", (input) => {
+    expect(appHrefSchema.parse(input)).toBe(input);
+  });
+
+  test("transforms empty string to null", () => {
+    expect(appHrefSchema.parse("")).toBeNull();
+  });
+
+  test("accepts null", () => {
+    expect(appHrefSchema.parse(null)).toBeNull();
+  });
+
+  test.each([
+    ["javascript:alert(1)"],
+    ["JavaScript:alert(1)"],
+    ["//evil.example.com/path"],
+    ["/"],
+    ["cockpit/"],
+    ["not-a-url"],
+    ["./relative"],
+    ["../relative"],
+    // Browser-normalized cross-origin escapes — WHATWG URL parser collapses
+    // backslash to forward slash for http(s), so these would navigate
+    // off-origin if rendered into <a href>. Reject up front.
+    ["/\\evil.example.com/x"],
+    ["/\\\\evil.example.com/x"],
+    // Whitespace / control characters anywhere in the path.
+    ["/foo bar"],
+    ["/foo\tbar"],
+    ["/foo\nbar"],
+    ["/\tfoo"],
+    // C0 / C1 controls (invisible).
+    ["/foo"],
+    ["/foo"],
+    ["/foo"],
+    ["/foo"],
+    // Zero-width / bidi / formatting characters (display-spoofing class).
+    ["/​foo"], // ZWSP
+    ["/‌foo"], // ZWNJ
+    ["/‍foo"], // ZWJ
+    ["/‮foo"], // RTL override
+    ["/﻿foo"], // BOM
+    // Consecutive slashes mid-path.
+    ["/foo//bar"],
+    ["/cockpit//"],
+  ])("rejects %s", (input) => {
+    expect(() => appHrefSchema.parse(input)).toThrow();
+  });
+});

--- a/packages/widgets/src/app/component.tsx
+++ b/packages/widgets/src/app/component.tsx
@@ -1,26 +1,22 @@
 "use client";
 
 import type { PropsWithChildren } from "react";
-import { Fragment, Suspense } from "react";
+import { Fragment } from "react";
 import { Flex, rem, Stack, Text, Tooltip, UnstyledButton } from "@mantine/core";
-import { IconMinus } from "@tabler/icons-react";
 import combineClasses from "clsx";
 
 import { clientApi } from "@homarr/api/client";
 import { useRequiredBoard } from "@homarr/boards/context";
 import { useSettings } from "@homarr/settings";
 import { useRegisterSpotlightContextResults } from "@homarr/spotlight";
-import { useI18n } from "@homarr/translation/client";
 import { MaskedOrNormalImage } from "@homarr/ui";
 
 import { WidgetEmptyState } from "../common/empty-state";
 import type { WidgetComponentProps } from "../definition";
 import classes from "./app.module.css";
-import { PingDot } from "./ping/ping-dot";
 import { PingIndicator } from "./ping/ping-indicator";
 
 export default function AppWidget({ options, isEditMode, height, width }: WidgetComponentProps<"app">) {
-  const t = useI18n();
   const settings = useSettings();
   const board = useRequiredBoard();
   const { data: app } = clientApi.app.byId.useQuery({
@@ -80,7 +76,6 @@ export default function AppWidget({ options, isEditMode, height, width }: Widget
           justify="center"
           align="center"
           gap={isColumnLayout ? 0 : "sm"}
-          onContextMenu={isEditMode ? (e) => e.preventDefault() : undefined}
         >
           <Stack gap={0}>
             {options.showTitle && (
@@ -125,9 +120,7 @@ export default function AppWidget({ options, isEditMode, height, width }: Widget
         </Flex>
       </Tooltip.Floating>
       {options.pingEnabled && !settings.forceDisableStatus && !board.disableStatus && app.href ? (
-        <Suspense fallback={<PingDot icon={IconMinus} color="gray" tooltip={`${t("common.action.loading")}…`} />}>
-          <PingIndicator appId={app.id} />
-        </Suspense>
+        <PingIndicator appId={app.id} />
       ) : null}
     </AppLink>
   );

--- a/packages/widgets/src/app/ping/ping-indicator.tsx
+++ b/packages/widgets/src/app/ping/ping-indicator.tsx
@@ -1,4 +1,5 @@
-import { IconCheck, IconMinus, IconX } from "@tabler/icons-react";
+import { IconCheck, IconLoader, IconMinus, IconX } from "@tabler/icons-react";
+import { TRPCClientError } from "@trpc/client";
 
 import { clientApi } from "@homarr/api/client";
 import { useI18n } from "@homarr/translation/client";
@@ -11,7 +12,14 @@ interface PingIndicatorProps {
 
 export const PingIndicator = ({ appId }: PingIndicatorProps) => {
   const t = useI18n();
-  const { data: pingResult } = clientApi.widget.app.ping.useQuery({ id: appId }, { refetchOnMount: false });
+  const { data: pingResult, error } = clientApi.widget.app.ping.useQuery({ id: appId }, { refetchOnMount: false });
+
+  // Apps without a server-pingable URL (e.g. a path-only href without an
+  // explicit pingUrl) yield a CONFLICT. Show an indeterminate orange dot for
+  // that case so the card stays usable instead of a perpetual loading state.
+  if (error instanceof TRPCClientError && error.data?.code === "CONFLICT") {
+    return <PingDot icon={IconLoader} color="orange" tooltip={error.message} />;
+  }
 
   if (!pingResult) return <PingDot icon={IconMinus} color="gray" tooltip={`${t("common.action.loading")}…`} />;
 

--- a/packages/widgets/src/bookmarks/component.tsx
+++ b/packages/widgets/src/bookmarks/component.tsx
@@ -11,6 +11,7 @@ import { MaskedOrNormalImage } from "@homarr/ui";
 
 import type { WidgetComponentProps } from "../definition";
 import classes from "./bookmark.module.css";
+import { getHrefSubLabel } from "./sub-label";
 
 export default function BookmarksWidget({ options, itemId }: WidgetComponentProps<"bookmarks">) {
   const board = useRequiredBoard();
@@ -247,7 +248,7 @@ const VerticalItem = ({
       )}
       {!hideHostname && (
         <Anchor ta="center" component="span" size="xs">
-          {app.href ? new URL(app.href).hostname : undefined}
+          {getHrefSubLabel(app.href)}
         </Anchor>
       )}
     </Stack>
@@ -294,7 +295,7 @@ const HorizontalItem = ({
 
             {!hideHostname && (
               <Anchor component="span" size="xs">
-                {app.href ? new URL(app.href).hostname : undefined}
+                {getHrefSubLabel(app.href)}
               </Anchor>
             )}
           </Stack>

--- a/packages/widgets/src/bookmarks/sub-label.ts
+++ b/packages/widgets/src/bookmarks/sub-label.ts
@@ -1,0 +1,8 @@
+import { removeTrailingSlash } from "@homarr/common";
+
+// Path-only hrefs render as the path itself; absolute hrefs render the host.
+export const getHrefSubLabel = (href: string | null | undefined): string | undefined => {
+  if (!href) return undefined;
+  if (href.startsWith("/")) return removeTrailingSlash(href);
+  return new URL(href).hostname;
+};

--- a/packages/widgets/src/bookmarks/test/sub-label.spec.ts
+++ b/packages/widgets/src/bookmarks/test/sub-label.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+
+import { getHrefSubLabel } from "../sub-label";
+
+describe("getHrefSubLabel", () => {
+  test.each([[null], [undefined], [""]])("returns undefined for %s", (input) => {
+    expect(getHrefSubLabel(input)).toBeUndefined();
+  });
+
+  test.each([
+    ["https://docs.halos.fi", "docs.halos.fi"],
+    ["https://docs.halos.fi/path", "docs.halos.fi"],
+    ["http://example.com:8080/x", "example.com"],
+  ])("returns hostname for absolute %s", (input, expected) => {
+    expect(getHrefSubLabel(input)).toBe(expected);
+  });
+
+  test.each([
+    ["/cockpit/", "/cockpit"],
+    ["/cockpit", "/cockpit"],
+    ["/signalk-server/@signalk/freeboard-sk/", "/signalk-server/@signalk/freeboard-sk"],
+    ["/x", "/x"],
+  ])("returns trimmed path for path-only %s", (input, expected) => {
+    expect(getHrefSubLabel(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
**This is a minimal alternative to #5595.**

Claude's description follows.
----
## Summary

Allow app card hrefs to be **path-only** (e.g. `/cockpit/`) in addition to
absolute URLs. A path-only href is rendered as a plain `<a href="/cockpit/">` and
resolved by the browser against the current origin, so a single dashboard works
across every hostname the device answers on (mDNS `.local`, a VPN FQDN, a
DHCP-provided FQDN) without baking a hostname into each card at registration time.

This is the motivating case for self-hosted / reverse-proxy setups where the same
Homarr instance is reached over more than one hostname and SSO/cookies/redirects
are already per-host.

## Scope

Deliberately narrow — just the app-card surface:

- `packages/validation` — `appHrefSchema` accepts absolute URL **or** path-only form
- `packages/common` — `resolveServerUrl(app)` centralises the
  pingUrl-or-absolute-or-null resolution used server-side
- `packages/widgets` — app card, ping indicator, and bookmarks sub-label handle
  path-only entries
- `packages/api` — the ping router routes through `resolveServerUrl`

No changes to the integration framework. Path-only support for integration
`externalUrl` (the `RenderablePath` work) and the URL-typing refactor from #5595
are intentionally left out so this can be reviewed and merged on its own; they can
follow as a separate PR.

## Server-side resolution

Path-only hrefs resolve to `null` server-side. The server has no canonical
hostname for a path-only app and must not synthesize one from request headers
(that would be a header-spoofing / SSRF vector). In the ping widget, a path-only
href without an explicit `pingUrl` returns a `CONFLICT` and the indicator shows an
indeterminate state rather than up/down. Apps that need server-side ping coverage
under a multi-hostname deployment set an explicit `pingUrl`.

## Backward compatibility

Additive. Absolute hrefs behave exactly as before — `resolveServerUrl` returns
them unchanged, the ping widget and bookmarks render identically, and no existing
app or integration changes behaviour. The only new acceptance is the path-only
form.

## Validation

The path-only branch rejects `javascript:`, protocol-relative `//host/...`,
single-slash root `/`, consecutive slashes mid-path, backslashes, whitespace,
C0/C1 control characters, and Unicode zero-width / bidi / formatting characters
(display-spoofing protection). Absolute-URL validation is unchanged.

## Documentation

`apps/docs/docs/management/apps/index.mdx` — documents the path-only URL form on
the App URL field, and notes that the status check needs an explicit Ping URL for
path-only apps.

## Testing

- `resolveServerUrl`: pingUrl precedence, absolute pass-through, path-only → null,
  null inputs, path-only-with-pingUrl
- `appHrefSchema`: accepts absolute and path-only; rejects the cases above
- Bookmarks sub-label: renders the path for path-only entries, hostname for
  absolute

----

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)

**NOTE:** Stale documentation repo in the template

- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App links now support clearer handling of full URLs vs. path-only values.
  * Bookmark items now show a more useful sub-label, such as a host name or path.

* **Bug Fixes**
  * Ping status now works correctly for apps with path-only URLs when a full ping URL is provided.
  * Added safer validation for app URLs, including rejecting invalid formats and consecutive slashes.

* **Documentation**
  * Clarified how Ping URL settings should be configured for path-only URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->