### PR TITLE
fix(integrations): update PatchMon API key settings link

### DIFF
--- a/packages/definitions/src/integration.ts
+++ b/packages/definitions/src/integration.ts
@@ -379,7 +379,7 @@ export const integrationDefs = {
     category: ["healthMonitoring"],
     documentationUrl: createDocumentationLink("/docs/integrations/patchmon"),
     defaultPort: 3413,
-    apiKeySettingsPath: "/settings/api-keys",
+    apiKeySettingsPath: "/settings/integrations",
   },
   tracearr: {
     name: "Tracearr",

--- a/packages/definitions/src/test/api-key-url.spec.ts
+++ b/packages/definitions/src/test/api-key-url.spec.ts
@@ -15,6 +15,12 @@ describe("getIntegrationApiKeyUrl", () => {
     );
   });
 
+  it("builds URL for patchmon", () => {
+    expect(getIntegrationApiKeyUrl("http://patchmon.local:3413", "patchmon")).toBe(
+      "http://patchmon.local:3413/settings/integrations",
+    );
+  });
+
   it("returns null for integrations without apiKeySettingsPath", () => {
     expect(getIntegrationApiKeyUrl("http://localhost", "plex")).toBeNull();
   });


### PR DESCRIPTION
Point the PatchMon “Get API key” link to /settings/integrations and add coverage for the generated URL.

Closes #6284

Documentation doesn't need updating 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated PatchMon integration links to direct users to the correct integrations settings page when managing API keys.

- **Tests**
  - Added coverage to verify that PatchMon API-key URLs are generated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->