### PR TITLE
fix(docs): fix docs build — MDX acorn error and CSS @import ordering

### DIFF
--- a/apps/docs/docs/integrations/immich/index.mdx
+++ b/apps/docs/docs/integrations/immich/index.mdx
@@ -58,7 +58,7 @@ import { immichServerStatsWidget } from '../../widgets/immich-server-stats';
     Additional permissions may be required depending on your Immich version. If you encounter authorization errors, grant any missing permissions requested by the server.
   </span>
 
-),Ï
+),
     'Create the integration in Homarr and copy the API key to there'
     ]
 }]} />

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -1,7 +1,6 @@
+@import url(https://api.fontshare.com/v2/css?f[]=work-sans@2,1&display=swap);
 @import "tailwindcss/theme" layer(theme);
 @import "tailwindcss/utilities" layer(utilities);
-
-@import url(https://api.fontshare.com/v2/css?f[]=work-sans@2,1&display=swap);
 
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -1,4 +1,4 @@
-@import url(https://api.fontshare.com/v2/css?f[]=work-sans@2,1&display=swap);
+@import url("https://api.fontshare.com/v2/css?f[]=work-sans@2,1&display=swap");
 @import "tailwindcss/theme" layer(theme);
 @import "tailwindcss/utilities" layer(utilities);
 


### PR DESCRIPTION
> 🤖 This PR was opened automatically by homarr-bot. A maintainer must review before merging.

## Fixes
- Fixed MDX acorn parse error in `apps/docs/docs/integrations/immich/index.mdx` line 62
- Fixed CSS `@import` ordering issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a minor formatting/rendering issue in the Immich integration guide to ensure the page content displays correctly.
* **Style**
  * Updated the stylesheet import order in the docs site CSS so font loading and Tailwind layers are applied consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->