### PR TITLE
fix(ci): remove persist-credentials: false to fix git-auto-commit-action push

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
-          persist-credentials: false
 
       - name: Setup
         uses: ./tooling/github/setup


### PR DESCRIPTION
The autofix workflow was failing because `persist-credentials: false` on the checkout step stripped the `GITHUB_TOKEN`, so `stefanzweifel/git-auto-commit-action@v7` couldn't authenticate to push the lint/format commit.

Error: `fatal: could not read Username for 'https://github.com': No such device or address`

Removing `persist-credentials: false` restores the default behavior (the token is persisted), which is what the original version of this workflow had.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code formatting and lint-fix workflow behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->