### PR TITLE
feat(docker-widget): replace footer timestamp text with compact refresh button

### DIFF
--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -5204,7 +5204,6 @@
     "table": {
       "updated": "Updated {when}",
       "refresh": {
-        "action": "Press to refresh",
         "lastUpdated": "Last refresh {when}"
       },
       "search": "Seach {count} containers",

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -5203,6 +5203,10 @@
     "title": "Containers",
     "table": {
       "updated": "Updated {when}",
+      "refresh": {
+        "action": "Press to refresh",
+        "lastUpdated": "Last refresh {when}"
+      },
       "search": "Seach {count} containers",
       "selected": "{selectCount} of {totalCount} containers selected",
       "footer": "Total {count} containers",

--- a/packages/widgets/src/docker/component.tsx
+++ b/packages/widgets/src/docker/component.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import { ActionIcon, Avatar, Badge, Center, Group, Stack, Text, Tooltip } from "@mantine/core";
 import type { IconProps } from "@tabler/icons-react";
-import { IconBrandDocker, IconPlayerPlay, IconPlayerStop, IconRotateClockwise } from "@tabler/icons-react";
+import { IconBrandDocker, IconPlayerPlay, IconPlayerStop, IconRefresh, IconRotateClockwise } from "@tabler/icons-react";
 import type { MRT_ColumnDef, MRT_VisibilityState } from "mantine-react-table";
 import { MantineReactTable } from "mantine-react-table";
 
@@ -184,7 +184,11 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
   const t = useScopedI18n("docker");
   const isTiny = width <= 256;
 
-  const { data } = clientApi.docker.getContainers.useQuery(undefined, {
+  const {
+    data,
+    refetch,
+    isFetching,
+  } = clientApi.docker.getContainers.useQuery(undefined, {
     refetchInterval: 30_000,
   });
   const containers = data?.containers ?? [];
@@ -300,9 +304,31 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
               {t("table.totalMemory", { memory: humanFileSize(totals.memory) })}
             </Text>
 
-            <Text size="sm" style={{ whiteSpace: "nowrap" }}>
-              {t("table.updated", { when: relativeTime })}
-            </Text>
+            <Tooltip
+              multiline
+              withArrow
+              label={
+                <Stack gap={0} py={2}>
+                  <Text size="xs" fw={600}>
+                    {t("table.refresh.action")}
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    {t("table.refresh.lastUpdated", { when: relativeTime })}
+                  </Text>
+                </Stack>
+              }
+            >
+              <ActionIcon
+                size="sm"
+                variant="transparent"
+                c="var(--mantine-color-text)"
+                loading={isFetching}
+                onClick={() => void refetch()}
+                aria-label={`${t("table.refresh.action")} - ${t("table.refresh.lastUpdated", { when: relativeTime })}`}
+              >
+                <IconRefresh style={actionIconIconStyle} />
+              </ActionIcon>
+            </Tooltip>
           </Group>
         </Group>
       )}

--- a/packages/widgets/src/docker/component.tsx
+++ b/packages/widgets/src/docker/component.tsx
@@ -305,18 +305,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
             </Text>
 
             <Tooltip
-              multiline
-              withArrow
-              label={
-                <Stack gap={0} py={2}>
-                  <Text size="xs" fw={600}>
-                    {t("table.refresh.action")}
-                  </Text>
-                  <Text size="xs" c="dimmed">
-                    {t("table.refresh.lastUpdated", { when: relativeTime })}
-                  </Text>
-                </Stack>
-              }
+              label={t("table.refresh.lastUpdated", { when: relativeTime })}
             >
               <ActionIcon
                 size="sm"
@@ -324,7 +313,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
                 c="var(--mantine-color-text)"
                 loading={isFetching}
                 onClick={() => void refetch()}
-                aria-label={`${t("table.refresh.action")} - ${t("table.refresh.lastUpdated", { when: relativeTime })}`}
+                aria-label={t("table.refresh.lastUpdated", { when: relativeTime })}
               >
                 <IconRefresh style={actionIconIconStyle} />
               </ActionIcon>

--- a/packages/widgets/src/docker/index.ts
+++ b/packages/widgets/src/docker/index.ts
@@ -25,6 +25,7 @@ const columnTranslationKeyMap = {
 
 export const { definition, componentLoader } = createWidgetDefinition("dockerContainers", {
   icon: IconBrandDocker,
+  queryKey: [["docker", "getContainers"]],
   createOptions() {
     return optionsBuilder.from((factory) => ({
       columns: factory.multiSelect({


### PR DESCRIPTION
Replaces the always-visible "Updated a few seconds ago" text in the Docker widget's footer with a compact icon-only refresh button. The previous text took up too much horizontal space in the footer, competing with the CPU/Memory totals — especially on narrower widget widths.

<img width="600" alt="Screenshot 2026-07-12 143405" src="https://github.com/user-attachments/assets/149c4e84-bcf3-4594-adf0-82c8643b622b" />
<img width="600" alt="Screenshot 2026-07-12 145532" src="https://github.com/user-attachments/assets/150e8b51-260e-4a1a-9dfc-1e5aa4a07b87" />
<img width="600" alt="Screenshot 2026-07-12 145547" src="https://github.com/user-attachments/assets/4ce69b6f-2903-4113-a7b0-f319a654b697" />

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [ x Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual refresh action to the Docker Containers widget.
  * Displayed “Last refresh {when}” using a relative time label with a tooltip.
  * Added a loading/spinner indicator on the refresh button while container data is updating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->