### PR TITLE
fix(qbittorrent): sort torrents by progress so active items appear before limit cutoff

### DIFF
--- a/packages/integrations/src/download-client/qbittorrent/qbittorrent-integration.ts
+++ b/packages/integrations/src/download-client/qbittorrent/qbittorrent-integration.ts
@@ -30,7 +30,7 @@ export class QBitTorrentIntegration extends Integration implements IDownloadClie
   public async getClientJobsAndStatusAsync(input: { limit: number }): Promise<DownloadClientJobsAndStatus> {
     const type = "torrent";
     const client = await this.getClientAsync();
-    const torrents = await client.listTorrents({ limit: input.limit });
+    const torrents = await client.listTorrents({ limit: input.limit, sort: "progress", reverse: false });
     const rates = torrents.reduce(
       ({ down, up }, { dlspeed, upspeed }) => ({ down: down + dlspeed, up: up + upspeed }),
       { down: 0, up: 0 },


### PR DESCRIPTION
## Problem

Reported on [Answer Overflow](https://www.answeroverflow.com/m/1525039765940863046): The qBittorrent widget shows no active torrents when a user has many completed torrents. Speeds, ratios stay at 0, and the list appears empty when `showCompletedTorrent` is off.

## Root Cause

The integration called `listTorrents({ limit })` without a sort parameter. The qBittorrent API returns completed torrents first by default. With a `limit=50` and 2000+ completed torrents, active/incomplete torrents were never in the response. The widget's client-side filter then had nothing to display.

## Fix

Added `sort: "progress", reverse: false` to the API call — sorts by progress ascending (0 → 1), so incomplete/active torrents always appear in the first batch regardless of how many completed torrents exist.

The `limitPerIntegration` default (50) stays the same — only the sort order changed.

## Files Changed

- `packages/integrations/src/download-client/qbittorrent/qbittorrent-integration.ts` — 1 line

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/homarr-labs/codesmith/homarr/pr/6297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786384971&installation_id=145921233&pr_number=6297&repository=homarr-labs%2Fhomarr&return_to=https%3A%2F%2Fgithub.com%2Fhomarr-labs%2Fhomarr%2Fpull%2F6297&signature=08e0ccaf230a0c24a70725e63991d50d2bbc1b3766774e875945ecfb438b8b0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Torrent jobs are now displayed in a consistent order based on download progress.
  * Progression is listed from lowest to highest, making active and incomplete downloads easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->