### PR TITLE
fix(docker): remove --offline flag from pnpm install step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,9 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
 
 COPY . .
 # Follow the pnpm fetch pattern from https://pnpm.io/cli/fetch
-# --offline enforces no registry access (all packages are in the store from fetch)
 # --frozen-lockfile is omitted as recommended by the pnpm fetch docs
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
-    pnpm install --recursive --offline
+    pnpm install --recursive
 
 ARG SKIP_ENV_VALIDATION='true'
 ARG CI='true'


### PR DESCRIPTION
## Problem

CI started failing with `ERR_PNPM_NO_OFFLINE_META` since #6328:

```
[ERR_PNPM_NO_OFFLINE_META] Failed to resolve next@16.2.10 in package mirror /root/.cache/pnpm/v11/metadata/registry.npmjs.org/next.jsonl
```

The `--offline` flag requires package metadata to be in the local pnpm metadata cache (`~/.cache/pnpm`), which is separate from the store mount (`/pnpm/store`). Newly introduced packages won't have their metadata cached there, causing resolution failures.

## Fix

Drop `--offline`. pnpm still uses the cached store for package content, and can fall back to the registry only for any metadata it can't resolve locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker builds by allowing package installation to access the registry when required, reducing failures caused by unavailable cached packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->