### PR TITLE
feat(auth): support nested OIDC claim paths

### DIFF
--- a/apps/docs/docs/advanced/single-sign-on/index.mdx
+++ b/apps/docs/docs/advanced/single-sign-on/index.mdx
@@ -199,9 +199,9 @@ Homarr supports multiple authentication options, from internal userbase (credent
     | ``AUTH_OIDC_CLIENT_NAME``   | Display name of provider (in login screen)                 | OIDC          |
     | ``AUTH_OIDC_AUTO_LOGIN``    | Automatically redirect to OIDC login                       | false         |
     | ``AUTH_OIDC_SCOPE_OVERWRITE`` | Overwrite default scopes (openid, profile, email)        | openid email profile groups           |
-    | ``AUTH_OIDC_GROUPS_ATTRIBUTE`` | Attribute used for groups (roles) claim                  | groups        |
+    | ``AUTH_OIDC_GROUPS_ATTRIBUTE`` | Attribute used for groups (roles) claim. Dot-separated paths such as `resource_access.homarr.roles` are supported. | groups        |
     | ``AUTH_OIDC_GROUPS_LOCAL_MANAGEMENT`` | Stop syncing group memberships of OIDC users from the groups claim and manage them locally via the group members page instead | false |
-    | ``AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE`` | Overwrite name attribute. By default it will use preferred_username if it does not contain a `@` and otherwise name. | ---          |
+    | ``AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE`` | Overwrite name attribute. Dot-separated paths are supported. By default it will use preferred_username if it does not contain a `@` and otherwise name. | ---          |
     | ``AUTH_OIDC_FORCE_USERINFO`` | Force userinfo endpoint to be used for user information.    | false         |
     | ``AUTH_OIDC_ENABLE_DANGEROUS_ACCOUNT_LINKING`` | Enable account linking for OIDC provider. This will link the OIDC accounts by email. Be sure that you have verified emails to prevent stealing accounts. | false |
     | ``AUTH_OIDC_TOKEN_ENDPOINT_AUTH_METHOD`` | Override method for the token endpoint authentication. Supported values are `client_secret_basic`, `client_secret_post`, `client_secret_jwt` and `none`. | client_secret_basic |

--- a/apps/docs/docs/getting-started/installation/helm.md
+++ b/apps/docs/docs/getting-started/installation/helm.md
@@ -398,9 +398,9 @@ All available values are listed on the [artifacthub](https://artifacthub.io/pack
 | env.AUTH_LOGOUT_REDIRECT_URL | string | `nil` | URL to redirect to after clicking logging out. |
 | env.AUTH_OIDC_AUTO_LOGIN | string | `"false"` | Automatically redirect to OIDC login |
 | env.AUTH_OIDC_CLIENT_NAME | string | `"OIDC"` | Display name of provider (in login screen) |
-| env.AUTH_OIDC_GROUPS_ATTRIBUTE | string | `"groups"` | Attribute used for groups (roles) claim |
+| env.AUTH_OIDC_GROUPS_ATTRIBUTE | string | `"groups"` | Attribute or dot-separated path used for groups (roles) claim |
 | env.AUTH_OIDC_ISSUER | string | `nil` | Issuer URI of OIDC provider without trailing slash (/) |
-| env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE | string | `nil` | Overwrite name attribute. By default, it will use preferred_username if it does not contain a @ and otherwise name. |
+| env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE | string | `nil` | Overwrite name attribute; dot-separated paths are supported. By default, it will use preferred_username if it does not contain a @ and otherwise name. |
 | env.AUTH_OIDC_SCOPE_OVERWRITE | string | `"openid email profile groups"` | Override the OIDC scopes |
 | env.AUTH_PROVIDERS | string | `"credentials"` | Enabled authentication methods. Multiple providers can be enabled with by separating them with , (ex. AUTH_PROVIDERS=credentials,oidc, it is highly recommended to just enable one provider). |
 | env.AUTH_SESSION_EXPIRY_TIME | string | `"30d"` | Time for the session to time out. Can be set as pure number, which will automatically be used in seconds, or followed by s, m, h or d for seconds, minutes, hours or days. (ex: "30m") |

--- a/packages/auth/events.ts
+++ b/packages/auth/events.ts
@@ -9,7 +9,7 @@ import { groupMembers, groups, users } from "@homarr/db/schema";
 import { colorSchemeCookieKey, everyoneGroup } from "@homarr/definitions";
 
 import { env } from "./env";
-import { extractProfileName } from "./providers/oidc/oidc-provider";
+import { extractProfileName, getProfileValueByPath } from "./providers/oidc/profile";
 
 const logger = createLogger({ module: "authEvents" });
 
@@ -30,15 +30,11 @@ export const createSignInEventHandler = (db: Database): Exclude<NextAuthConfig["
     if (!dbUser) throw new Error("User not found");
 
     const groupsKey = env.AUTH_OIDC_GROUPS_ATTRIBUTE;
+    const profileGroups = profile ? getProfileValueByPath(profile, groupsKey) : undefined;
     // Groups from oidc provider are provided from the profile, it's not typed.
-    if (
-      !env.AUTH_OIDC_GROUPS_LOCAL_MANAGEMENT &&
-      profile &&
-      groupsKey in profile &&
-      Array.isArray(profile[groupsKey])
-    ) {
-      logger.debug(`Using profile groups (${groupsKey}): ${JSON.stringify(profile[groupsKey])}`);
-      await synchronizeGroupsWithExternalForUserAsync(db, user.id, profile[groupsKey] as string[]);
+    if (!env.AUTH_OIDC_GROUPS_LOCAL_MANAGEMENT && Array.isArray(profileGroups)) {
+      logger.debug(`Using profile groups (${groupsKey}): ${JSON.stringify(profileGroups)}`);
+      await synchronizeGroupsWithExternalForUserAsync(db, user.id, profileGroups as string[]);
     }
 
     // In ldap-authroization we return the groups from ldap, it's not typed.

--- a/packages/auth/providers/oidc/oidc-provider.ts
+++ b/packages/auth/providers/oidc/oidc-provider.ts
@@ -7,6 +7,7 @@ import { fetchWithTrustedCertificatesAsync } from "@homarr/core/infrastructure/h
 
 import { env } from "../../env";
 import { createRedirectUri } from "../../redirect";
+import { extractProfileName } from "./profile";
 
 export const OidcProvider = (headers: ReadonlyHeaders | null): OIDCConfig<Profile> => ({
   id: "oidc",
@@ -73,12 +74,3 @@ export const OidcProvider = (headers: ReadonlyHeaders | null): OIDCConfig<Profil
   // @ts-expect-error `undici` has a `duplex` option
   [customFetch]: fetchWithTrustedCertificatesAsync,
 });
-
-export const extractProfileName = (profile: Profile) => {
-  if (!env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE) {
-    // Use the name as the username if the preferred_username is an email address
-    return profile.preferred_username?.includes("@") ? profile.name : profile.preferred_username;
-  }
-
-  return profile[env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE as keyof typeof profile] as string;
-};

--- a/packages/auth/providers/oidc/profile.ts
+++ b/packages/auth/providers/oidc/profile.ts
@@ -12,10 +12,10 @@ export const getProfileValueByPath = (profile: Profile, path: string): unknown =
   }, profile);
 };
 
-export const extractProfileName = (profile: Profile) => {
+export const extractProfileName = (profile: Profile): string | undefined => {
   if (!env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE) {
     // Use the name as the username if the preferred_username is an email address
-    return profile.preferred_username?.includes("@") ? profile.name : profile.preferred_username;
+    return (profile.preferred_username?.includes("@") ? profile.name : profile.preferred_username) ?? undefined;
   }
 
   const profileName = getProfileValueByPath(profile, env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE);

--- a/packages/auth/providers/oidc/profile.ts
+++ b/packages/auth/providers/oidc/profile.ts
@@ -1,0 +1,23 @@
+import type { Profile } from "@auth/core/types";
+
+import { env } from "../../env";
+
+export const getProfileValueByPath = (profile: Profile, path: string): unknown => {
+  return path.split(".").reduce<unknown>((value, key) => {
+    if (typeof value !== "object" || value === null || !Object.hasOwn(value, key)) {
+      return undefined;
+    }
+
+    return (value as Record<string, unknown>)[key];
+  }, profile);
+};
+
+export const extractProfileName = (profile: Profile) => {
+  if (!env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE) {
+    // Use the name as the username if the preferred_username is an email address
+    return profile.preferred_username?.includes("@") ? profile.name : profile.preferred_username;
+  }
+
+  const profileName = getProfileValueByPath(profile, env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE);
+  return typeof profileName === "string" ? profileName : undefined;
+};

--- a/packages/auth/providers/oidc/test/profile.spec.ts
+++ b/packages/auth/providers/oidc/test/profile.spec.ts
@@ -66,6 +66,14 @@ describe("extractProfileName", () => {
     expect(extractProfileName(profile)).toBeUndefined();
   });
 
+  test("returns undefined when preferred_username is missing", () => {
+    const profile = {
+      sub: "user-id",
+    } satisfies Profile;
+
+    expect(extractProfileName(profile)).toBeUndefined();
+  });
+
   test("uses a nested name claim when configured", () => {
     mockEnv.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE = "user.profile.display_name";
     const profile = {

--- a/packages/auth/providers/oidc/test/profile.spec.ts
+++ b/packages/auth/providers/oidc/test/profile.spec.ts
@@ -1,0 +1,59 @@
+import type { Profile } from "@auth/core/types";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const mockEnv = vi.hoisted(() => ({
+  AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE: undefined as string | undefined,
+}));
+
+vi.mock("../../../env", () => ({ env: mockEnv }));
+
+import { extractProfileName, getProfileValueByPath } from "../profile";
+
+afterEach(() => {
+  mockEnv.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE = undefined;
+});
+
+describe("getProfileValueByPath", () => {
+  const profile = {
+    sub: "user-id",
+    resource_access: {
+      homarr: {
+        roles: ["admins"],
+      },
+    },
+  } satisfies Profile;
+
+  test("returns a top-level claim", () => {
+    expect(getProfileValueByPath(profile, "sub")).toBe("user-id");
+  });
+
+  test("returns a nested claim", () => {
+    expect(getProfileValueByPath(profile, "resource_access.homarr.roles")).toEqual(["admins"]);
+  });
+
+  test("returns undefined when the path does not exist", () => {
+    expect(getProfileValueByPath(profile, "resource_access.missing.roles")).toBeUndefined();
+  });
+});
+
+describe("extractProfileName", () => {
+  test("uses a nested name claim when configured", () => {
+    mockEnv.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE = "user.profile.display_name";
+    const profile = {
+      sub: "user-id",
+      user: { profile: { display_name: "Nested User" } },
+    } satisfies Profile;
+
+    expect(extractProfileName(profile)).toBe("Nested User");
+  });
+
+  test("returns undefined when the configured claim is not a string", () => {
+    mockEnv.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE = "user.profile";
+    const profile = {
+      sub: "user-id",
+      user: { profile: { display_name: "Nested User" } },
+    } satisfies Profile;
+
+    expect(extractProfileName(profile)).toBeUndefined();
+  });
+});

--- a/packages/auth/providers/oidc/test/profile.spec.ts
+++ b/packages/auth/providers/oidc/test/profile.spec.ts
@@ -37,6 +37,35 @@ describe("getProfileValueByPath", () => {
 });
 
 describe("extractProfileName", () => {
+  test("uses preferred_username when overwrite is not set", () => {
+    const profile = {
+      sub: "user-id",
+      preferred_username: "johndoe",
+    } satisfies Profile;
+
+    expect(extractProfileName(profile)).toBe("johndoe");
+  });
+
+  test("uses name when preferred_username is an email", () => {
+    const profile = {
+      sub: "user-id",
+      preferred_username: "john@example.com",
+      name: "John Doe",
+    } satisfies Profile;
+
+    expect(extractProfileName(profile)).toBe("John Doe");
+  });
+
+  test("returns undefined when the fallback name is null", () => {
+    const profile = {
+      sub: "user-id",
+      preferred_username: "john@example.com",
+      name: null,
+    } satisfies Profile;
+
+    expect(extractProfileName(profile)).toBeUndefined();
+  });
+
   test("uses a nested name claim when configured", () => {
     mockEnv.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE = "user.profile.display_name";
     const profile = {

--- a/packages/auth/test/events.spec.ts
+++ b/packages/auth/test/events.spec.ts
@@ -1,7 +1,7 @@
 import type { ResponseCookie } from "next/dist/compiled/@edge-runtime/cookies";
 import type { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
 import { cookies } from "next/headers";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { eq } from "@homarr/db";
 import type { Database } from "@homarr/db";
@@ -21,6 +21,12 @@ vi.mock("../env", () => {
     env: mockEnv,
   };
 });
+
+afterEach(() => {
+  mockEnv.AUTH_OIDC_GROUPS_ATTRIBUTE = "someRandomGroupsKey";
+  mockEnv.AUTH_OIDC_GROUPS_LOCAL_MANAGEMENT = false;
+});
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 type HeadersExport = typeof import("next/headers");
 vi.mock("next/headers", async (importOriginal) => {
@@ -143,6 +149,30 @@ describe("createSignInEventHandler should create signInEventHandler", () => {
       await eventHandler?.({
         user: { id: "1", name: "test" },
         profile: { preferred_username: "test", someRandomGroupsKey: ["test"] },
+        account: null,
+      });
+
+      // Assert
+      const dbGroupMembers = await db.query.groupMembers.findFirst({
+        where: eq(groupMembers.userId, "1"),
+      });
+      expect(dbGroupMembers?.groupId).toBe("1");
+    });
+    test("should add missing group membership from a nested claim", async () => {
+      // Arrange
+      mockEnv.AUTH_OIDC_GROUPS_ATTRIBUTE = "resource_access.homarr.roles";
+      const db = createDb();
+      await createUserAsync(db);
+      await createGroupAsync(db);
+      const eventHandler = createSignInEventHandler(db);
+
+      // Act
+      await eventHandler?.({
+        user: { id: "1", name: "test" },
+        profile: {
+          preferred_username: "test",
+          resource_access: { homarr: { roles: ["test"] } },
+        },
         account: null,
       });
 


### PR DESCRIPTION
## Summary

- resolve OIDC profile claims through dot-separated paths while preserving existing top-level claim support
- use nested claims for both group synchronization and `AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE`
- document nested claim paths in the SSO and Helm configuration references

For example, `AUTH_OIDC_GROUPS_ATTRIBUTE=resource_access.homarr.roles` now resolves this profile shape:

```json
{
  "resource_access": {
    "homarr": {
      "roles": ["admins"]
    }
  }
}
```

Fixes #2657.

## Verification

- `NODE_ENV=development CI=true pnpm exec vitest run packages/auth/test/events.spec.ts packages/auth/providers/oidc/test/profile.spec.ts --coverage.enabled=false` — 18 tests passed
- `pnpm --filter @homarr/auth typecheck` — passed
- `pnpm --filter @homarr/auth lint` — passed with 0 errors (6 existing warnings in the package)
- `pnpm exec oxfmt --check` on the changed TypeScript files — passed
- `git diff --check` — passed

## Checklist

- [ ] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`) — full build not run; targeted checks are listed above
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used
- [x] Documentation is up to date in the monorepo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for nested, dot-separated OIDC claim paths when deriving the display name and synchronizing external group membership.
* **Documentation**
  * Updated Single Sign-On and Helm charts to clarify dot-separated path support for relevant `AUTH_OIDC_*` environment variables.
* **Bug Fixes**
  * Improved handling of missing, non-object, or non-string OIDC claims when computing names and groups.
* **Tests**
  * Expanded coverage for nested profile path lookups and OIDC groups synchronization from nested claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->