### PR TITLE
fix: Docker widget full-screen mode layout

### DIFF
--- a/apps/nextjs/src/components/layout/header/docker-quick-access-modal.tsx
+++ b/apps/nextjs/src/components/layout/header/docker-quick-access-modal.tsx
@@ -6,5 +6,5 @@ import { DockerTable } from "~/app/[locale]/manage/tools/docker/docker-table";
 
 export const DockerQuickAccessModal = createModal<void>(() => <DockerTable />).withOptions({
   defaultTitle: (t) => t("docker.title"),
-  size: 1400,
+  fullScreen: true,
 });


### PR DESCRIPTION
Closes #6230

🤖 This PR was opened automatically by homarr-bot. A maintainer must review before merging.

## Summary
Fixed Docker widget full-screen mode to properly expand across the viewport instead of displaying a narrow strip.

## Changes
- Changed modal sizing from fixed numeric size (1400px) to fullScreen property
- This allows the modal to use responsive viewport sizing

## Root Cause
The modal theme system only applies responsive width constraints to named sizes (e.g., "xxl", "lg"). Numeric sizes like 1400 bypass this styling and render with a fixed width that can be too narrow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Docker quick access modal to open in full-screen mode, improving the viewing experience on smaller screens and for larger content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->