### PR TITLE
ci: skip lint-format-autofix on fork PRs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   lint-format-autofix:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
The `lint-format-autofix` job fails on every pull request opened from a fork. It checks out `github.head_ref` from the base repository and pushes autofix commits with `git-auto-commit-action`, and neither works cross-repository. The head branch doesn't exist in the base repo, so checkout fails before any lint runs, and even if it succeeded the default `GITHUB_TOKEN` has no write access to the fork's branch.

This PR fixes the pipeline for external PRs by restricting the job to same-repo pull requests, comparing `github.event.pull_request.head.repo.id` against `github.repository_id` (immutable numeric IDs, rename-proof). Fork PRs now skip the job instead of failing, while same-repo PRs are unchanged. Lint and format coverage for forks is unaffected, since the separate `lint` and `format` jobs already run on all PRs.

See [this job](https://github.com/homarr-labs/homarr/actions/runs/28791831128/job/85372286316?pr=6149) for an example of the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated quality checks so the formatting auto-fix step now runs only for pull requests coming from forks, reducing unnecessary runs on same-repository PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->