### PR TITLE
fix(releases): add required octokit throttling rate limit handlers

### DIFF
--- a/packages/api/src/router/widgets/releases.ts
+++ b/packages/api/src/router/widgets/releases.ts
@@ -3,6 +3,7 @@ import { escapeForRegEx } from "@tiptap/react";
 import { z } from "zod/v4";
 
 import { decryptSecret } from "@homarr/common/server";
+import { createLogger } from "@homarr/core/infrastructure/logs";
 import { eq } from "@homarr/db";
 import { boards, items, widgetSecrets } from "@homarr/db/schema";
 import { releaseProviderKinds } from "@homarr/definitions";
@@ -10,6 +11,8 @@ import { releasesRequestHandler } from "@homarr/request-handler/releases";
 
 import { createTRPCRouter, publicProcedure } from "../../trpc";
 import { throwIfActionForbiddenAsync } from "../board/board-access";
+
+const logger = createLogger({ module: "releasesRouter" });
 
 const formatVersionFilterRegex = (versionFilter: z.infer<typeof releaseVersionFilterSchema> | undefined) => {
   if (!versionFilter) return undefined;
@@ -71,13 +74,13 @@ export const releasesRouter = createTRPCRouter({
             for (const secret of secrets) {
               try {
                 tokensByProvider.set(secret.kind, decryptSecret(secret.value));
-              } catch {
-                // Skip corrupt secrets
+              } catch (error) {
+                logger.warn("Failed to decrypt widget secret", { itemId: input.itemId, kind: secret.kind, error });
               }
             }
           }
-        } catch {
-          // Access denied or table not yet migrated -- proceed without tokens
+        } catch (error) {
+          logger.warn("Failed to load release widget tokens", { itemId: input.itemId, error });
         }
       }
 

--- a/packages/request-handler/src/release-providers.ts
+++ b/packages/request-handler/src/release-providers.ts
@@ -134,7 +134,21 @@ const getGithubApi = (baseUrl: string, userAgent: string, token?: string) =>
     baseUrl,
     auth: token,
     request: { fetch: fetchWithTrustedCertificatesAsync },
-    throttle: { enabled: true },
+    throttle: {
+      enabled: true,
+      onRateLimit: (retryAfter: number, options: { url?: string; method?: string }) => {
+        logger.warn(`GitHub rate limit exceeded, retrying after ${retryAfter}s`, {
+          url: options.url,
+          method: options.method,
+        });
+      },
+      onSecondaryRateLimit: (retryAfter: number, options: { url?: string; method?: string }) => {
+        logger.warn(`GitHub secondary rate limit exceeded, retrying after ${retryAfter}s`, {
+          url: options.url,
+          method: options.method,
+        });
+      },
+    },
     userAgent,
   });
 

--- a/packages/request-handler/src/release-providers.ts
+++ b/packages/request-handler/src/release-providers.ts
@@ -136,17 +136,19 @@ const getGithubApi = (baseUrl: string, userAgent: string, token?: string) =>
     request: { fetch: fetchWithTrustedCertificatesAsync },
     throttle: {
       enabled: true,
-      onRateLimit: (retryAfter: number, options: { url?: string; method?: string }) => {
-        logger.warn(`GitHub rate limit exceeded, retrying after ${retryAfter}s`, {
+      onRateLimit: (retryAfter: number, options: { url?: string; method?: string }, _octokit: unknown, retryCount: number) => {
+        logger.warn(`GitHub rate limit exceeded, retrying after ${retryAfter}s (attempt ${retryCount + 1})`, {
           url: options.url,
           method: options.method,
         });
+        return retryCount < 1;
       },
-      onSecondaryRateLimit: (retryAfter: number, options: { url?: string; method?: string }) => {
-        logger.warn(`GitHub secondary rate limit exceeded, retrying after ${retryAfter}s`, {
+      onSecondaryRateLimit: (retryAfter: number, options: { url?: string; method?: string }, _octokit: unknown, retryCount: number) => {
+        logger.warn(`GitHub secondary rate limit exceeded, retrying after ${retryAfter}s (attempt ${retryCount + 1})`, {
           url: options.url,
           method: options.method,
         });
+        return retryCount < 1;
       },
     },
     userAgent,

--- a/packages/request-handler/src/release-providers.ts
+++ b/packages/request-handler/src/release-providers.ts
@@ -136,14 +136,24 @@ const getGithubApi = (baseUrl: string, userAgent: string, token?: string) =>
     request: { fetch: fetchWithTrustedCertificatesAsync },
     throttle: {
       enabled: true,
-      onRateLimit: (retryAfter: number, options: { url?: string; method?: string }, _octokit: unknown, retryCount: number) => {
+      onRateLimit: (
+        retryAfter: number,
+        options: { url?: string; method?: string },
+        _octokit: unknown,
+        retryCount: number,
+      ) => {
         logger.warn(`GitHub rate limit exceeded, retrying after ${retryAfter}s (attempt ${retryCount + 1})`, {
           url: options.url,
           method: options.method,
         });
         return retryCount < 1;
       },
-      onSecondaryRateLimit: (retryAfter: number, options: { url?: string; method?: string }, _octokit: unknown, retryCount: number) => {
+      onSecondaryRateLimit: (
+        retryAfter: number,
+        options: { url?: string; method?: string },
+        _octokit: unknown,
+        retryCount: number,
+      ) => {
         logger.warn(`GitHub secondary rate limit exceeded, retrying after ${retryAfter}s (attempt ${retryCount + 1})`, {
           url: options.url,
           method: options.method,


### PR DESCRIPTION
## Summary

Fixes #6309

The releases widget was crashing because Octokit's throttling plugin was enabled with  but without the required  and  handlers. The plugin throws an error at initialization when these handlers are missing.

## Changes

- Added  and  handlers to the Octokit instance in 
- Both handlers log a warning with the retry delay and request details, allowing the throttling plugin to automatically retry after rate limits

## Root Cause

In , the GitHub API client was created with:


The  plugin requires  and  callback handlers when throttling is enabled. Without them, it throws:


This affected the releases widget whenever it tried to fetch GitHub or DockerHub release data.

## Testing

- ✅ Typecheck passes ()
- ✅ Lint passes ()

## Impact

Medium — releases widget was completely broken for all users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer warnings when GitHub API primary and secondary rate limits are reached, including retry timing and (when available) request URL/method context.
  * Improved retry handling behavior when secondary rate limits occur.
  * Release widget issues such as secret decryption failures and token-loading problems now emit warnings instead of failing silently.
* **Documentation**
  * (No user-facing documentation updates.)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->