### PR TITLE
fix: add utf8 email validation support

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/users/create/_components/create-user-stepper.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/users/create/_components/create-user-stepper.tsx
@@ -17,6 +17,7 @@ import { showErrorNotification } from "@homarr/notifications";
 import { useI18n, useScopedI18n } from "@homarr/translation/client";
 import { UserAvatar } from "@homarr/ui";
 import { createCustomErrorParams } from "@homarr/validation/form/i18n";
+import { optionalEmailSchema } from "@homarr/validation/email";
 import { userPasswordSchema } from "@homarr/validation/user";
 
 import { GroupSelectModal } from "~/components/access/group-select-modal";
@@ -60,7 +61,7 @@ export const UserCreateStepperComponent = ({ initialGroups }: UserCreateStepperC
   const generalForm = useZodForm(
     z.object({
       username: z.string().min(1),
-      email: z.string().email().or(z.string().length(0).optional()),
+      email: optionalEmailSchema,
     }),
     {
       initialValues: {

--- a/packages/auth/providers/credentials/authorization/ldap-authorization.ts
+++ b/packages/auth/providers/credentials/authorization/ldap-authorization.ts
@@ -53,9 +53,7 @@ export const authorizeWithLdapCredentialsAsync = async (
     throw new CredentialsSignin(`User not found in LDAP username="${credentials.name}"`);
   }
 
-  const mailResult = await utf8EmailSchema.safeParseAsync(
-    ldapUser[env.AUTH_LDAP_USER_MAIL_ATTRIBUTE],
-  );
+  const mailResult = await utf8EmailSchema.safeParseAsync(ldapUser[env.AUTH_LDAP_USER_MAIL_ATTRIBUTE]);
 
   if (!mailResult.success) {
     logger.error("User found in LDAP but with invalid or non-existing Email", {

--- a/packages/auth/providers/credentials/authorization/ldap-authorization.ts
+++ b/packages/auth/providers/credentials/authorization/ldap-authorization.ts
@@ -1,5 +1,5 @@
 import { CredentialsSignin } from "@auth/core/errors";
-import { z } from "zod/v4";
+import type { z } from "zod/v4";
 
 import { createId } from "@homarr/common";
 import { createLogger } from "@homarr/core/infrastructure/logs";
@@ -7,6 +7,7 @@ import type { Database, InferInsertModel } from "@homarr/db";
 import { and, eq } from "@homarr/db";
 import { users } from "@homarr/db/schema";
 import type { ldapSignInSchema } from "@homarr/validation/user";
+import { utf8EmailSchema } from "@homarr/validation/email";
 
 import { env } from "../../../env";
 import { LdapClient } from "../ldap-client";
@@ -52,8 +53,9 @@ export const authorizeWithLdapCredentialsAsync = async (
     throw new CredentialsSignin(`User not found in LDAP username="${credentials.name}"`);
   }
 
-  // Validate email
-  const mailResult = await z.string().email().safeParseAsync(ldapUser[env.AUTH_LDAP_USER_MAIL_ATTRIBUTE]);
+  const mailResult = await utf8EmailSchema.safeParseAsync(
+    ldapUser[env.AUTH_LDAP_USER_MAIL_ATTRIBUTE],
+  );
 
   if (!mailResult.success) {
     logger.error("User found in LDAP but with invalid or non-existing Email", {

--- a/packages/old-import/src/user-schema.ts
+++ b/packages/old-import/src/user-schema.ts
@@ -1,5 +1,7 @@
 import { z } from "zod/v4";
 
+import { nullableEmailSchema } from "@homarr/validation/email";
+
 const regexEncryptedSchema = z.string().regex(/^[a-f0-9]+\.[a-f0-9]+$/g);
 
 const encryptedSchema = z.custom<`${string}.${string}`>((value) => regexEncryptedSchema.safeParse(value).success);
@@ -7,7 +9,7 @@ const encryptedSchema = z.custom<`${string}.${string}`>((value) => regexEncrypte
 export const oldmarrImportUserSchema = z.object({
   id: z.string(),
   name: z.string(),
-  email: z.string().email().nullable(),
+  email: nullableEmailSchema,
   emailVerified: z.date().nullable(),
   image: z.string().nullable(),
   isAdmin: z.boolean(),

--- a/packages/old-import/src/user-schema.ts
+++ b/packages/old-import/src/user-schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod/v4";
 
-import { nullableEmailSchema } from "@homarr/validation/email";
+import { requiredNullableEmailSchema } from "@homarr/validation/email";
 
 const regexEncryptedSchema = z.string().regex(/^[a-f0-9]+\.[a-f0-9]+$/g);
 
@@ -9,7 +9,7 @@ const encryptedSchema = z.custom<`${string}.${string}`>((value) => regexEncrypte
 export const oldmarrImportUserSchema = z.object({
   id: z.string(),
   name: z.string(),
-  email: nullableEmailSchema,
+  email: requiredNullableEmailSchema,
   emailVerified: z.date().nullable(),
   image: z.string().nullable(),
   isAdmin: z.boolean(),

--- a/packages/validation/src/email.ts
+++ b/packages/validation/src/email.ts
@@ -2,9 +2,7 @@ import { z } from "zod/v4";
 
 export const utf8EmailSchema = z.email({ pattern: z.regexes.unicodeEmail });
 
-export const optionalEmailSchema = utf8EmailSchema
-  .or(z.string().length(0))
-  .optional();
+export const optionalEmailSchema = utf8EmailSchema.or(z.string().length(0)).optional();
 
 export const nullableEmailSchema = utf8EmailSchema
   .or(z.literal(""))

--- a/packages/validation/src/email.ts
+++ b/packages/validation/src/email.ts
@@ -9,3 +9,8 @@ export const nullableEmailSchema = utf8EmailSchema
   .transform((value) => (value === "" ? null : value))
   .optional()
   .nullable();
+
+export const requiredNullableEmailSchema = utf8EmailSchema
+  .or(z.literal(""))
+  .transform((value) => (value === "" ? null : value))
+  .nullable();

--- a/packages/validation/src/email.ts
+++ b/packages/validation/src/email.ts
@@ -1,0 +1,13 @@
+import { z } from "zod/v4";
+
+export const utf8EmailSchema = z.email({ pattern: z.regexes.unicodeEmail });
+
+export const optionalEmailSchema = utf8EmailSchema
+  .or(z.string().length(0))
+  .optional();
+
+export const nullableEmailSchema = utf8EmailSchema
+  .or(z.literal(""))
+  .transform((value) => (value === "" ? null : value))
+  .optional()
+  .nullable();

--- a/packages/validation/src/form/i18n.spec.ts
+++ b/packages/validation/src/form/i18n.spec.ts
@@ -4,6 +4,7 @@ import { z } from "zod/v4";
 import type { TranslationFunction } from "@homarr/translation";
 
 import { createCustomErrorParams, zodErrorMap } from "./i18n";
+import { utf8EmailSchema } from "../email";
 
 const expectError = (error: z.core.$ZodIssue, key: string) => {
   expect(error.message).toContain(key);
@@ -110,5 +111,20 @@ describe("i18n", () => {
     if (result.success) return;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expectError(result.error.issues[0]!, "boardAlreadyExists");
+  });
+
+  test("should validate UTF8SMTP email with umlauts", () => {
+    const result = utf8EmailSchema.safeParse("jörg@example.com");
+    expect(result.success).toBe(true);
+  });
+
+  test("should validate UTF8SMTP email with unicode domain", () => {
+    const result = utf8EmailSchema.safeParse("user@münchen.de");
+    expect(result.success).toBe(true);
+  });
+
+  test("should validate standard ASCII emails", () => {
+    const result = utf8EmailSchema.safeParse("user@example.com");
+    expect(result.success).toBe(true);
   });
 });

--- a/packages/validation/src/user.ts
+++ b/packages/validation/src/user.ts
@@ -6,6 +6,7 @@ import type { TranslationObject } from "@homarr/translation";
 
 import { zodEnumFromArray } from "./enums";
 import { createCustomErrorParams } from "./form/i18n";
+import { nullableEmailSchema, optionalEmailSchema } from "./email";
 
 // We always want the lowercase version of the username to compare it in a case-insensitive way
 export const usernameSchema = z.string().trim().toLowerCase().min(3).max(255);
@@ -42,7 +43,7 @@ export const userBaseCreateSchema = z.object({
   username: usernameSchema,
   password: userPasswordSchema,
   confirmPassword: z.string(),
-  email: z.string().email().or(z.string().length(0)).optional(),
+  email: optionalEmailSchema,
 });
 
 export const userCreateSchema = addConfirmPasswordRefinement(userBaseCreateSchema).and(
@@ -85,13 +86,7 @@ export const userRegistrationApiSchema = userRegistrationSchema.and(
 export const userEditProfileSchema = z.object({
   id: z.string(),
   name: usernameSchema,
-  email: z
-    .string()
-    .email()
-    .or(z.literal(""))
-    .transform((value) => (value === "" ? null : value))
-    .optional()
-    .nullable(),
+  email: nullableEmailSchema,
 });
 
 const baseChangePasswordSchema = z.object({


### PR DESCRIPTION
## Summary
This PR adds UTF-8 (UTF8SMTP) email support so addresses containing umlauts and other non-ASCII characters (e.g. `müller@test.de`, `user@münchen.de`) are accepted. It introduces a shared UTF-8 email schema and switches all email validators — user create/edit, LDAP login, and legacy import — over to it. Resolves #3764.

## Changes 
- `packages/validation/src/email.ts`: New shared schemas — `utf8EmailSchema` (`z.email({ pattern: z.regexes.unicodeEmail })`), plus `optionalEmailSchema` and `nullableEmailSchema` variants.
- `packages/validation/src/user.ts`: `userBaseCreateSchema` and `userEditProfileSchema` now use `optionalEmailSchema` / `nullableEmailSchema` instead of `z.string().email()`.
- `apps/nextjs/src/app/[locale]/manage/users/create/_components/create-user-stepper.tsx`: Create-user form email field switched to `optionalEmailSchema`.
- `packages/auth/providers/credentials/authorization/ldap-authorization.ts`: LDAP email validation switched to `utf8EmailSchema`; `zod` import narrowed to `import type`.
- `packages/old-import/src/user-schema.ts`: Legacy import user email switched to `nullableEmailSchema`.

## Testing
- Unit and integration testing
## UI Testing: typing email with special characters but no error message is shown
<img width="2163" height="1449" alt="image" src="https://github.com/user-attachments/assets/6bd1b9b0-6cad-47c9-aabf-a4bc4d38887f" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced shared email validation utilities supporting Unicode email addresses consistently across the app.

* **Bug Fixes**
  * Improved user creation and profile editing email validation, handling empty values consistently and producing the expected optional/null outcomes.
  * Updated LDAP sign-in email validation to use the standardized Unicode-aware parsing.
  * Adjusted legacy import email validation to align with the shared rules.

* **Tests**
  * Added coverage to verify UTF-8/Unicode email validation (umlauts and internationalized domains) plus standard ASCII emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->