### PR TITLE
fix(integrations): preserve Nextcloud subpaths

### DIFF
--- a/packages/integrations/src/nextcloud/nextcloud-url.ts
+++ b/packages/integrations/src/nextcloud/nextcloud-url.ts
@@ -1,0 +1,10 @@
+export const createNextcloudCalendarServerUrl = (integrationUrl: string) => {
+  const calendarServerUrl = new URL(integrationUrl);
+  const integrationPath = calendarServerUrl.pathname.replace(/\/+$/, "");
+
+  calendarServerUrl.pathname = `${integrationPath}/remote.php/dav/`;
+  calendarServerUrl.search = "";
+  calendarServerUrl.hash = "";
+
+  return calendarServerUrl.toString();
+};

--- a/packages/integrations/src/nextcloud/nextcloud-url.ts
+++ b/packages/integrations/src/nextcloud/nextcloud-url.ts
@@ -1,8 +1,11 @@
 export const createNextcloudCalendarServerUrl = (integrationUrl: string) => {
   const calendarServerUrl = new URL(integrationUrl);
   const integrationPath = calendarServerUrl.pathname.replace(/\/+$/, "");
+  const davPath = "/remote.php/dav";
 
-  calendarServerUrl.pathname = `${integrationPath}/remote.php/dav/`;
+  calendarServerUrl.pathname = integrationPath.endsWith(davPath)
+    ? `${integrationPath}/`
+    : `${integrationPath}${davPath}/`;
   calendarServerUrl.search = "";
   calendarServerUrl.hash = "";
 

--- a/packages/integrations/src/nextcloud/nextcloud.integration.ts
+++ b/packages/integrations/src/nextcloud/nextcloud.integration.ts
@@ -21,6 +21,7 @@ import type { ICalendarIntegration } from "../interfaces/calendar/calendar-integ
 import type { CalendarEvent } from "../interfaces/calendar/calendar-types";
 import type { Notification } from "../interfaces/notifications/notification-types";
 import type { INotificationsIntegration } from "../interfaces/notifications/notifications-integration";
+import { createNextcloudCalendarServerUrl } from "./nextcloud-url";
 
 // Register all existing timezones
 if (ICAL.TimezoneService.count === 0) {
@@ -189,7 +190,7 @@ export class NextcloudIntegration extends Integration implements ICalendarIntegr
 
   private async createCalendarClientAsync(agent?: Agent) {
     return new DAVClient({
-      serverUrl: this.integration.url,
+      serverUrl: createNextcloudCalendarServerUrl(this.integration.url),
       credentials: {
         username: this.getSecretValue("username"),
         password: this.getSecretValue("password"),

--- a/packages/integrations/src/nextcloud/test/nextcloud-integration.spec.ts
+++ b/packages/integrations/src/nextcloud/test/nextcloud-integration.spec.ts
@@ -1,0 +1,38 @@
+import type { Agent } from "node:https";
+import { DAVClient } from "tsdav";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { NextcloudIntegration } from "../nextcloud.integration";
+
+vi.mock("tsdav", () => ({ DAVClient: vi.fn() }));
+
+interface NextcloudCalendarClientFactory {
+  createCalendarClientAsync(agent: Agent): Promise<unknown>;
+}
+
+describe("NextcloudIntegration", () => {
+  beforeEach(() => {
+    vi.mocked(DAVClient).mockClear();
+  });
+
+  test("uses a calendar server URL that preserves the integration subpath", async () => {
+    const integration = new NextcloudIntegration({
+      id: "integration-id",
+      name: "Nextcloud",
+      url: "https://example.com/nextcloud",
+      externalUrl: null,
+      decryptedSecrets: [
+        { kind: "username", value: "admin" },
+        { kind: "password", value: "password" },
+      ],
+    });
+
+    await (integration as unknown as NextcloudCalendarClientFactory).createCalendarClientAsync({} as Agent);
+
+    expect(DAVClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverUrl: "https://example.com/nextcloud/remote.php/dav/",
+      }),
+    );
+  });
+});

--- a/packages/integrations/src/nextcloud/test/nextcloud-url.spec.ts
+++ b/packages/integrations/src/nextcloud/test/nextcloud-url.spec.ts
@@ -20,4 +20,10 @@ describe("createNextcloudCalendarServerUrl", () => {
       "https://example.com/nextcloud/remote.php/dav/",
     );
   });
+
+  test("does not duplicate an existing DAV endpoint", () => {
+    expect(createNextcloudCalendarServerUrl("https://example.com/nextcloud/remote.php/dav")).toBe(
+      "https://example.com/nextcloud/remote.php/dav/",
+    );
+  });
 });

--- a/packages/integrations/src/nextcloud/test/nextcloud-url.spec.ts
+++ b/packages/integrations/src/nextcloud/test/nextcloud-url.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+
+import { createNextcloudCalendarServerUrl } from "../nextcloud-url";
+
+describe("createNextcloudCalendarServerUrl", () => {
+  test("uses the DAV endpoint for a root installation", () => {
+    expect(createNextcloudCalendarServerUrl("https://cloud.example.com")).toBe(
+      "https://cloud.example.com/remote.php/dav/",
+    );
+  });
+
+  test("preserves the base path for a subpath installation", () => {
+    expect(createNextcloudCalendarServerUrl("https://example.com/nextcloud")).toBe(
+      "https://example.com/nextcloud/remote.php/dav/",
+    );
+  });
+
+  test("does not duplicate a trailing slash", () => {
+    expect(createNextcloudCalendarServerUrl("https://example.com/nextcloud/")).toBe(
+      "https://example.com/nextcloud/remote.php/dav/",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- point the Nextcloud calendar client at Nextcloud's canonical `/remote.php/dav/` endpoint
- preserve the configured installation path when Nextcloud is hosted below a subpath
- keep already-complete `/remote.php/dav` integration URLs idempotent
- add regression coverage for root, subpath, trailing-slash, existing-endpoint, and DAV client configuration cases

`tsdav` performs well-known discovery from the origin and therefore drops a configured path such as `/nextcloud`. Supplying the canonical DAV endpoint as its server URL keeps that path available as a discovery fallback without changing the integration URL used by notifications or external links.

Fixes #3597.

## Verification

- `NODE_ENV=development CI=true pnpm exec vitest run packages/integrations/src/nextcloud/test/nextcloud-url.spec.ts packages/integrations/src/nextcloud/test/nextcloud-integration.spec.ts` — 5 tests passed
- `pnpm --filter @homarr/integrations typecheck` — passed
- `pnpm --filter @homarr/integrations lint` — passed with 0 errors (existing package warnings only)
- `pnpm exec oxfmt --check` on all changed files — passed
- `git diff --check` — passed

## Checklist

- [ ] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`) — full build not run; targeted checks are listed above
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used
- [x] Documentation is up to date; no configuration or user workflow changed