### PR TITLE
fix(docker): report current CPU usage instead of the lifetime average

### DIFF
--- a/packages/request-handler/src/docker.ts
+++ b/packages/request-handler/src/docker.ts
@@ -300,7 +300,10 @@ async function getContainersWithStatsAsync() {
 
     const stats = await instance
       .getContainer(container.Id)
-      .stats({ stream: false, "one-shot": true })
+      // Not in one-shot mode: the daemon then includes precpu_stats (the
+      // previous reading), which is required to compute the current CPU usage
+      // as a delta. One-shot omits it and would only expose lifetime totals.
+      .stats({ stream: false })
       .catch(
         () =>
           ({
@@ -336,12 +339,22 @@ export function calculateCpuUsage(stats: ContainerStats): number {
   }
 
   const numberOfCpus = stats.cpu_stats.online_cpus;
-  const usage = stats.cpu_stats.system_cpu_usage;
-  if (!usage || usage === 0) {
+
+  // Docker's own formula for the current (instantaneous) CPU usage: it compares
+  // the latest reading against the previous one (precpu_stats). Dividing the
+  // cumulative total_usage by the cumulative system_cpu_usage instead would
+  // report the container's lifetime average, which stays high long after a load
+  // spike has ended. precpu_stats is only present when the stats are NOT fetched
+  // in one-shot mode; when it is absent (e.g. Podman) the deltas fall back to the
+  // cumulative totals, matching the previous behaviour.
+  const cpuDelta = stats.cpu_stats.cpu_usage.total_usage - (stats.precpu_stats?.cpu_usage?.total_usage ?? 0);
+  const systemDelta = (stats.cpu_stats.system_cpu_usage ?? 0) - (stats.precpu_stats?.system_cpu_usage ?? 0);
+
+  if (systemDelta <= 0 || cpuDelta < 0) {
     return 0;
   }
 
-  return (stats.cpu_stats.cpu_usage.total_usage / usage) * numberOfCpus * 100;
+  return (cpuDelta / systemDelta) * numberOfCpus * 100;
 }
 
 export function calculateMemoryUsage(stats: ContainerStats): number {

--- a/packages/request-handler/src/test/docker.spec.ts
+++ b/packages/request-handler/src/test/docker.spec.ts
@@ -75,6 +75,26 @@ describe("calculateCpuUsage", () => {
     // (500 / 100000) * 2 * 100 = 1
     expect(calculateCpuUsage(stats)).toBe(1);
   });
+
+  test("should use the delta against precpu_stats for the current usage", () => {
+    const stats = createStats({
+      cpu_stats: { online_cpus: 4, cpu_usage: { total_usage: 1_002_000 }, system_cpu_usage: 20_000 },
+      precpu_stats: { cpu_usage: { total_usage: 1_000_000 }, system_cpu_usage: 10_000 },
+    });
+    // Despite a large lifetime total_usage, only the recent delta counts:
+    // (2000 / 10000) * 4 * 100 = 80
+    expect(calculateCpuUsage(stats)).toBe(80);
+  });
+
+  test("should report 0 for a container that was busy over its lifetime but is idle now", () => {
+    const stats = createStats({
+      cpu_stats: { online_cpus: 4, cpu_usage: { total_usage: 1_000_000 }, system_cpu_usage: 20_000 },
+      precpu_stats: { cpu_usage: { total_usage: 1_000_000 }, system_cpu_usage: 10_000 },
+    });
+    // No CPU delta since the last reading -> current usage is 0, even though the
+    // lifetime average would be high. This is the regression the fix addresses.
+    expect(calculateCpuUsage(stats)).toBe(0);
+  });
 });
 
 describe("calculateMemoryUsage", () => {


### PR DESCRIPTION
Closes #5544

## Problem

The Docker containers widget reports each container's **lifetime-average** CPU usage instead of its **current** usage — a value stays high long after a load spike has ended (as described in the issue, regressed by #4266 / #4311).

## Cause

The stats are requested in one-shot mode:

```ts
.stats({ stream: false, "one-shot": true })
```

One-shot mode makes the daemon return immediately **without** `precpu_stats` (the previous reading). `calculateCpuUsage` was therefore left dividing the cumulative `total_usage` by the cumulative `system_cpu_usage`, which is exactly the lifetime average.

## Fix

- Request the stats **without** one-shot so the daemon includes `precpu_stats`.
- Compute the usage from the **delta** between the current and previous readings, which is [Docker's own CPU-percentage formula](https://github.com/docker/cli/blob/master/cli/command/container/stats_helpers.go).

When `precpu_stats` is absent (e.g. Podman, or the very first reading) the deltas fall back to the cumulative totals, so the previous behaviour is preserved for those runtimes.

## Tests

Extended `docker.spec.ts`: one test proving the delta (a large lifetime `total_usage` but a small recent delta yields the real current percentage) and one proving a container that was busy over its lifetime but is idle now reports `0`. All existing `calculateCpuUsage` tests still pass.

## Checklist

- [x] Builds without errors (`tsc --noEmit` clean on `@homarr/request-handler`)
- [x] `oxfmt` formatted, `oxlint` clean
- [x] Targets `dev`; conventional commit; no shorthand variable names

Note: dropping one-shot means the stats call now takes the usual ~1s Docker sampling interval; the per-container calls already run in parallel, so this only adds that interval once per refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container CPU usage reporting so values now reflect recent activity more accurately instead of relying on lifetime totals.
  * Fixed cases where CPU usage could appear inflated or incorrect when a container had little or no change since the last reading.
  * Added coverage to ensure CPU usage shows `0` when there is no measurable CPU change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->