### PR TITLE
fix(layout): raise AppShellHeader z-index above Proxmox status dots

### DIFF
--- a/apps/nextjs/src/components/layout/header.tsx
+++ b/apps/nextjs/src/components/layout/header.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 export const MainHeader = ({ logo, actions, hasNavigation = true }: Props) => {
   return (
-    <AppShellHeader maw="100vw" style={{ overflowX: "hidden" }}>
+    <AppShellHeader maw="100vw" zIndex={201} style={{ overflowX: "hidden" }}>
       <Group h="100%" gap="xl" px="md" justify="apart" wrap="nowrap">
         <Group h="100%" align="center" style={{ flex: 1 }} wrap="nowrap">
           {hasNavigation && <ClientBurger />}


### PR DESCRIPTION
## Summary

- The Proxmox cluster health widget uses Mantine `Indicator` for the VM/LXC status dots, which sits at `z-index: 200`. The `AppShellHeader` defaults to `z-index: 100`, so the dots bled above the header when scrolling the widget.
- Set `zIndex={201}` on `AppShellHeader` in `apps/nextjs/src/components/layout/header.tsx` so the header stacks above `Indicator` content (and below modal/popover layers at 300+).

Fixes #6194
Closes https://github.com/homarr-labs/homarr/issues/6194

## Reproduction

Using the Proxmox app, scrolling caused the status dots for VMs/LXCs to render above the sticky header.

## Changes

```diff
- <AppShellHeader maw="100vw" style={{ overflowX: "hidden" }}>
+ <AppShellHeader maw="100vw" zIndex={201} style={{ overflowX: "hidden" }}>
```

## Impact

Cosmetic only — no behavior change beyond stacking order.