### PR TITLE
fix(query-cache): guard against undefined from superjson.parse on legacy cache entries

### DIFF
--- a/apps/nextjs/src/app/[locale]/boards/(content)/_creator.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_creator.tsx
@@ -123,7 +123,7 @@ async function QueryCacheHydration({ userId, boardId }: { userId: string; boardI
     const serialized = await getQueryCacheAsync(userId, boardId);
     if (!serialized) return null;
 
-    const persisted = superjson.parse<PersistedClient>(serialized);
+    const persisted = superjson.parse<PersistedClient | undefined>(serialized);
     if (!persisted || persisted.buster !== queryCacheBuster) return null;
     if (!persisted.clientState?.queries?.length) return null;
 

--- a/apps/nextjs/src/app/[locale]/boards/(content)/_creator.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_creator.tsx
@@ -124,8 +124,8 @@ async function QueryCacheHydration({ userId, boardId }: { userId: string; boardI
     if (!serialized) return null;
 
     const persisted = superjson.parse<PersistedClient>(serialized);
-    if (persisted.buster !== queryCacheBuster) return null;
-    if (!persisted?.clientState?.queries?.length) return null;
+    if (!persisted || persisted.buster !== queryCacheBuster) return null;
+    if (!persisted.clientState?.queries?.length) return null;
 
     return <HydrationBoundary state={persisted.clientState} />;
   } catch (error) {


### PR DESCRIPTION
## Summary

Fixes #6219 — homarr crashing on page reload with \"Cannot read properties of undefined (reading 'buster')\".

- `superjson.parse` returns `undefined` when given a plain-JSON string (cache entries written before the superjson serializer was introduced in `b663dae40`). Without a null guard, accessing `.buster` on `undefined` throws, which is caught and logged as \"Failed to hydrate query cache\".
- Adds `!persisted ||` guard to safely discard any `undefined` result (same effect as the existing buster mismatch path — returns null and skips hydration).
- Removes now-redundant optional chaining (`persisted?.clientState`) on the next line, since `persisted` is guaranteed non-null at that point.

**Root cause verified:** `superjson.parse('{"buster":"","clientState":{}}')` → `undefined` (plain JSON lacks the `{json,meta}` envelope superjson expects). `superjson.parse(superjson.stringify({...}))` → correct object.

## Test plan

- [ ] Deploy with an existing Redis entry from a pre-superjson version — board page should load without crashing or logging \"Failed to hydrate query cache\"
- [ ] Fresh cache (new superjson format, matching buster) → hydration proceeds normally
- [ ] Fresh cache (mismatched buster) → hydration skipped, no crash
- [ ] No Redis entry → no change in behaviour

> 🤖 I am a bot. This PR was opened automatically as part of issue #6219 investigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability during client cache hydration by safely handling missing or invalid persisted cache payloads.
  * Prevented rare crashes when restoring cached state by adding an explicit guard before using persisted “buster” and cache query details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->