### PR TITLE
fix(integrations): resolve intermittent Seerr/Overseerr crashes and add query status to context menu

### DIFF
--- a/apps/nextjs/src/components/board/items/widget-context-menu.tsx
+++ b/apps/nextjs/src/components/board/items/widget-context-menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { MutableRefObject, ReactNode } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { Group, Loader, Menu, Switch, Text, Tooltip } from "@mantine/core";
 import {
   IconAlertTriangle,
@@ -19,6 +19,7 @@ import { clientApi } from "@homarr/api/client";
 import { useSession } from "@homarr/auth/client";
 import { useRequiredBoard } from "@homarr/boards/context";
 import { useEditMode } from "@homarr/boards/edit-mode";
+import { useTimeAgo } from "@homarr/common";
 import { useConfirmModal, useModalAction } from "@homarr/modals";
 import { useSettings } from "@homarr/settings";
 import { translateIfNecessary } from "@homarr/translation";
@@ -293,13 +294,10 @@ interface WidgetQueryStatusProps {
 }
 
 const WidgetQueryStatus = ({ queryClient, queryKey, isFetching, t }: WidgetQueryStatusProps) => {
-  const [, setTick] = useState(0);
-  useEffect(() => {
-    const id = setInterval(() => setTick((n) => n + 1), 1000);
-    return () => clearInterval(id);
-  }, []);
-
   const queries = queryClient.getQueryCache().findAll({ queryKey });
+  const timestamps = queries.map((query) => query.state.dataUpdatedAt).filter(Boolean);
+  const latest = timestamps.length > 0 ? Math.max(...timestamps) : 0;
+  const ageLabel = useTimeAgo(new Date(latest));
 
   if (isFetching) {
     return (
@@ -321,10 +319,6 @@ const WidgetQueryStatus = ({ queryClient, queryKey, isFetching, t }: WidgetQuery
   }
 
   const hasError = queries.some((q) => q.state.status === "error");
-  const timestamps = queries.map((q) => q.state.dataUpdatedAt).filter(Boolean);
-  const latest = timestamps.length > 0 ? Math.max(...timestamps) : 0;
-  const seconds = Math.floor((Date.now() - latest) / 1000);
-  const ageLabel = seconds < 5 ? "just now" : seconds < 60 ? `${seconds}s ago` : `${Math.floor(seconds / 60)}m ago`;
 
   if (hasError) {
     const errorQuery = queries.find((q) => q.state.status === "error");

--- a/apps/nextjs/src/components/board/items/widget-context-menu.tsx
+++ b/apps/nextjs/src/components/board/items/widget-context-menu.tsx
@@ -3,7 +3,15 @@
 import type { MutableRefObject, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Group, Loader, Menu, Switch, Text, Tooltip } from "@mantine/core";
-import { IconAlertTriangle, IconCircleCheck, IconCopy, IconLayoutKanban, IconRefresh, IconSettings, IconTrash } from "@tabler/icons-react";
+import {
+  IconAlertTriangle,
+  IconCircleCheck,
+  IconCopy,
+  IconLayoutKanban,
+  IconRefresh,
+  IconSettings,
+  IconTrash,
+} from "@tabler/icons-react";
 import type { QueryClient, QueryKey } from "@tanstack/react-query";
 import { useIsFetching, useQueryClient } from "@tanstack/react-query";
 
@@ -235,7 +243,12 @@ export const WidgetContextMenu = ({ item, widgetStateRef, children }: WidgetCont
           >
             <Group justify="space-between" wrap="nowrap" gap="sm">
               {tMenu("refresh")}
-              <WidgetQueryStatus queryClient={queryClient} queryKey={widgetQueryKey} isFetching={isWidgetFetching} t={t} />
+              <WidgetQueryStatus
+                queryClient={queryClient}
+                queryKey={widgetQueryKey}
+                isFetching={isWidgetFetching}
+                t={t}
+              />
             </Group>
           </Menu.Item>
           <Menu.Item
@@ -300,7 +313,11 @@ const WidgetQueryStatus = ({ queryClient, queryKey, isFetching, t }: WidgetQuery
   }
 
   if (queries.length === 0) {
-    return <Text size="xs" c="dimmed">{t("item.menu.status.idle")}</Text>;
+    return (
+      <Text size="xs" c="dimmed">
+        {t("item.menu.status.idle")}
+      </Text>
+    );
   }
 
   const hasError = queries.some((q) => q.state.status === "error");
@@ -311,9 +328,10 @@ const WidgetQueryStatus = ({ queryClient, queryKey, isFetching, t }: WidgetQuery
 
   if (hasError) {
     const errorQuery = queries.find((q) => q.state.status === "error");
-    const errorMessage = errorQuery?.state.error instanceof Error
-      ? errorQuery.state.error.message
-      : String(errorQuery?.state.error ?? "Unknown error");
+    const errorMessage =
+      errorQuery?.state.error instanceof Error
+        ? errorQuery.state.error.message
+        : String(errorQuery?.state.error ?? "Unknown error");
 
     return (
       <Tooltip label={errorMessage} multiline position="left" w={250}>

--- a/apps/nextjs/src/components/board/items/widget-context-menu.tsx
+++ b/apps/nextjs/src/components/board/items/widget-context-menu.tsx
@@ -2,8 +2,8 @@
 
 import type { MutableRefObject, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Group, Loader, Menu, Switch, Text } from "@mantine/core";
-import { IconCopy, IconLayoutKanban, IconRefresh, IconSettings, IconTrash } from "@tabler/icons-react";
+import { Group, Loader, Menu, Switch, Text, Tooltip } from "@mantine/core";
+import { IconAlertTriangle, IconCircleCheck, IconCopy, IconLayoutKanban, IconRefresh, IconSettings, IconTrash } from "@tabler/icons-react";
 import type { QueryClient, QueryKey } from "@tanstack/react-query";
 import { useIsFetching, useQueryClient } from "@tanstack/react-query";
 
@@ -15,6 +15,7 @@ import { useConfirmModal, useModalAction } from "@homarr/modals";
 import { useSettings } from "@homarr/settings";
 import { translateIfNecessary } from "@homarr/translation";
 import { useI18n, useScopedI18n } from "@homarr/translation/client";
+import type { TranslationFunction } from "@homarr/translation";
 import type { WidgetContextMenuAction } from "@homarr/widgets";
 import { reduceWidgetOptionsWithDefaultValues, widgetImports } from "@homarr/widgets";
 import { WidgetEditModal } from "@homarr/widgets/modals";
@@ -232,11 +233,9 @@ export const WidgetContextMenu = ({ item, widgetStateRef, children }: WidgetCont
             onClick={handleRefetch}
             disabled={isWidgetFetching}
           >
-            <Group justify="space-between" wrap="nowrap">
+            <Group justify="space-between" wrap="nowrap" gap="sm">
               {tMenu("refresh")}
-              <Text size="xs" c="dimmed">
-                <WidgetCacheAge queryClient={queryClient} queryKey={widgetQueryKey} isFetching={isWidgetFetching} />
-              </Text>
+              <WidgetQueryStatus queryClient={queryClient} queryKey={widgetQueryKey} isFetching={isWidgetFetching} t={t} />
             </Group>
           </Menu.Item>
           <Menu.Item
@@ -273,34 +272,67 @@ export const WidgetContextMenu = ({ item, widgetStateRef, children }: WidgetCont
   );
 };
 
-const WidgetCacheAge = ({
-  queryClient,
-  queryKey,
-  isFetching,
-}: {
+interface WidgetQueryStatusProps {
   queryClient: QueryClient;
   queryKey: QueryKey;
   isFetching: boolean;
-}) => {
-  // 1s tick for "just now" → "1s ago" label transition; isFetching prop handles refetch reactivity
+  t: TranslationFunction;
+}
+
+const WidgetQueryStatus = ({ queryClient, queryKey, isFetching, t }: WidgetQueryStatusProps) => {
   const [, setTick] = useState(0);
   useEffect(() => {
     const id = setInterval(() => setTick((n) => n + 1), 1000);
     return () => clearInterval(id);
   }, []);
 
-  if (isFetching) return <Loader size={12} />;
+  const queries = queryClient.getQueryCache().findAll({ queryKey });
 
-  const timestamps = queryClient
-    .getQueryCache()
-    .findAll({ queryKey })
-    .map((q) => q.state.dataUpdatedAt)
-    .filter(Boolean);
-  if (timestamps.length === 0) return null;
+  if (isFetching) {
+    return (
+      <Group gap={4} wrap="nowrap">
+        <Loader size={12} />
+        <Text size="xs" c="dimmed">
+          {t("item.menu.status.loading")}
+        </Text>
+      </Group>
+    );
+  }
 
-  const latest = Math.max(...timestamps);
+  if (queries.length === 0) {
+    return <Text size="xs" c="dimmed">{t("item.menu.status.idle")}</Text>;
+  }
+
+  const hasError = queries.some((q) => q.state.status === "error");
+  const timestamps = queries.map((q) => q.state.dataUpdatedAt).filter(Boolean);
+  const latest = timestamps.length > 0 ? Math.max(...timestamps) : 0;
   const seconds = Math.floor((Date.now() - latest) / 1000);
-  if (seconds < 5) return "just now";
-  if (seconds < 60) return `${seconds}s ago`;
-  return `${Math.floor(seconds / 60)}m ago`;
+  const ageLabel = seconds < 5 ? "just now" : seconds < 60 ? `${seconds}s ago` : `${Math.floor(seconds / 60)}m ago`;
+
+  if (hasError) {
+    const errorQuery = queries.find((q) => q.state.status === "error");
+    const errorMessage = errorQuery?.state.error instanceof Error
+      ? errorQuery.state.error.message
+      : String(errorQuery?.state.error ?? "Unknown error");
+
+    return (
+      <Tooltip label={errorMessage} multiline position="left" w={250}>
+        <Group gap={4} wrap="nowrap">
+          <IconAlertTriangle size={12} color="var(--mantine-color-red-6)" />
+          <Text size="xs" c="red.6">
+            {t("item.menu.status.error")} · {ageLabel}
+          </Text>
+        </Group>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Group gap={4} wrap="nowrap">
+      <IconCircleCheck size={12} color="var(--mantine-color-green-6)" />
+      <Text size="xs" c="dimmed">
+        {t("item.menu.status.success")} · {ageLabel}
+      </Text>
+    </Group>
+  );
 };

--- a/packages/integrations/src/overseerr/overseerr-integration.ts
+++ b/packages/integrations/src/overseerr/overseerr-integration.ts
@@ -153,9 +153,9 @@ export class OverseerrIntegration
       );
     } else if (pendingResults.length > 0) requests = pendingResults;
     else if (allResults.length > 0) requests = allResults;
-    else return Promise.all([]);
+    else return [];
 
-    return await Promise.all(
+    const settled = await Promise.allSettled(
       requests.map(async (request): Promise<MediaRequest> => {
         const information = await this.getItemInformationAsync(request.media.tmdbId, request.type);
 
@@ -184,6 +184,10 @@ export class OverseerrIntegration
         };
       }),
     );
+
+    return settled
+      .filter((result): result is PromiseFulfilledResult<MediaRequest> => result.status === "fulfilled")
+      .map((result) => result.value);
   }
 
   protected mapRequestStatus(status: UpstreamMediaRequestStatus): MediaRequestStatus {
@@ -300,6 +304,10 @@ export class OverseerrIntegration
         "X-Api-Key": this.getSecretValue("apiKey"),
       },
     });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${type} information for id ${id}: ${response.status} ${response.statusText}`);
+    }
 
     if (type === "tv") {
       const series = (await response.json()) as TvInformation;

--- a/packages/request-handler/src/lib/integration-request-handler.ts
+++ b/packages/request-handler/src/lib/integration-request-handler.ts
@@ -13,6 +13,7 @@ type IntegrationOfKind<TKind extends IntegrationKind> = Omit<Integration, "kind"
 interface Options<TData, TKind extends IntegrationKind, TInput extends Record<string, unknown>> {
   requestAsync: (integration: IntegrationOfKind<TKind>, input: TInput) => Promise<TData>;
   cacheTtlMs?: number;
+  fallbackToStaleOnError?: boolean;
 }
 
 export const createIntegrationRequestHandler = <
@@ -32,6 +33,7 @@ export const createIntegrationRequestHandler = <
       return options.requestAsync(integration, input.options);
     },
     cacheTtlMs: options.cacheTtlMs,
+    fallbackToStaleOnError: options.fallbackToStaleOnError,
   });
 
   return {

--- a/packages/request-handler/src/lib/request-handler.ts
+++ b/packages/request-handler/src/lib/request-handler.ts
@@ -1,6 +1,7 @@
 interface Options<TData, TInput extends Record<string, unknown>> {
   requestAsync: (input: TInput) => Promise<TData>;
   cacheTtlMs?: number;
+  fallbackToStaleOnError?: boolean;
 }
 
 type CacheEntry<TData> = { data: TData; timestamp: Date; expiresAt: number };
@@ -35,7 +36,6 @@ export const createRequestHandler = <TData, TInput extends Record<string, unknow
         if (cached && Date.now() < cached.expiresAt) {
           return { data: cached.data, timestamp: cached.timestamp };
         }
-        if (cached) cache.delete(key);
 
         const existing = inflight.get(key);
         if (existing) return existing;
@@ -55,6 +55,9 @@ export const createRequestHandler = <TData, TInput extends Record<string, unknow
           })
           .catch((err) => {
             inflight.delete(key);
+            if (options.fallbackToStaleOnError && cached) {
+              return cached;
+            }
             throw err;
           });
 

--- a/packages/request-handler/src/media-request-list.ts
+++ b/packages/request-handler/src/media-request-list.ts
@@ -13,4 +13,6 @@ export const mediaRequestListRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getRequestsAsync();
   },
+  cacheTtlMs: 60_000,
+  fallbackToStaleOnError: true,
 });

--- a/packages/translation/src/lang/en-gb.json
+++ b/packages/translation/src/lang/en-gb.json
@@ -1598,10 +1598,16 @@
     },
     "menu": {
       "label": {
-        "settings": "Settings",
+        "settings": "",
         "refresh": "",
         "options": "",
         "actions": ""
+      },
+      "status": {
+        "success": "",
+        "error": "",
+        "loading": "",
+        "idle": ""
       }
     },
     "create": {

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -1622,6 +1622,12 @@
         "refresh": "Refresh",
         "options": "Options",
         "actions": "Actions"
+      },
+      "status": {
+        "success": "OK",
+        "error": "Error",
+        "loading": "Loading",
+        "idle": "Idle"
       }
     },
     "create": {


### PR DESCRIPTION
## Summary

 Since v1.69.0, the caching refactor caused Seerr/Overseerr/Jellyseerr widgets to intermittently crash with "No integration data available" errors.

### Root cause

The v1.69.0 caching refactor (`f19033e0d`) replaced the old Redis-backed cached request handler with a simpler in-memory handler, introducing three problems:

1. **Cache TTL dropped from 60s → 10s** (the default), causing every 30s poll to hit the upstream API
2. **Stale cache entries were deleted on expiry** instead of being kept as fallback, so transient upstream errors propagated directly to the widget
3. **`getItemInformationAsync` never checked `response.ok`**, and a single failing media detail fetch inside `Promise.all` crashed the entire `getRequestsAsync` call

### Changes

**Seerr/Overseerr fix (4 files):**
- Added `fallbackToStaleOnError` option to `createRequestHandler` — on API failure, returns stale cached data instead of throwing
- Passed `fallbackToStaleOnError` through `createIntegrationRequestHandler`
- Set `cacheTtlMs: 60_000` and `fallbackToStaleOnError: true` on `mediaRequestListRequestHandler`
- Added `response.ok` check in `OverseerrIntegration.getItemInformationAsync`
- Changed `Promise.all` → `Promise.allSettled` in `getRequestsAsync` so a single failing media detail fetch skips that item instead of crashing the batch

**Context menu query status (3 files):**
- Replaced `WidgetCacheAge` with `WidgetQueryStatus` in the right-click context menu, showing error/success/loading state with age and error message tooltip
- Added i18n keys for status labels

### Testing
- `pnpm exec turbo typecheck --filter=@homarr/request-handler --filter=@homarr/integrations --filter=@homarr/nextjs --filter=@homarr/translation` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded the widget refresh menu to display a localized status (loading, idle, success, error) with relative “age”, including error details via tooltip.

- **Bug Fixes**
  - Improved media request handling so one failed request no longer blocks successful results, with conditional fallback to stale cached data on failures.

- **Performance**
  - Added short-term caching (60s) for the media request list, allowing stale data reuse if a refresh fails.

- **Localization**
  - Updated widget/menu status and related menu labels in English translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->