### PR TITLE
docs(integrations): define the CPU utilization convention (total-system %, 0-100)

### DIFF
--- a/packages/integrations/src/dashdot/dashdot-integration.ts
+++ b/packages/integrations/src/dashdot/dashdot-integration.ts
@@ -39,7 +39,7 @@ export class DashDotIntegration extends Integration implements ISystemHealthMoni
     const history = await channel.getSliceUntilTimeAsync(dayjs().subtract(15, "minutes").toDate());
 
     return {
-      cpuUtilization: cpuLoad.sumLoad,
+      cpuUtilization: cpuLoad.averageLoad,
       memUsedInBytes: memoryLoad.loadInBytes,
       memAvailableInBytes: info.maxAvailableMemoryBytes - memoryLoad.loadInBytes,
       network: networkLoad,
@@ -97,7 +97,7 @@ export class DashDotIntegration extends Integration implements ISystemHealthMoni
     // we convert it to text as the response is either valid json or empty if cpu widget is disabled.
     if (result.length === 0) {
       return {
-        sumLoad: 0,
+        averageLoad: 0,
         averageTemperature: 0,
       };
     }
@@ -105,7 +105,7 @@ export class DashDotIntegration extends Integration implements ISystemHealthMoni
     const data = await cpuLoadPerCoreApiList.parseAsync(JSON.parse(result));
     await channel.pushAsync(data);
     return {
-      sumLoad: this.getAverageOfCpu(data),
+      averageLoad: this.getAverageOfCpu(data),
       averageTemperature: data.reduce((acc, current) => acc + current.temp, 0) / data.length,
     };
   }

--- a/packages/integrations/src/interfaces/health-monitoring/health-monitoring-types.ts
+++ b/packages/integrations/src/interfaces/health-monitoring/health-monitoring-types.ts
@@ -3,6 +3,14 @@ import type { LxcResource, NodeResource, QemuResource, StorageResource } from ".
 export interface SystemHealthMonitoring {
   version: string;
   cpuModelName: string;
+  /**
+   * CPU usage as a share of the WHOLE machine, in percent (0-100).
+   *
+   * This is the homarr-wide convention for every CPU reading: a machine with
+   * 3 of 4 cores fully busy reports 75, never 300. Integrations must convert
+   * per-core readings (sums, or docker-stats style values that can exceed
+   * 100) into the total-system share before returning them here.
+   */
   cpuUtilization: number;
   memUsedInBytes: number;
   memAvailableInBytes: number;

--- a/packages/widgets/src/health-monitoring/rings/cpu-ring.tsx
+++ b/packages/widgets/src/health-monitoring/rings/cpu-ring.tsx
@@ -21,7 +21,9 @@ export const CpuRing = ({ cpuUtilization, isTiny }: { cpuUtilization: number; is
       }
       sections={[
         {
-          value: Number(cpuUtilization.toFixed(2)),
+          // cpuUtilization is a total-system share (0-100) by convention; the
+          // clamp only guards the ring geometry against misreporting sources.
+          value: Math.min(100, Number(cpuUtilization.toFixed(2))),
           color: progressColor(Number(cpuUtilization.toFixed(2))),
         },
       ]}


### PR DESCRIPTION
Follow-up to the discussion in #6250, where @ajnart suggested defining how CPU usage should be shown across the whole of homarr.

This PR writes that convention down and aligns the code with it:

**The convention:** `cpuUtilization` is the share of the WHOLE machine, in percent (0-100). A machine with 3 of 4 cores fully busy reports 75, never 300. Readings like `134%` (docker-stats per-core style) are not allowed to reach widgets.

**Changes:**

- Documented the convention as JSDoc on `SystemHealthMonitoring.cpuUtilization`, so every current and future integration author sees it right at the source of truth.
- Audited all integrations that report `cpuUtilization` today: glances (`cpu.total`), truenas (per-core average), synology, openmediavault and unraid (after #6250) already follow the convention. dashdot also does, but its internal field was misleadingly named `sumLoad` while actually holding the per-core *average* - renamed to `averageLoad` so nobody "fixes" it into a real sum later.
- Clamped the health-monitoring CPU ring geometry at 100 as a defensive guard against misreporting sources (the text label keeps showing the raw value, so a genuinely broken source stays visible).
- Container CPU on the Docker side is aligned to the same convention in #6250.

No behavioural change for any integration that already followed the convention.
