### PR TITLE
fix: context menu refresh stays open with loading spinner, cache age reacts to refetch

### DIFF
--- a/apps/nextjs/src/components/board/items/widget-context-menu.tsx
+++ b/apps/nextjs/src/components/board/items/widget-context-menu.tsx
@@ -2,10 +2,10 @@
 
 import type { MutableRefObject, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Group, Menu, Switch, Text } from "@mantine/core";
+import { Group, Loader, Menu, Switch, Text } from "@mantine/core";
 import { IconCopy, IconLayoutKanban, IconRefresh, IconSettings, IconTrash } from "@tabler/icons-react";
 import type { QueryClient } from "@tanstack/react-query";
-import { useQueryClient } from "@tanstack/react-query";
+import { useIsFetching, useQueryClient } from "@tanstack/react-query";
 
 import { clientApi } from "@homarr/api/client";
 import { useSession } from "@homarr/auth/client";
@@ -50,8 +50,9 @@ export const WidgetContextMenu = ({ item, widgetStateRef, children }: WidgetCont
   const queryClient = useQueryClient();
 
   const widgetQueryKey = useMemo(() => [["widget", item.kind]], [item.kind]);
+  const isWidgetFetching = useIsFetching({ queryKey: widgetQueryKey }) > 0;
   const handleRefetch = useCallback(() => {
-    void queryClient.invalidateQueries({ queryKey: widgetQueryKey });
+    void queryClient.refetchQueries({ queryKey: widgetQueryKey, type: "all" });
   }, [queryClient, widgetQueryKey]);
 
   const options = useMemo(
@@ -223,7 +224,7 @@ export const WidgetContextMenu = ({ item, widgetStateRef, children }: WidgetCont
 
         <>
           {(toggleOptions.length > 0 || visibleWidgetActions.length > 0 || isEditMode) && <Menu.Divider />}
-          <Menu.Item closeMenuOnClick leftSection={<IconRefresh size={16} />} onClick={handleRefetch}>
+          <Menu.Item leftSection={isWidgetFetching ? <Loader size={16} /> : <IconRefresh size={16} />} onClick={handleRefetch} disabled={isWidgetFetching}>
             <Group justify="space-between" wrap="nowrap">
               {tMenu("refresh")}
               <Text size="xs" c="dimmed">
@@ -266,11 +267,15 @@ export const WidgetContextMenu = ({ item, widgetStateRef, children }: WidgetCont
 };
 
 const WidgetCacheAge = ({ queryClient, queryKey }: { queryClient: QueryClient; queryKey: unknown[] }) => {
+  const isFetching = useIsFetching({ queryKey }) > 0;
+  // ponytail: 1s tick for "just now" → "1s ago" transition; useIsFetching handles refetch reactivity
   const [, setTick] = useState(0);
   useEffect(() => {
     const id = setInterval(() => setTick((n) => n + 1), 1000);
     return () => clearInterval(id);
   }, []);
+
+  if (isFetching) return <Loader size={12} />;
 
   const timestamps = queryClient
     .getQueryCache()

--- a/apps/nextjs/src/components/board/items/widget-context-menu.tsx
+++ b/apps/nextjs/src/components/board/items/widget-context-menu.tsx
@@ -224,7 +224,11 @@ export const WidgetContextMenu = ({ item, widgetStateRef, children }: WidgetCont
 
         <>
           {(toggleOptions.length > 0 || visibleWidgetActions.length > 0 || isEditMode) && <Menu.Divider />}
-          <Menu.Item leftSection={isWidgetFetching ? <Loader size={16} /> : <IconRefresh size={16} />} onClick={handleRefetch} disabled={isWidgetFetching}>
+          <Menu.Item
+            leftSection={isWidgetFetching ? <Loader size={16} /> : <IconRefresh size={16} />}
+            onClick={handleRefetch}
+            disabled={isWidgetFetching}
+          >
             <Group justify="space-between" wrap="nowrap">
               {tMenu("refresh")}
               <Text size="xs" c="dimmed">

--- a/apps/nextjs/src/components/board/items/widget-context-menu.tsx
+++ b/apps/nextjs/src/components/board/items/widget-context-menu.tsx
@@ -232,7 +232,7 @@ export const WidgetContextMenu = ({ item, widgetStateRef, children }: WidgetCont
             <Group justify="space-between" wrap="nowrap">
               {tMenu("refresh")}
               <Text size="xs" c="dimmed">
-                <WidgetCacheAge queryClient={queryClient} queryKey={widgetQueryKey} />
+                <WidgetCacheAge queryClient={queryClient} queryKey={widgetQueryKey} isFetching={isWidgetFetching} />
               </Text>
             </Group>
           </Menu.Item>
@@ -270,9 +270,16 @@ export const WidgetContextMenu = ({ item, widgetStateRef, children }: WidgetCont
   );
 };
 
-const WidgetCacheAge = ({ queryClient, queryKey }: { queryClient: QueryClient; queryKey: unknown[] }) => {
-  const isFetching = useIsFetching({ queryKey }) > 0;
-  // ponytail: 1s tick for "just now" → "1s ago" transition; useIsFetching handles refetch reactivity
+const WidgetCacheAge = ({
+  queryClient,
+  queryKey,
+  isFetching,
+}: {
+  queryClient: QueryClient;
+  queryKey: unknown[];
+  isFetching: boolean;
+}) => {
+  // 1s tick for "just now" → "1s ago" label transition; isFetching prop handles refetch reactivity
   const [, setTick] = useState(0);
   useEffect(() => {
     const id = setInterval(() => setTick((n) => n + 1), 1000);


### PR DESCRIPTION
## Changes

- **Refresh button no longer closes the context menu** — removed `closeMenuOnClick` from the refresh `Menu.Item`
- **Loading spinner on refresh button** — `useIsFetching` shows a `Loader` icon while widget queries are fetching, button is disabled during fetch
- **Cache age updates reactively** — `WidgetCacheAge` now uses `useIsFetching` to detect query fetch completions and re-render, instead of relying solely on the 1s tick timer
- **`refetchQueries` instead of `invalidateQueries`** — `refetchQueries({ type: 'all' })` forces immediate refetch for all matching queries (active and inactive), ensuring the cache timestamp updates

## Files changed
- `apps/nextjs/src/components/board/items/widget-context-menu.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The widget context menu now shows real-time loading feedback when the selected widget is refreshing.
  * Widget cache age information now displays a loading indicator while data is being fetched.
* **Bug Fixes**
  * The refresh action now triggers a more targeted reload for the selected widget and disables the refresh menu item during in-progress fetching to prevent repeated clicks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->