### PR TITLE
feat(media-requests): filter requests list by status and time window

### DIFF
--- a/apps/docs/docs/widgets/media-request-list/index.mdx
+++ b/apps/docs/docs/widgets/media-request-list/index.mdx
@@ -1,41 +1,44 @@
 ---
-title: 'Media Request List'
-description: 'See a list of all media requests from your integration'
+title: "Media Request List"
+description: "See a list of all media requests from your integration"
 hide_title: true
 ---
 
-import { WidgetHeader } from '@site/src/components/widgets/header';
-import { AddingWidget } from '@site/src/components/widgets/adding';
-import { WidgetConfig } from '@site/src/components/widgets/configuration';
-import { WidgetIntegrations } from '@site/src/components/widgets/integrations';
+import { WidgetHeader } from "@site/src/components/widgets/header";
+import { AddingWidget } from "@site/src/components/widgets/adding";
+import { WidgetConfig } from "@site/src/components/widgets/configuration";
+import { WidgetIntegrations } from "@site/src/components/widgets/integrations";
 import { IconAd } from "@tabler/icons-react";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import { mediaRequestListWidget } from '.';
-import { jellyseerrIntegration } from '@site/docs/integrations/jellyseerr';
-import { overseerrIntegration } from '@site/docs/integrations/overseerr';
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import { mediaRequestListWidget } from ".";
+import { jellyseerrIntegration } from "@site/docs/integrations/jellyseerr";
+import { overseerrIntegration } from "@site/docs/integrations/overseerr";
 
-
-<WidgetHeader
-  widget={mediaRequestListWidget}
-  categories={['Media requests']}
-/>
+<WidgetHeader widget={mediaRequestListWidget} categories={["Media requests"]} />
 
 Provides a list of all open and recently closed requests. It also provides the functionality to approve or reject requests.
 
+You can limit the list to specific request statuses (for example, only show `pending` and `processing`) and restrict it to requests created within a configurable time window (for example, the last 2 weeks).
+
 ### Screenshots
 
-import mediaRequestList from './img/list.png';
+import mediaRequestList from "./img/list.png";
 
 <img src={mediaRequestList} alt="media-request-list" width={256} height={256} />
 
 ### Supported Integrations
 
-<WidgetIntegrations items={[{
-  integration: jellyseerrIntegration,
-}, {
-  integration: overseerrIntegration,
-}]} />
+<WidgetIntegrations
+  items={[
+    {
+      integration: jellyseerrIntegration,
+    },
+    {
+      integration: overseerrIntegration,
+    },
+  ]}
+/>
 
 ### Interactions
 
@@ -47,4 +50,5 @@ import mediaRequestList from './img/list.png';
 <AddingWidget />
 
 ### Configuration
+
 <WidgetConfig configuration={mediaRequestListWidget.configuration} />

--- a/apps/docs/docs/widgets/media-request-list/index.ts
+++ b/apps/docs/docs/widgets/media-request-list/index.ts
@@ -14,6 +14,26 @@ export const mediaRequestListWidget: WidgetDefinition = {
         values: { type: "boolean" },
         defaultValue: "yes",
       },
+      {
+        name: "Statuses to show",
+        description:
+          "Only requests with these statuses will be shown. Defaults to all statuses ('pending', 'approved', 'declined', 'failed', 'completed').",
+        values: "List of: 'pending', 'approved', 'declined', 'failed', 'completed'",
+        defaultValue: "All statuses",
+      },
+      {
+        name: "Show only recent requests",
+        description:
+          "Limit to requests created within this amount of time. Set to 0 to disable the time filter and show all requests.",
+        values: "0-365 (combined with the time unit below)",
+        defaultValue: "0",
+      },
+      {
+        name: "Time unit",
+        description: "Unit used by the time filter (days or weeks).",
+        values: "'days' or 'weeks'",
+        defaultValue: "days",
+      },
     ],
   },
 };

--- a/packages/api/src/router/widgets/media-requests.ts
+++ b/packages/api/src/router/widgets/media-requests.ts
@@ -3,7 +3,10 @@ import { z } from "zod/v4";
 import { getIntegrationKindsByCategory } from "@homarr/definitions";
 import { createIntegrationAsync } from "@homarr/integrations";
 import { mediaRequestStatusConfiguration } from "@homarr/integrations/types";
-import { mediaRequestListRequestHandler } from "@homarr/request-handler/media-request-list";
+import {
+  mediaRequestListInputSchema,
+  mediaRequestListRequestHandler,
+} from "@homarr/request-handler/media-request-list";
 import { mediaRequestStatsRequestHandler } from "@homarr/request-handler/media-request-stats";
 
 import { createManyIntegrationMiddleware, createOneIntegrationMiddleware } from "../../middlewares/integration";
@@ -16,13 +19,14 @@ export const mediaRequestsRouter = createTRPCRouter({
       mcp: {
         enabled: true,
         description:
-          "Get latest media requests from Overseerr/Jellyseerr with their status (pending, approved, declined, available). REQUIRED: integrationIds (array of Overseerr/Jellyseerr integration IDs from integration_all)",
+          "Get latest media requests from Overseerr/Jellyseerr with their status (pending, approved, declined, available). REQUIRED: integrationIds (array of Overseerr/Jellyseerr integration IDs from integration_all). OPTIONAL: statuses (array of statuses to include) and recentDays (number, 0 disables the time filter).",
       },
     })
     .concat(createManyIntegrationMiddleware("query", ...getIntegrationKindsByCategory("mediaRequest")))
-    .query(async ({ ctx }) => {
+    .input(mediaRequestListInputSchema)
+    .query(async ({ ctx, input }) => {
       const results = await settleIntegrationQueries(ctx.integrations, async (integration) => {
-        const { data } = await mediaRequestListRequestHandler.handler(integration, {}).getDataAsync();
+        const { data } = await mediaRequestListRequestHandler.handler(integration, input).getDataAsync();
         return { integration: { id: integration.id, name: integration.name, kind: integration.kind }, data };
       });
       return results

--- a/packages/old-import/src/widgets/options.ts
+++ b/packages/old-import/src/widgets/options.ts
@@ -23,6 +23,9 @@ type OptionMapping = {
 const optionMapping: OptionMapping = {
   "mediaRequests-requestList": {
     linksTargetNewTab: (oldOptions) => oldOptions.openInNewTab,
+    statusFilter: () => undefined,
+    recentDays: () => undefined,
+    recentUnit: () => undefined,
   },
   "mediaRequests-requestStats": {},
   bookmarks: {

--- a/packages/request-handler/src/media-request-list.ts
+++ b/packages/request-handler/src/media-request-list.ts
@@ -1,16 +1,42 @@
+import { z } from "zod/v4";
+
 import type { IntegrationKindByCategory } from "@homarr/definitions";
 import { createIntegrationAsync } from "@homarr/integrations";
-import type { MediaRequest } from "@homarr/integrations/types";
+import type { MediaRequest, MediaRequestStatus } from "@homarr/integrations/types";
 
 import { createIntegrationRequestHandler } from "./lib/integration-request-handler";
+
+const mediaRequestStatusValues = [
+  "pending",
+  "approved",
+  "declined",
+  "failed",
+  "completed",
+] as const satisfies readonly MediaRequestStatus[];
+
+export const mediaRequestListInputSchema = z.object({
+  statuses: z.array(z.enum(mediaRequestStatusValues)).nonempty(),
+  recentDays: z.number().min(0).max(365),
+});
+
+export type MediaRequestListInput = z.infer<typeof mediaRequestListInputSchema>;
+
+const daysToMs = (days: number) => days * 24 * 60 * 60 * 1000;
 
 export const mediaRequestListRequestHandler = createIntegrationRequestHandler<
   MediaRequest[],
   IntegrationKindByCategory<"mediaRequest">,
-  Record<string, never>
+  MediaRequestListInput
 >({
-  async requestAsync(integration, _input) {
+  async requestAsync(integration, input) {
     const integrationInstance = await createIntegrationAsync(integration);
-    return await integrationInstance.getRequestsAsync();
+    const requests = await integrationInstance.getRequestsAsync();
+    const cutoff = input.recentDays > 0 ? Date.now() - daysToMs(input.recentDays) : null;
+    const statusSet = new Set<MediaRequestStatus>(input.statuses);
+    return requests.filter((request) => {
+      if (!statusSet.has(request.status)) return false;
+      if (cutoff !== null && request.createdAt.getTime() < cutoff) return false;
+      return true;
+    });
   },
 });

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -3195,6 +3195,21 @@
       "option": {
         "linksTargetNewTab": {
           "label": "Open links in new tab"
+        },
+        "statusFilter": {
+          "label": "Statuses to show",
+          "description": "Only requests with these statuses will be shown"
+        },
+        "recentDays": {
+          "label": "Show only recent requests",
+          "description": "Limit to requests created within this amount of time. Set to 0 to disable the time filter"
+        },
+        "recentUnit": {
+          "label": "Time unit",
+          "options": {
+            "days": "Days",
+            "weeks": "Weeks"
+          }
         }
       },
       "pending": {

--- a/packages/widgets/src/docker/component.tsx
+++ b/packages/widgets/src/docker/component.tsx
@@ -184,11 +184,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
   const t = useScopedI18n("docker");
   const isTiny = width <= 256;
 
-  const {
-    data,
-    refetch,
-    isFetching,
-  } = clientApi.docker.getContainers.useQuery(undefined, {
+  const { data, refetch, isFetching } = clientApi.docker.getContainers.useQuery(undefined, {
     refetchInterval: 30_000,
   });
   const containers = data?.containers ?? [];
@@ -304,9 +300,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
               {t("table.totalMemory", { memory: formatBytes(totals.memory) })}
             </Text>
 
-            <Tooltip
-              label={t("table.refresh.lastUpdated", { when: relativeTime })}
-            >
+            <Tooltip label={t("table.refresh.lastUpdated", { when: relativeTime })}>
               <ActionIcon
                 size="sm"
                 variant="transparent"

--- a/packages/widgets/src/media-requests/list/component.tsx
+++ b/packages/widgets/src/media-requests/list/component.tsx
@@ -38,6 +38,11 @@ export default function MediaServerWidget({
 }: WidgetComponentProps<"mediaRequests-requestList">) {
   const { data: mediaRequests } = clientApi.widget.mediaRequests.getLatestRequests.useQuery({
     integrationIds,
+    statuses:
+      options.statusFilter.length > 0
+        ? options.statusFilter
+        : ["pending", "approved", "declined", "failed", "completed"],
+    recentDays: options.recentDays > 0 ? options.recentDays * (options.recentUnit === "weeks" ? 7 : 1) : 0,
   });
 
   if (!mediaRequests) return <WidgetEmptyState />;

--- a/packages/widgets/src/media-requests/list/index.ts
+++ b/packages/widgets/src/media-requests/list/index.ts
@@ -1,4 +1,5 @@
 import { IconSearch, IconZoomQuestion } from "@tabler/icons-react";
+import { z } from "zod/v4";
 
 import { getIntegrationKindsByCategory } from "@homarr/definitions";
 import { openMediaRequestSearch } from "@homarr/spotlight";
@@ -6,12 +7,33 @@ import { openMediaRequestSearch } from "@homarr/spotlight";
 import { createWidgetDefinition } from "../../definition";
 import { optionsBuilder } from "../../options";
 
+const mediaRequestStatusValues = ["pending", "approved", "declined", "failed", "completed"] as const;
+const recentUnitValues = ["days", "weeks"] as const;
+
 export const { componentLoader, definition } = createWidgetDefinition("mediaRequests-requestList", {
   icon: IconZoomQuestion,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       linksTargetNewTab: factory.switch({
         defaultValue: true,
+      }),
+      statusFilter: factory.multiSelect({
+        defaultValue: [...mediaRequestStatusValues],
+        options: mediaRequestStatusValues.map((value) => ({
+          value,
+          label: (t) => t(`widget.mediaRequests-requestList.status.${value}`),
+        })),
+      }),
+      recentDays: factory.number({
+        validate: z.number().min(0).max(365),
+        defaultValue: 0,
+      }),
+      recentUnit: factory.select({
+        defaultValue: "days",
+        options: recentUnitValues.map((value) => ({
+          value,
+          label: (t) => t(`widget.mediaRequests-requestList.option.recentUnit.options.${value}`),
+        })),
       }),
     }));
   },


### PR DESCRIPTION
## Description

Closes #4561

Adds three new options to the **Media Requests List** widget so users can narrow the Overseerr/Jellyseerr requests list to specific request statuses and a configurable recent time window.

### New widget options

| Option | Type | Default | Description |
| --- | --- | --- | --- |
| `statusFilter` | multi-select | all 5 statuses | Only requests with these statuses are shown |
| `recentDays` | number (0-365) | `0` | Time-window length. `0` disables the filter |
| `recentUnit` | select (`days` / `weeks`) | `days` | Unit used by `recentDays` |

### Behavior

- The new options default to the previous behavior (all statuses, no time filter) so existing widgets keep working without reconfiguration.
- Filtering is applied server-side in the request handler / tRPC `getLatestRequests` procedure.
- The status list reuses the existing five homarr request statuses (`pending`, `approved`, `declined`, `failed`, `completed`).

## Changes

- `packages/widgets/src/media-requests/list/index.ts` — new widget options
- `packages/widgets/src/media-requests/list/component.tsx` — pass new options to the tRPC query
- `packages/request-handler/src/media-request-list.ts` — input schema + server-side filter
- `packages/api/src/router/widgets/media-requests.ts` — accept input on `getLatestRequests`
- `packages/old-import/src/widgets/options.ts` — migration mapping (`undefined` for new options)
- `packages/translation/src/lang/en.json` — translation keys for the new options
- `apps/docs/docs/widgets/media-request-list/{index.mdx,index.ts}` — docs

## Verification

- `pnpm turbo typecheck` — passes for the 6 affected packages
- `pnpm lint` — 0 errors
- `pnpm oxfmt --check` — all touched files formatted