### PR TITLE
fix (Calendar Widget): Add superjson serialization to query cache persister

### DIFF
--- a/apps/nextjs/src/app/[locale]/_client-providers/query-cache-persister.ts
+++ b/apps/nextjs/src/app/[locale]/_client-providers/query-cache-persister.ts
@@ -1,4 +1,5 @@
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
+import superjson from "superjson";
 
 import { fetchApi } from "@homarr/api/client";
 import { getActiveQueryCacheBoardId, queryCacheStoragePrefix } from "@homarr/api/query-cache";
@@ -26,4 +27,6 @@ export const createWidgetQueryPersister = () =>
     storage: typeof window === "undefined" ? undefined : queryCacheStorage,
     key: queryCacheStoragePrefix,
     throttleTime: 2000,
+    serialize: (data) => superjson.stringify(data),
+    deserialize: (data) => superjson.parse(data),
   });


### PR DESCRIPTION

<img width="300" height="377" alt="Screenshot 2026-07-04 081724" src="https://github.com/user-attachments/assets/d5fa26b8-e585-413c-a1a8-6c32b6cd2138" />
<img width="300" height="377" alt="Screenshot 2026-07-04 090146" src="https://github.com/user-attachments/assets/369b2a76-2652-484b-a870-e354f473edec" />



This fixes the calendar widget's query results were being cached to disk (query-cache-persister.ts) using plain JSON.stringify/JSON.parse, which turns Date objects into strings with no way to convert them back. 

On reload, the calendar rendered with those string startDate values before fresh data arrived, and a .getTime() call on a string threw the error.

Fix: I've made the persister use superjson instead of plain JSON, so Date objects round-trip correctly through the cache.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence of cached app data so it can be restored more reliably across sessions and page reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->