### PR TITLE
fix(db): restore widget_secret migration journal entries accidentally removed by #6206

### DIFF
--- a/packages/db/migrations/mysql/meta/_journal.json
+++ b/packages/db/migrations/mysql/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1780764500000,
       "tag": "0041_merge_custom_widget_url",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "5",
+      "when": 1783176100870,
+      "tag": "0042_add_widget_secret",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/postgresql/meta/_journal.json
+++ b/packages/db/migrations/postgresql/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1780764500000,
       "tag": "0007_merge_custom_widget_url",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1783176100870,
+      "tag": "0008_add_widget_secret",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/sqlite/meta/_journal.json
+++ b/packages/db/migrations/sqlite/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1780764500000,
       "tag": "0039_merge_custom_widget_url",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "6",
+      "when": 1783176100870,
+      "tag": "0040_add_widget_secret",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes #6203, fixes #6266

## Root Cause

The `add_widget_secret` migration (postgresql/0008, mysql/0042, sqlite/0040) was originally added by `885be1b9a` (Jul 4) with correct journal entries. However, when the Traefik integration PR (#6206, `9864fed77`, Jul 10) was merged, `drizzle-kit generate` regenerated the `_journal.json` files from a branch that didn't have these entries, accidentally stripping them.

Without these journal entries, `drizzle-orm/migrate()` never discovers the migration. The `widget_secret` table is never created, and all provider token saves fail silently — causing the Releases widget to hit GitHub API rate limits.

The migration SQL files and snapshot files were never removed — only the journal indices were lost.

## Fix

Re-added the missing journal entries (identical to the original fix's timestamp `1783176100870`).

## Verification

- `drizzle-orm/migrate()` reads `meta/_journal.json` to discover pending migrations
- With these entries restored, the migration will be discovered and applied on next startup
- The `widget_secret` table will be created, and provider tokens will persist correctly

## Affected Databases

All three dialects were affected — journal entries restored for postgresql, mysql, and sqlite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated database migration tracking across supported database engines.
  * Improved consistency and reliability when applying schema updates during deployments.
  * No direct changes to the user interface or application functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->