### PR TITLE
fix: increase default widget preview dimensions for fullscreen view

### DIFF
--- a/apps/nextjs/src/app/[locale]/widgets/[kind]/_content.tsx
+++ b/apps/nextjs/src/app/[locale]/widgets/[kind]/_content.tsx
@@ -37,8 +37,8 @@ export const WidgetPreviewPageContent = ({ kind, integrationData }: WidgetPrevie
   const currentDefinition = useMemo(() => widgetImports[kind].definition, [kind]);
   const [editMode, setEditMode] = useState(false);
   const [dimensions, setDimensions] = useState<Dimensions>({
-    width: 128,
-    height: 128,
+    width: 960,
+    height: 640,
   });
   const [state, setState] = useState<{
     options: Record<string, unknown>;


### PR DESCRIPTION
## Description

Fixes #6230

The widget fullscreen page (`/widgets/[kind]`) renders widgets inside a `<Card>` with hardcoded default dimensions of 128x128 px. For table-based widgets like Docker containers, this squishes the MantineReactTable into a tiny strip instead of filling the viewport.

## Root Cause

In `apps/nextjs/src/app/[locale]/widgets/[kind]/_content.tsx`, the `dimensions` state defaults to `width: 128, height: 128`, which are the minimum grid dimensions for a board widget. The WidgetPreviewPageContent wraps the actual widget component in a `<Card w={dimensions.width} h={dimensions.height}>`, constraining the content to these tiny dimensions.

## Fix

Increased the default dimensions from `128x128` to `960x640`, which gives widgets a reasonable viewing area when opened via the sidebar navigation. Users can still use the Dimension button (bottom-right) to adjust the preview size to any value between 64 and 1024.

## Testing

1. Navigate to `/widgets/dockerContainers`
2. Verify the Docker table renders at a reasonable size (not a tiny strip)
3. Click the Dimension button to verify manual sizing still works
4. Verify other widgets also render correctly in the preview page