### PR TITLE
feat(users): add ability to disable users without deleting them

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_disable-user-button.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_disable-user-button.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useTransition } from "react";
+import { Button, Tooltip } from "@mantine/core";
+
+import type { RouterOutputs } from "@homarr/api";
+import { clientApi } from "@homarr/api/client";
+import { showErrorNotification, showSuccessNotification } from "@homarr/notifications";
+import { useI18n } from "@homarr/translation/client";
+
+interface DisableUserButtonProps {
+  user: RouterOutputs["user"]["getById"];
+}
+
+export const DisableUserButton = ({ user }: DisableUserButtonProps) => {
+  const t = useI18n();
+  const [isPending, startTransition] = useTransition();
+  const changeDisabledMutation = clientApi.user.changeDisabled.useMutation();
+
+  const handleToggle = () => {
+    startTransition(async () => {
+      try {
+        await changeDisabledMutation.mutateAsync({
+          userId: user.id,
+          disabled: !user.disabled,
+        });
+        showSuccessNotification({
+          title: user.disabled
+            ? t("user.action.enable.success", { defaultValue: "User enabled" })
+            : t("user.action.disable.success", { defaultValue: "User disabled" }),
+          message: user.disabled
+            ? t("user.action.enable.successDescription", { defaultValue: "User has been enabled" })
+            : t("user.action.disable.successDescription", { defaultValue: "User has been disabled" }),
+        });
+      } catch {
+        showErrorNotification({
+          title: t("common.notification.update.error"),
+          message: t("common.notification.update.error"),
+        });
+      }
+    });
+  };
+
+  const tooltipLabel = user.disabled
+    ? t("user.action.enable.description", { defaultValue: "Enable this user" })
+    : t("user.action.disable.description", { defaultValue: "Disable this user" });
+
+  return (
+    <Tooltip label={tooltipLabel} position="top">
+      <Button
+        onClick={handleToggle}
+        loading={isPending || changeDisabledMutation.isPending}
+        color={user.disabled ? "green" : "yellow"}
+        variant="light"
+      >
+        {user.disabled
+          ? t("user.action.enable.label", { defaultValue: "Enable user" })
+          : t("user.action.disable.label", { defaultValue: "Disable user" })}
+      </Button>
+    </Tooltip>
+  );
+};

--- a/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_disable-user-button.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_disable-user-button.tsx
@@ -16,22 +16,29 @@ export const DisableUserButton = ({ user }: DisableUserButtonProps) => {
   const t = useI18n();
   const [isPending, startTransition] = useTransition();
   const changeDisabledMutation = clientApi.user.changeDisabled.useMutation();
+  const isDisabled = user.disabled;
+
+  const getSuccessMessage = () => {
+    if (isDisabled) {
+      return {
+        title: t("user.action.enable.success", { defaultValue: "User enabled" }),
+        message: t("user.action.enable.successDescription", { defaultValue: "User has been enabled" }),
+      };
+    }
+    return {
+      title: t("user.action.disable.success", { defaultValue: "User disabled" }),
+      message: t("user.action.disable.successDescription", { defaultValue: "User has been disabled" }),
+    };
+  };
 
   const handleToggle = () => {
     startTransition(async () => {
       try {
         await changeDisabledMutation.mutateAsync({
           userId: user.id,
-          disabled: !user.disabled,
+          disabled: !isDisabled,
         });
-        showSuccessNotification({
-          title: user.disabled
-            ? t("user.action.enable.success", { defaultValue: "User enabled" })
-            : t("user.action.disable.success", { defaultValue: "User disabled" }),
-          message: user.disabled
-            ? t("user.action.enable.successDescription", { defaultValue: "User has been enabled" })
-            : t("user.action.disable.successDescription", { defaultValue: "User has been disabled" }),
-        });
+        showSuccessNotification(getSuccessMessage());
       } catch {
         showErrorNotification({
           title: t("common.notification.update.error"),
@@ -41,21 +48,31 @@ export const DisableUserButton = ({ user }: DisableUserButtonProps) => {
     });
   };
 
-  const tooltipLabel = user.disabled
-    ? t("user.action.enable.description", { defaultValue: "Enable this user" })
-    : t("user.action.disable.description", { defaultValue: "Disable this user" });
+  const getTooltipLabel = () => {
+    if (isDisabled) {
+      return t("user.action.enable.description", { defaultValue: "Enable this user" });
+    }
+    return t("user.action.disable.description", { defaultValue: "Disable this user" });
+  };
+
+  const getButtonLabel = () => {
+    if (isDisabled) {
+      return t("user.action.enable.label", { defaultValue: "Enable user" });
+    }
+    return t("user.action.disable.label", { defaultValue: "Disable user" });
+  };
+
+  const getButtonColor = () => (isDisabled ? "green" : "yellow");
 
   return (
-    <Tooltip label={tooltipLabel} position="top">
+    <Tooltip label={getTooltipLabel()} position="top">
       <Button
         onClick={handleToggle}
         loading={isPending || changeDisabledMutation.isPending}
-        color={user.disabled ? "green" : "yellow"}
+        color={getButtonColor()}
         variant="light"
       >
-        {user.disabled
-          ? t("user.action.enable.label", { defaultValue: "Enable user" })
-          : t("user.action.disable.label", { defaultValue: "Disable user" })}
+        {getButtonLabel()}
       </Button>
     </Tooltip>
   );

--- a/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_disable-user-button.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_disable-user-button.tsx
@@ -10,9 +10,10 @@ import { useI18n } from "@homarr/translation/client";
 
 interface DisableUserButtonProps {
   user: RouterOutputs["user"]["getById"];
+  isSelf?: boolean;
 }
 
-export const DisableUserButton = ({ user }: DisableUserButtonProps) => {
+export const DisableUserButton = ({ user, isSelf = false }: DisableUserButtonProps) => {
   const t = useI18n();
   const [isPending, startTransition] = useTransition();
   const changeDisabledMutation = clientApi.user.changeDisabled.useMutation();
@@ -32,6 +33,8 @@ export const DisableUserButton = ({ user }: DisableUserButtonProps) => {
   };
 
   const handleToggle = () => {
+    if (isSelf) return;
+
     startTransition(async () => {
       try {
         await changeDisabledMutation.mutateAsync({
@@ -65,12 +68,13 @@ export const DisableUserButton = ({ user }: DisableUserButtonProps) => {
   const getButtonColor = () => (isDisabled ? "green" : "yellow");
 
   return (
-    <Tooltip label={getTooltipLabel()} position="top">
+    <Tooltip label={isSelf ? t("user.action.disableSelf.disabled", { defaultValue: "Cannot disable your own account" }) : getTooltipLabel()} position="top">
       <Button
         onClick={handleToggle}
         loading={isPending || changeDisabledMutation.isPending}
         color={getButtonColor()}
         variant="light"
+        disabled={isSelf}
       >
         {getButtonLabel()}
       </Button>

--- a/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_disable-user-button.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/_components/_disable-user-button.tsx
@@ -68,7 +68,14 @@ export const DisableUserButton = ({ user, isSelf = false }: DisableUserButtonPro
   const getButtonColor = () => (isDisabled ? "green" : "yellow");
 
   return (
-    <Tooltip label={isSelf ? t("user.action.disableSelf.disabled", { defaultValue: "Cannot disable your own account" }) : getTooltipLabel()} position="top">
+    <Tooltip
+      label={
+        isSelf
+          ? t("user.action.disableSelf.disabled", { defaultValue: "Cannot disable your own account" })
+          : getTooltipLabel()
+      }
+      position="top"
+    >
       <Button
         onClick={handleToggle}
         loading={isPending || changeDisabledMutation.isPending}

--- a/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/page.tsx
@@ -110,11 +110,13 @@ export default async function EditUserPage(props: Props) {
       )}
 
       <DangerZoneRoot>
-        <DangerZoneItem
-          label={getDisableItemLabel()}
-          description={getDisableItemDescription()}
-          action={<DisableUserButton user={user} />}
-        />
+        {!isSelf && (
+          <DangerZoneItem
+            label={getDisableItemLabel()}
+            description={getDisableItemDescription()}
+            action={<DisableUserButton user={user} isSelf={isSelf} />}
+          />
+        )}
         <DangerZoneItem
           label={t("user.action.delete.label")}
           description={t("user.action.delete.description")}

--- a/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/page.tsx
@@ -11,6 +11,7 @@ import { catchTrpcNotFound } from "~/errors/trpc-catch-error";
 import { createMetaTitle } from "~/metadata";
 import { canAccessUserEditPage } from "../access";
 import { DeleteUserButton } from "./_components/_delete-user-button";
+import { DisableUserButton } from "./_components/_disable-user-button";
 import { UserGeneralSettingsForm } from "./_components/_general-settings-form";
 import { UserProfileAvatarForm } from "./_components/_profile-avatar-form";
 import { ResetTours } from "./_components/_reset-tours";
@@ -96,6 +97,15 @@ export default async function EditUserPage(props: Props) {
       )}
 
       <DangerZoneRoot>
+        <DangerZoneItem
+          label={user.disabled ? t("user.action.enable.label") : t("user.action.disable.label")}
+          description={
+            user.disabled
+              ? t("management.page.user.action.enable.description", { defaultValue: "Re-enable access for this user" })
+              : t("management.page.user.action.disable.description", { defaultValue: "Prevent this user from logging in" })
+          }
+          action={<DisableUserButton user={user} />}
+        />
         <DangerZoneItem
           label={t("user.action.delete.label")}
           description={t("user.action.delete.description")}

--- a/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/page.tsx
@@ -102,7 +102,9 @@ export default async function EditUserPage(props: Props) {
           description={
             user.disabled
               ? t("management.page.user.action.enable.description", { defaultValue: "Re-enable access for this user" })
-              : t("management.page.user.action.disable.description", { defaultValue: "Prevent this user from logging in" })
+              : t("management.page.user.action.disable.description", {
+                  defaultValue: "Prevent this user from logging in",
+                })
           }
           action={<DisableUserButton user={user} />}
         />

--- a/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/[userId]/general/page.tsx
@@ -62,6 +62,19 @@ export default async function EditUserPage(props: Props) {
   const searchEngines = await api.searchEngine.getSelectable();
   const isSelf = session?.user.id === user.id;
   const isCredentialsUser = user.provider === "credentials";
+  const isDisabled = user.disabled;
+
+  const getDisableItemLabel = () => {
+    if (isDisabled) return t("user.action.enable.label");
+    return t("user.action.disable.label");
+  };
+
+  const getDisableItemDescription = () => {
+    if (isDisabled) {
+      return t("management.page.user.action.enable.description", { defaultValue: "Re-enable access for this user" });
+    }
+    return t("management.page.user.action.disable.description", { defaultValue: "Prevent this user from logging in" });
+  };
 
   return (
     <Stack>
@@ -98,14 +111,8 @@ export default async function EditUserPage(props: Props) {
 
       <DangerZoneRoot>
         <DangerZoneItem
-          label={user.disabled ? t("user.action.enable.label") : t("user.action.disable.label")}
-          description={
-            user.disabled
-              ? t("management.page.user.action.enable.description", { defaultValue: "Re-enable access for this user" })
-              : t("management.page.user.action.disable.description", {
-                  defaultValue: "Prevent this user from logging in",
-                })
-          }
+          label={getDisableItemLabel()}
+          description={getDisableItemDescription()}
           action={<DisableUserButton user={user} />}
         />
         <DangerZoneItem

--- a/apps/nextjs/src/app/[locale]/manage/users/_components/user-list.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/_components/user-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { Anchor, Group, Text, Tooltip } from "@mantine/core";
+import { Anchor, Badge, Group, Text, Tooltip } from "@mantine/core";
 import { IconCheck } from "@tabler/icons-react";
 import type { MRT_ColumnDef } from "mantine-react-table";
 import { MantineReactTable } from "mantine-react-table";
@@ -51,6 +51,15 @@ export const UserListComponent = ({ initialUserList }: UserListComponentProps) =
             )}
           </Group>
         ),
+      },
+      {
+        accessorKey: "disabled",
+        header: t("user.field.status.label", { defaultValue: "Status" }),
+        size: 100,
+        Cell: ({ row }) =>
+          row.original.disabled ? (
+            <Badge color="red">{t("user.field.status.disabled", { defaultValue: "Disabled" })}</Badge>
+          ) : null,
       },
     ],
     [t],

--- a/apps/nextjs/src/app/[locale]/manage/users/_components/user-list.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/_components/user-list.tsx
@@ -56,10 +56,10 @@ export const UserListComponent = ({ initialUserList }: UserListComponentProps) =
         accessorKey: "disabled",
         header: t("user.field.status.label", { defaultValue: "Status" }),
         size: 100,
-        Cell: ({ row }) =>
-          row.original.disabled ? (
-            <Badge color="red">{t("user.field.status.disabled", { defaultValue: "Disabled" })}</Badge>
-          ) : null,
+        Cell: ({ row }) => {
+          if (!row.original.disabled) return null;
+          return <Badge color="red">{t("user.field.status.disabled", { defaultValue: "Disabled" })}</Badge>;
+        },
       },
     ],
     [t],

--- a/packages/api/src/router/user.ts
+++ b/packages/api/src/router/user.ts
@@ -232,6 +232,7 @@ export const userRouter = createTRPCRouter({
           email: true,
           emailVerified: true,
           image: true,
+          disabled: true,
         }),
       ),
     )
@@ -252,6 +253,7 @@ export const userRouter = createTRPCRouter({
           email: true,
           emailVerified: true,
           image: true,
+          disabled: true,
         },
       });
     }),
@@ -341,6 +343,7 @@ export const userRouter = createTRPCRouter({
         emailVerified: true,
         image: true,
         provider: true,
+        disabled: true,
         homeBoardId: true,
         mobileHomeBoardId: true,
         firstDayOfWeek: true,
@@ -377,6 +380,7 @@ export const userRouter = createTRPCRouter({
           emailVerified: true,
           image: true,
           provider: true,
+          disabled: true,
           homeBoardId: true,
           mobileHomeBoardId: true,
           firstDayOfWeek: true,
@@ -777,6 +781,23 @@ export const userRouter = createTRPCRouter({
       completedBoardTour: user?.completedBoardTour ?? false,
     };
   }),
+  changeDisabled: permissionRequiredProcedure
+    .requiresPermission("admin")
+    .input(
+      z.object({
+        userId: z.string(),
+        disabled: z.boolean(),
+      }),
+    )
+    .output(z.void())
+    .mutation(async ({ input, ctx }) => {
+      await ctx.db
+        .update(users)
+        .set({
+          disabled: input.disabled,
+        })
+        .where(eq(users.id, input.userId));
+    }),
 });
 
 const createUserAsync = async (db: Database, input: Omit<z.infer<typeof userBaseCreateSchema>, "groupIds">) => {

--- a/packages/api/src/router/user.ts
+++ b/packages/api/src/router/user.ts
@@ -790,7 +790,29 @@ export const userRouter = createTRPCRouter({
       }),
     )
     .output(z.void())
+    .meta({
+      openapi: {
+        method: "PATCH",
+        path: "/api/users/disabled",
+        tags: ["users"],
+        protect: true,
+      },
+    })
     .mutation(async ({ input, ctx }) => {
+      const dbUser = await ctx.db.query.users.findFirst({
+        columns: {
+          id: true,
+        },
+        where: eq(users.id, input.userId),
+      });
+
+      if (!dbUser) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "User not found",
+        });
+      }
+
       await ctx.db
         .update(users)
         .set({

--- a/packages/auth/callbacks.ts
+++ b/packages/auth/callbacks.ts
@@ -47,13 +47,8 @@ export const createSessionCallback = (db: Database): NextAuthCallbackOf<"session
       where: eq(users.id, user.id),
       columns: {
         colorScheme: true,
-        disabled: true,
       },
     });
-
-    if (additionalProperties?.disabled) {
-      return null;
-    }
 
     return {
       ...session,

--- a/packages/auth/callbacks.ts
+++ b/packages/auth/callbacks.ts
@@ -47,8 +47,13 @@ export const createSessionCallback = (db: Database): NextAuthCallbackOf<"session
       where: eq(users.id, user.id),
       columns: {
         colorScheme: true,
+        disabled: true,
       },
     });
+
+    if (additionalProperties?.disabled) {
+      return null;
+    }
 
     return {
       ...session,

--- a/packages/auth/providers/credentials/authorization/basic-authorization.ts
+++ b/packages/auth/providers/credentials/authorization/basic-authorization.ts
@@ -23,6 +23,11 @@ export const authorizeWithBasicCredentialsAsync = async (
     return null;
   }
 
+  if (user.disabled) {
+    logger.warn("User is disabled", { userName: user.name });
+    return null;
+  }
+
   logger.info("User is trying to log in. Checking password...", { userName: user.name });
   const isValidPassword = await comparePasswordsAsync(credentials.password, user.password);
 

--- a/packages/auth/providers/credentials/authorization/ldap-authorization.ts
+++ b/packages/auth/providers/credentials/authorization/ldap-authorization.ts
@@ -107,6 +107,7 @@ export const authorizeWithLdapCredentialsAsync = async (
       email: true,
       emailVerified: true,
       provider: true,
+      disabled: true,
     },
     where: and(eq(users.email, mailResult.data), eq(users.provider, "ldap")),
   });
@@ -128,6 +129,11 @@ export const authorizeWithLdapCredentialsAsync = async (
     user = insertUser;
 
     logger.info("User created successfully", { userName: credentials.name });
+  }
+
+  if (user.disabled) {
+    logger.warn("User is disabled", { userName: credentials.name });
+    throw new CredentialsSignin("User is disabled");
   }
 
   return {

--- a/packages/db/migrations/mysql/0009_add_user_disabled.sql
+++ b/packages/db/migrations/mysql/0009_add_user_disabled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user` ADD `disabled` boolean DEFAULT false NOT NULL;

--- a/packages/db/migrations/postgresql/0009_add_user_disabled.sql
+++ b/packages/db/migrations/postgresql/0009_add_user_disabled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "disabled" boolean DEFAULT false NOT NULL;

--- a/packages/db/migrations/sqlite/0009_add_user_disabled.sql
+++ b/packages/db/migrations/sqlite/0009_add_user_disabled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "disabled" integer DEFAULT 0 NOT NULL;

--- a/packages/db/schema/mysql.ts
+++ b/packages/db/schema/mysql.ts
@@ -72,6 +72,7 @@ export const users = mysqlTable("user", {
   image: text(),
   password: text(),
   provider: varchar({ length: 64 }).$type<SupportedAuthProvider>().default("credentials").notNull(),
+  disabled: boolean().default(false).notNull(),
   homeBoardId: varchar({ length: 64 }).references((): AnyMySqlColumn => boards.id, {
     onDelete: "set null",
   }),

--- a/packages/db/schema/postgresql.ts
+++ b/packages/db/schema/postgresql.ts
@@ -71,6 +71,7 @@ export const users = pgTable("user", {
   image: text(),
   password: text(),
   provider: varchar({ length: 64 }).$type<SupportedAuthProvider>().default("credentials").notNull(),
+  disabled: boolean().default(false).notNull(),
   homeBoardId: varchar({ length: 64 }).references((): AnyPgColumn => boards.id, {
     onDelete: "set null",
   }),

--- a/packages/db/schema/sqlite.ts
+++ b/packages/db/schema/sqlite.ts
@@ -54,6 +54,7 @@ export const users = sqliteTable("user", {
   image: text(),
   password: text(),
   provider: text().$type<SupportedAuthProvider>().default("credentials").notNull(),
+  disabled: int({ mode: "boolean" }).default(false).notNull(),
   homeBoardId: text().references((): AnySQLiteColumn => boards.id, {
     onDelete: "set null",
   }),


### PR DESCRIPTION
Closes #4455

> 🤖 This PR was opened automatically by homarr-bot. A maintainer must review before merging.

## Summary
Adds a disabled toggle to users, accessible only from the admin interface. Disabled users cannot log in through any authentication method (credentials, LDAP, OIDC).

## Changes
- Added `disabled` boolean column to users table with migration (PostgreSQL, MySQL, SQLite)
- Disabled users cannot log in (checked at credentials provider, LDAP provider, and session callback)
- Session callback invalidates sessions for disabled users (prevents session replay across auth methods)
- Admin-only API endpoint to enable/disable users
- Admin UI toggle with status badge in user list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user status flag to identify disabled accounts.
  * Admins can now disable or re-enable a user from the user management page.
  * User lists now show a disabled status badge when applicable.

* **Bug Fixes**
  * Disabled users can no longer sign in through supported authentication flows.
  * Disabled accounts are prevented from creating new sessions.

* **Chores**
  * Updated database schema and migrations to store the new user status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->