### PR TITLE
feat(widgets): add per-filesystem storage chart to Beszel system stats

### DIFF
--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -3747,6 +3747,9 @@
         },
         "showDockerNetwork": {
           "label": "Show Docker network chart"
+        },
+        "showStorage": {
+          "label": "Show storage chart"
         }
       },
       "selectSystem": "Select system",
@@ -3781,6 +3784,11 @@
           "subtitle": "Throughput of root filesystem",
           "read": "Read",
           "write": "Write"
+        },
+        "storage": {
+          "title": "Storage",
+          "subtitle": "Per-filesystem disk usage",
+          "series": "Used"
         },
         "network": {
           "title": "Bandwidth",

--- a/packages/widgets/src/beszel-system-stats/component.tsx
+++ b/packages/widgets/src/beszel-system-stats/component.tsx
@@ -21,6 +21,7 @@ import {
   CPU_Y_AXIS_DOMAIN,
   useContainerNames,
   useDockerChartData,
+  useEfsChartData,
   useSystemChartData,
 } from "../beszel/_shared/chart";
 import {
@@ -185,9 +186,33 @@ export default function BeszelSystemStatsWidget({
     timePeriod,
   );
 
+  const efsPaths = useMemo(() => {
+    if (!systemStats) return [];
+    const paths = new Set<string>();
+    for (const record of systemStats) {
+      if (record.stats.efs) {
+        for (const path of Object.keys(record.stats.efs)) {
+          paths.add(path);
+        }
+      }
+    }
+    return [...paths];
+  }, [systemStats]);
+
+  const storageData = useEfsChartData(
+    statsWhenShown(options.showStorage, systemStats),
+    efsPaths,
+    timePeriod,
+  );
+
   const containerSeries = useMemo(
     () => containerNames.map((name, i) => ({ name, color: containerColors[i % containerColors.length] as string })),
     [containerNames],
+  );
+
+  const storageSeries = useMemo(
+    () => efsPaths.map((path, i) => ({ name: path, color: containerColors[i % containerColors.length] as string })),
+    [efsPaths],
   );
 
   const cols = gridColumns[Number(width > 600)];
@@ -381,6 +406,21 @@ export default function BeszelSystemStatsWidget({
                     series: series.network,
                     yAxisFormatter: chartAxisFormatters.rate,
                     tooltipProps: tooltipRate,
+                  }}
+                />
+              )}
+
+              {options.showStorage && storageData.length > 0 && storageSeries.length > 0 && (
+                <BeszelChartPanel
+                  title={t("chart.storage.title")}
+                  subtitle={t("chart.storage.subtitle")}
+                  chartProps={{
+                    h: CHART_HEIGHT,
+                    data: storageData,
+                    type: "stacked",
+                    series: storageSeries,
+                    yAxisFormatter: chartAxisFormatters.bytes,
+                    tooltipProps: tooltipBytesTotal,
                   }}
                 />
               )}

--- a/packages/widgets/src/beszel-system-stats/component.tsx
+++ b/packages/widgets/src/beszel-system-stats/component.tsx
@@ -199,11 +199,7 @@ export default function BeszelSystemStatsWidget({
     return [...paths];
   }, [systemStats]);
 
-  const storageData = useEfsChartData(
-    statsWhenShown(options.showStorage, systemStats),
-    efsPaths,
-    timePeriod,
-  );
+  const storageData = useEfsChartData(statsWhenShown(options.showStorage, systemStats), efsPaths, timePeriod);
 
   const containerSeries = useMemo(
     () => containerNames.map((name, i) => ({ name, color: containerColors[i % containerColors.length] as string })),

--- a/packages/widgets/src/beszel-system-stats/index.ts
+++ b/packages/widgets/src/beszel-system-stats/index.ts
@@ -45,6 +45,7 @@ export const { definition, componentLoader } = createWidgetDefinition("beszelSys
       showDockerCpu: factory.switch({ defaultValue: true }),
       showDockerMemory: factory.switch({ defaultValue: true }),
       showDockerNetwork: factory.switch({ defaultValue: true }),
+      showStorage: factory.switch({ defaultValue: true }),
     }));
   },
   errors: {

--- a/packages/widgets/src/beszel/_shared/chart.tsx
+++ b/packages/widgets/src/beszel/_shared/chart.tsx
@@ -174,6 +174,25 @@ const defaultContainerExtractors: Record<string, ContainerExtractor> = {
   network: (c) => (c?.b ? c.b[0] + c.b[1] : (c?.ns ?? 0) + (c?.nr ?? 0)),
 };
 
+export const useEfsChartData = (
+  systemStats: BeszelSystemStatsRecord[] | undefined,
+  efsPaths: string[],
+  timePeriod: BeszelTimePeriod = "1h",
+) =>
+  useMemo(() => {
+    if (!systemStats?.length) return [];
+    const { fmt, ordered } = prepareRecords(systemStats, timePeriod);
+    const mapped = ordered.map((record) => {
+      const point: Record<string, unknown> = { time: fmt(record.created), rawTime: record.created };
+      const efs = record.stats.efs ?? {};
+      for (const path of efsPaths) {
+        point[path] = efs[path]?.du ?? 0;
+      }
+      return point;
+    });
+    return padTimeGrid(mapped, timePeriod);
+  }, [systemStats, efsPaths, timePeriod]);
+
 export const useDockerChartData = (
   containerStats: BeszelContainerStatsRecord[] | undefined,
   containerNames: string[],


### PR DESCRIPTION
Resolves #6154

The Beszel API already returns per-mount storage data (the `efs` field on `BeszelSystemStats`) but no widget ever displayed it. This adds a stacked area chart to the `beszelSystemStats` widget showing per-filesystem disk usage over time.

## Changes

- **`useEfsChartData`** hook in `packages/widgets/src/beszel/_shared/chart.tsx` (mirrors `useDockerChartData` for extra filesystem stats)
- **`showStorage`** toggle option on the widget definition
- **Storage chart panel** in `beszel-system-stats/component.tsx` — uses existing `formatStorageBytes` for axis/tooltip formatting, consistent with Docker memory chart
- **Translation strings** in `en.json` for the option label and chart title/subtitle

## Design notes

- Filesystem paths become chart series, each colored from the existing `containerColors` palette
- Mounts that temporarily disappear from a stats record render as 0 at that point (same trade-off as the Docker chart)
- New chart is enabled by default alongside the other charts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new storage chart to the Beszel System Stats widget, showing EFS storage usage alongside existing charts.
  * Added a new display option to show or hide the storage chart.
* **Bug Fixes**
  * Improved widget translation support so the new storage chart labels appear correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->