### PR TITLE
fix(docker): report container CPU as a total-system percentage

### DIFF
--- a/packages/integrations/src/unraid/unraid-integration.ts
+++ b/packages/integrations/src/unraid/unraid-integration.ts
@@ -36,9 +36,6 @@ export class UnraidIntegration extends Integration implements ISystemHealthMonit
   public async getSystemInfoAsync(): Promise<SystemHealthMonitoring> {
     const systemInfo = await this.getSystemInformationAsync();
 
-    const cpuUtilization = systemInfo.metrics.cpu.cpus.reduce((acc, val) => acc + val.percentTotal, 0);
-    const cpuCount = systemInfo.info.cpu.cores;
-
     // We use "info" object instead of the stats since this is the exact amount the kernel sees, which is what Unraid displays.
     const totalMemory = systemInfo.info.memory.layout.reduce((acc, layout) => layout.size + acc, 0);
     const usedMemory = totalMemory * (systemInfo.metrics.memory.percentTotal / 100);
@@ -47,7 +44,12 @@ export class UnraidIntegration extends Integration implements ISystemHealthMonit
     return {
       version: systemInfo.info.os.release,
       cpuModelName: systemInfo.info.cpu.brand,
-      cpuUtilization: cpuUtilization / cpuCount,
+      // Use the overall CPU utilization the Unraid API already reports (0-100),
+      // which is the value Unraid itself displays. Previously the per-thread
+      // percentages were summed and divided by the number of physical cores,
+      // which double-counted on hyper-threaded systems (e.g. 24 threads over
+      // 12 cores) and could even exceed 100%.
+      cpuUtilization: systemInfo.metrics.cpu.percentTotal,
       memUsedInBytes: usedMemory,
       memAvailableInBytes: totalMemory - usedMemory,
       uptime: dayjs().diff(uptime, "seconds"),

--- a/packages/request-handler/src/docker.ts
+++ b/packages/request-handler/src/docker.ts
@@ -335,13 +335,25 @@ export function calculateCpuUsage(stats: ContainerStats): number {
     return 0;
   }
 
-  const numberOfCpus = stats.cpu_stats.online_cpus;
-  const usage = stats.cpu_stats.system_cpu_usage;
-  if (!usage || usage === 0) {
+  // Instantaneous CPU usage: compare the latest reading against the previous one
+  // (precpu_stats). Dividing the cumulative total_usage by the cumulative
+  // system_cpu_usage instead would report the container's lifetime average, which
+  // stays high long after a load spike has ended. precpu_stats is only present
+  // when the stats are NOT fetched in one-shot mode; when it is absent (e.g.
+  // Podman) the deltas fall back to the cumulative totals.
+  const cpuDelta = stats.cpu_stats.cpu_usage.total_usage - (stats.precpu_stats?.cpu_usage?.total_usage ?? 0);
+  const systemDelta = (stats.cpu_stats.system_cpu_usage ?? 0) - (stats.precpu_stats?.system_cpu_usage ?? 0);
+
+  if (systemDelta <= 0 || cpuDelta < 0) {
     return 0;
   }
 
-  return (stats.cpu_stats.cpu_usage.total_usage / usage) * numberOfCpus * 100;
+  // Report usage as a share of the WHOLE machine (0-100%), not docker-stats'
+  // per-core convention (which multiplies by online_cpus and can exceed 100%,
+  // e.g. "134%" for 1.34 busy cores). system_cpu_usage already accumulates
+  // across all cores, so the plain ratio is the total-system share. This keeps
+  // every CPU reading in homarr on the same intuitive 0-100% scale.
+  return (cpuDelta / systemDelta) * 100;
 }
 
 export function calculateMemoryUsage(stats: ContainerStats): number {

--- a/packages/request-handler/src/test/docker.spec.ts
+++ b/packages/request-handler/src/test/docker.spec.ts
@@ -64,16 +64,45 @@ describe("calculateCpuUsage", () => {
     const stats = createStats({
       cpu_stats: { online_cpus: 4, cpu_usage: { total_usage: 2000 }, system_cpu_usage: 10000 },
     });
-    // (2000 / 10000) * 4 * 100 = 80
-    expect(calculateCpuUsage(stats)).toBe(80);
+    // Total-system share: (2000 / 10000) * 100 = 20 (system_cpu_usage spans all cores)
+    expect(calculateCpuUsage(stats)).toBe(20);
   });
 
   test("should handle fractional CPU usage", () => {
     const stats = createStats({
       cpu_stats: { online_cpus: 2, cpu_usage: { total_usage: 500 }, system_cpu_usage: 100000 },
     });
-    // (500 / 100000) * 2 * 100 = 1
-    expect(calculateCpuUsage(stats)).toBe(1);
+    // (500 / 100000) * 100 = 0.5
+    expect(calculateCpuUsage(stats)).toBe(0.5);
+  });
+
+  test("should never exceed 100% even when multiple cores are fully busy", () => {
+    const stats = createStats({
+      // 3 of 4 cores fully busy: docker-stats' per-core convention would say 300%.
+      cpu_stats: { online_cpus: 4, cpu_usage: { total_usage: 7500 }, system_cpu_usage: 10000 },
+    });
+    // Total-system share: (7500 / 10000) * 100 = 75
+    expect(calculateCpuUsage(stats)).toBe(75);
+  });
+
+  test("should use the delta against precpu_stats for the current usage", () => {
+    const stats = createStats({
+      cpu_stats: { online_cpus: 4, cpu_usage: { total_usage: 1_002_000 }, system_cpu_usage: 20_000 },
+      precpu_stats: { cpu_usage: { total_usage: 1_000_000 }, system_cpu_usage: 10_000 },
+    });
+    // Despite a large lifetime total_usage, only the recent delta counts:
+    // (2000 / 10000) * 100 = 20
+    expect(calculateCpuUsage(stats)).toBe(20);
+  });
+
+  test("should report 0 for a container that was busy over its lifetime but is idle now", () => {
+    const stats = createStats({
+      cpu_stats: { online_cpus: 4, cpu_usage: { total_usage: 1_000_000 }, system_cpu_usage: 20_000 },
+      precpu_stats: { cpu_usage: { total_usage: 1_000_000 }, system_cpu_usage: 10_000 },
+    });
+    // No CPU delta since the last reading -> current usage is 0, even though the
+    // lifetime average would be high. This is the regression the fix addresses.
+    expect(calculateCpuUsage(stats)).toBe(0);
   });
 });
 


### PR DESCRIPTION
This branch started as the Unraid CPU fix for #6082. That landed separately in #6510 on 2026-08-22, so the Unraid hunk is gone and what is left is a different fix on a different file. Retitling rather than opening a new PR, so the review history stays attached.

## Problem

`calculateCpuUsage` in `packages/request-handler/src/docker.ts` divides the container's cumulative `total_usage` by the cumulative `system_cpu_usage`. Both counters run from container start, so the result is the container's lifetime average, not what it is doing now. A container that was busy an hour ago keeps reporting a high number long after the load ended.

It then multiplies by `online_cpus`, following docker stats' per-core convention, where 134% means 1.34 busy cores. Every other CPU reading in Homarr is a 0-100% share of the machine, so the same dashboard shows two different scales.

## Fix

Compare the latest reading against the previous one, which is what `precpu_stats` is for, and report the plain ratio. `system_cpu_usage` already accumulates across all cores, so the ratio is the whole-machine share and cannot exceed 100%.

`precpu_stats` is absent when stats are fetched in one-shot mode, Podman being the case that matters here, so the deltas fall back to the cumulative totals and behave as before rather than dividing by zero.

## The part worth a second opinion

Dropping the `online_cpus` multiplier changes what the number means: a container using 1.34 cores on an 8 core host reported 134% before and reports about 17% now. I think matching the rest of Homarr's 0-100% scale is the right call, but it is a visible change and it is yours to make. Say so if you would rather keep docker stats' convention and I will restore the multiplier while keeping the delta fix.

## Tests

`docker.spec.ts` covers the delta calculation, the fallback when `precpu_stats` is missing, and that several fully busy cores stay at or below 100%. The two existing expectations that encoded the old per-core scale were updated with the arithmetic spelled out.
