### PR TITLE
feat(demo): allow mutations in demo mode via DEMO_READ_ONLY flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,10 @@ TURBO_TELEMETRY_DISABLED=1
 
 # Enable mock integration
 UNSAFE_ENABLE_MOCK_INTEGRATION=true
+
+# Enable demo mode (seeds a demo user "demo"/"demo", a sample board and a mock integration)
+# DEMO_MODE=true
+
+# Whether demo mode is read-only. Defaults to true (the public demo blocks all mutations).
+# Set to false for writable preview deployments so the demo user can modify the dashboard.
+# DEMO_READ_ONLY=false

--- a/apps/nextjs/src/app/[locale]/boards/(content)/_header-actions.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_header-actions.tsx
@@ -45,7 +45,7 @@ export const BoardContentHeaderActions = () => {
   const [isEditMode] = useEditMode();
   const board = useRequiredBoard();
   const { hasChangeAccess } = useBoardPermissions(board);
-  const { data: demoMode, isLoading } = clientApi.info.isDemoMode.useQuery();
+  const { data: demoReadOnly, isLoading } = clientApi.info.isDemoReadOnly.useQuery();
 
   if (!hasChangeAccess || isLoading) {
     return <SelectBoardsMenu />;
@@ -55,9 +55,9 @@ export const BoardContentHeaderActions = () => {
     <>
       {isEditMode && <AddMenu />}
 
-      <EditModeMenu demoMode={demoMode ?? false} />
+      <EditModeMenu demoReadOnly={demoReadOnly ?? false} />
 
-      {!demoMode && (
+      {!demoReadOnly && (
         <OnboardingTour.Target id="board-settings">
           <HeaderButton href={`/boards/${board.name}/settings`}>
             <IconSettings stroke={1.5} />
@@ -158,7 +158,7 @@ const AddMenu = () => {
   );
 };
 
-const EditModeMenu = ({ demoMode }: { demoMode: boolean }) => {
+const EditModeMenu = ({ demoReadOnly }: { demoReadOnly: boolean }) => {
   const [isEditMode, { open, close }] = useEditMode();
   const board = useRequiredBoard();
   const utils = clientApi.useUtils();
@@ -188,11 +188,11 @@ const EditModeMenu = ({ demoMode }: { demoMode: boolean }) => {
 
   const toggle = useCallback(() => {
     if (isEditMode) {
-      if (demoMode) return discardDemoChanges();
+      if (demoReadOnly) return discardDemoChanges();
       return saveBoard(board);
     }
     open();
-  }, [board, isEditMode, demoMode, saveBoard, open, discardDemoChanges]);
+  }, [board, isEditMode, demoReadOnly, saveBoard, open, discardDemoChanges]);
 
   useHotkeys([[hotkeys.toggleBoardEdit, toggle]]);
   usePreventLeaveWithDirty(isEditMode);

--- a/apps/nextjs/src/app/[locale]/boards/(content)/_header-actions.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_header-actions.tsx
@@ -45,7 +45,9 @@ export const BoardContentHeaderActions = () => {
   const [isEditMode] = useEditMode();
   const board = useRequiredBoard();
   const { hasChangeAccess } = useBoardPermissions(board);
-  const { data: demoReadOnly, isLoading } = clientApi.info.isDemoReadOnly.useQuery();
+  // Fall back to read-only if the query has no data (e.g. errored) so we never expose
+  // edit/save/settings UI that would then fail server-side.
+  const { data: demoReadOnly = true, isLoading } = clientApi.info.isDemoReadOnly.useQuery();
 
   if (!hasChangeAccess || isLoading) {
     return <SelectBoardsMenu />;
@@ -55,7 +57,7 @@ export const BoardContentHeaderActions = () => {
     <>
       {isEditMode && <AddMenu />}
 
-      <EditModeMenu demoReadOnly={demoReadOnly ?? false} />
+      <EditModeMenu demoReadOnly={demoReadOnly} />
 
       {!demoReadOnly && (
         <OnboardingTour.Target id="board-settings">

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -6,9 +6,11 @@ export const env = createEnv({
   server: {
     KUBERNETES_SERVICE_ACCOUNT_NAME: z.string().optional(),
     DEMO_MODE: createBooleanSchema(false),
+    DEMO_READ_ONLY: createBooleanSchema(true),
   },
   runtimeEnv: {
     KUBERNETES_SERVICE_ACCOUNT_NAME: process.env.KUBERNETES_SERVICE_ACCOUNT_NAME,
     DEMO_MODE: process.env.DEMO_MODE,
+    DEMO_READ_ONLY: process.env.DEMO_READ_ONLY,
   },
 });

--- a/packages/api/src/router/info.ts
+++ b/packages/api/src/router/info.ts
@@ -1,7 +1,7 @@
 import z from "zod/v4";
 
 import packageJson from "../../../../package.json";
-import { createTRPCRouter, isDemoMode, publicProcedure, protectedProcedure } from "../trpc";
+import { createTRPCRouter, isDemoMode, isDemoReadOnly, publicProcedure, protectedProcedure } from "../trpc";
 
 export const infoRouter = createTRPCRouter({
   getInfo: protectedProcedure
@@ -20,4 +20,5 @@ export const infoRouter = createTRPCRouter({
       };
     }),
   isDemoMode: publicProcedure.query(() => isDemoMode),
+  isDemoReadOnly: publicProcedure.query(() => isDemoReadOnly),
 });

--- a/packages/api/src/router/info.ts
+++ b/packages/api/src/router/info.ts
@@ -20,5 +20,12 @@ export const infoRouter = createTRPCRouter({
       };
     }),
   isDemoMode: publicProcedure.query(() => isDemoMode),
-  isDemoReadOnly: publicProcedure.query(() => isDemoReadOnly),
+  isDemoReadOnly: publicProcedure
+    .meta({
+      mcp: {
+        enabled: true,
+        description: "Returns whether demo mode is read-only, i.e. whether mutations are blocked for this deployment",
+      },
+    })
+    .query(() => isDemoReadOnly),
 });

--- a/packages/api/src/router/info.ts
+++ b/packages/api/src/router/info.ts
@@ -20,12 +20,5 @@ export const infoRouter = createTRPCRouter({
       };
     }),
   isDemoMode: publicProcedure.query(() => isDemoMode),
-  isDemoReadOnly: publicProcedure
-    .meta({
-      mcp: {
-        enabled: true,
-        description: "Returns whether demo mode is read-only, i.e. whether mutations are blocked for this deployment",
-      },
-    })
-    .query(() => isDemoReadOnly),
+  isDemoReadOnly: publicProcedure.query(() => isDemoReadOnly),
 });

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -95,8 +95,12 @@ export const createTRPCRouter = t.router;
 
 export const isDemoMode = env.DEMO_MODE;
 
+// The public "real demo" (demo + mock integrations) stays read-only, while preview
+// deployments run with DEMO_MODE + DEMO_READ_ONLY=false to allow mutations.
+export const isDemoReadOnly = env.DEMO_MODE && env.DEMO_READ_ONLY;
+
 const enforceDemoModeReadOnly = t.middleware(({ ctx, next, type }) => {
-  if (env.DEMO_MODE && type === "mutation") {
+  if (isDemoReadOnly && type === "mutation") {
     throw new TRPCError({
       code: "FORBIDDEN",
       message: "Mutations are disabled in demo mode",
@@ -105,7 +109,7 @@ const enforceDemoModeReadOnly = t.middleware(({ ctx, next, type }) => {
   return next({ ctx });
 });
 
-const baseProcedure = env.DEMO_MODE ? t.procedure.use(enforceDemoModeReadOnly) : t.procedure;
+const baseProcedure = isDemoReadOnly ? t.procedure.use(enforceDemoModeReadOnly) : t.procedure;
 
 /**
  * Public (unauthed) procedure


### PR DESCRIPTION
## What & why

`DEMO_MODE` currently does two separate jobs: it sets up a demo *deployment* (seeds the `demo`/`demo` user, a sample board, and a mock integration; shows the login hint; enables mock docker data; auto-completes tours) **and** it enforces *read-only* by blocking all tRPC mutations.

For PR preview deployments we want the full demo setup but the ability to actually modify the dashboard. This PR splits those two concerns apart with a new `DEMO_READ_ONLY` env var.

## Changes

- **`packages/api/src/env.ts`** — add `DEMO_READ_ONLY` (default `true`).
- **`packages/api/src/trpc.ts`** — add `isDemoReadOnly = DEMO_MODE && DEMO_READ_ONLY`; the mutation-blocking middleware and `baseProcedure` now gate on `isDemoReadOnly` instead of `DEMO_MODE`. `isDemoMode` is unchanged (still used by docker middleware, docker mock containers, and tour auto-complete).
- **`packages/api/src/router/info.ts`** — expose a new `isDemoReadOnly` query alongside the existing `isDemoMode`.
- **`apps/nextjs/.../boards/(content)/_header-actions.tsx`** — the board editor now follows `isDemoReadOnly` (renamed prop/var to `demoReadOnly`), so a writable demo **saves** changes and shows the settings button.
- **`.env.example`** — document `DEMO_MODE` and `DEMO_READ_ONLY`.

## Behavior

- `DEMO_MODE=true` alone (public demo) → **read-only by default**, unchanged from today.
- `DEMO_MODE=true` + `DEMO_READ_ONLY=false` (preview) → full demo setup, mutations allowed, dashboard editable.
- `DEMO_MODE` unset → identical to today (no middleware attached).

## Reviewer notes

- Read-only remains the default; you must explicitly opt out with `DEMO_READ_ONLY=false`.
- Demo *setup* behaviors (seeding, login hint, docker mock, tours) intentionally stay gated on `DEMO_MODE` and are unchanged — correct for preview deployments too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a demo read-only configuration for preview environments, with clearer setup guidance.
  * Exposed demo read-only status to support smarter UI and edit behavior.

* **Bug Fixes**
  * Updated board edit controls so editing is disabled in demo read-only mode, while saving remains available when write access is enabled.
  * Adjusted onboarding/settings edit targeting based on whether editing is permitted.

* **Documentation**
  * Updated the environment example with `DEMO_MODE` and `DEMO_READ_ONLY` guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->