### PR TITLE
fix(nextjs): suppress Turbopack node:crypto export-star warning

### DIFF
--- a/apps/nextjs/next.config.ts
+++ b/apps/nextjs/next.config.ts
@@ -42,6 +42,13 @@ const nextConfig: NextConfig = {
         path: "**/*",
         title: "Encountered unexpected file in NFT list",
       },
+      {
+        // node:crypto is CJS; `export *` from it triggers a Turbopack warning
+        // that exits 1 in Next.js 16. Named imports in image-proxy are fine at
+        // runtime — suppress until upstream resolves the ESM/CJS detection.
+        path: "**/*",
+        title: "unexpected export *",
+      },
     ],
   },
   transpilePackages: ["@homarr/ui", "@homarr/notifications", "@homarr/modals", "@homarr/spotlight", "@homarr/widgets"],


### PR DESCRIPTION
## Problem

Next.js 16 exits with code 1 when Turbopack encounters any unhandled warning, even after a successful compile. The build was failing with:

```
✓ Compiled successfully in 99s
  Skipping validation of types
[ELIFECYCLE] Command failed with exit code 1.
```

The cause is the Turbopack warning from the `image-proxy` → `node:crypto` chain:
```
[externals]/node:crypto
unexpected export *
export * used with module [externals]/node:crypto [external] (node:crypto, cjs)
```

`node:crypto` is a CJS module and Turbopack can't statically analyze its re-exports. The named imports (`createHmac`, `hkdfSync`) work fine at runtime — this is purely a static analysis limitation.

## Fix

Add the warning to the existing `turbopack.ignoreIssue` list in `next.config.ts` (same approach already used for the NFT list warning).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a build-time issue that could cause Turbopack to fail when processing certain wildcard exports.
  * Improved compatibility with CommonJS-based cryptography modules during development and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->