### PR TITLE
fix(request-handler): restore media organizer build

### DIFF
--- a/packages/request-handler/src/media-organizer.ts
+++ b/packages/request-handler/src/media-organizer.ts
@@ -1,10 +1,8 @@
-import dayjs from "dayjs";
-
 import type { IntegrationKindByCategory } from "@homarr/definitions";
 import { createIntegrationAsync } from "@homarr/integrations";
 import type { IMediaOrganizerIntegration, MissingMediaItem, QueuedMediaItem } from "@homarr/integrations/types";
 
-import { createCachedIntegrationRequestHandler } from "./lib/cached-integration-request-handler";
+import { createIntegrationRequestHandler } from "./lib/integration-request-handler";
 
 interface MediaOrganizerData {
   missing: MissingMediaItem[];
@@ -13,7 +11,7 @@ interface MediaOrganizerData {
   queuedCount: number;
 }
 
-export const mediaOrganizerRequestHandler = createCachedIntegrationRequestHandler<
+export const mediaOrganizerRequestHandler = createIntegrationRequestHandler<
   MediaOrganizerData,
   IntegrationKindByCategory<"mediaOrganizer">,
   { pageSize: number }
@@ -31,6 +29,5 @@ export const mediaOrganizerRequestHandler = createCachedIntegrationRequestHandle
       queuedCount: queueResult.totalCount,
     };
   },
-  cacheDuration: dayjs.duration(1, "minute"),
-  queryKey: "mediaOrganizer",
+  cacheTtlMs: 60_000,
 });


### PR DESCRIPTION
## Summary
- replace the removed cached request handler import with the current integration request handler
- preserve the media organizer cache TTL at 60 seconds

## Verification
- `pnpm build` passes on Node 24.18.0
- `pnpm lint` reaches unrelated existing errors in integrations/widgets
- `pnpm typecheck` reaches the unrelated existing `searchCh` definition error
- `pnpm test` runs 3,928 passing tests; remaining failures require a container runtime or come from local `.claude/worktrees` discovery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved media organizer request handling for more consistent loading of missing items and queued media.
  * Added short-term caching to help reduce repeated requests while keeping displayed information current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->