### PR TITLE
fix(request-handler): restore cacheTtlMs values lost in v1.69.0 refactor

### DIFF
--- a/packages/request-handler/src/anchor-notes.ts
+++ b/packages/request-handler/src/anchor-notes.ts
@@ -12,6 +12,7 @@ export const anchorNotesListRequestHandler = createIntegrationRequestHandler<
     const instance = await createIntegrationAsync(integration);
     return instance.listNotesAsync(input);
   },
+  cacheTtlMs: 15_000,
 });
 
 export const anchorNoteRequestHandler = createIntegrationRequestHandler<AnchorNote, "anchor", { noteId: string }>({
@@ -19,4 +20,5 @@ export const anchorNoteRequestHandler = createIntegrationRequestHandler<AnchorNo
     const instance = await createIntegrationAsync(integration);
     return instance.getNoteAsync(input.noteId);
   },
+  cacheTtlMs: 15_000,
 });

--- a/packages/request-handler/src/archive-team-warrior.ts
+++ b/packages/request-handler/src/archive-team-warrior.ts
@@ -13,4 +13,5 @@ export const archiveTeamWarriorRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getStatusAsync();
   },
+  cacheTtlMs: 300_000,
 });

--- a/packages/request-handler/src/audiobookshelf.ts
+++ b/packages/request-handler/src/audiobookshelf.ts
@@ -12,4 +12,5 @@ export const audiobookshelfRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getDashboardDataAsync();
   },
+  cacheTtlMs: 600_000,
 });

--- a/packages/request-handler/src/calendar.ts
+++ b/packages/request-handler/src/calendar.ts
@@ -23,4 +23,5 @@ export const calendarMonthRequestHandler = createIntegrationRequestHandler<
       input.showUnmonitored,
     );
   },
+  cacheTtlMs: 60_000,
 });

--- a/packages/request-handler/src/coolify.ts
+++ b/packages/request-handler/src/coolify.ts
@@ -12,4 +12,5 @@ export const coolifyRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getInstanceInfoAsync();
   },
+  cacheTtlMs: 30_000,
 });

--- a/packages/request-handler/src/dns-hole.ts
+++ b/packages/request-handler/src/dns-hole.ts
@@ -13,4 +13,5 @@ export const dnsHoleRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getSummaryAsync();
   },
+  cacheTtlMs: 5_000,
 });

--- a/packages/request-handler/src/docker.ts
+++ b/packages/request-handler/src/docker.ts
@@ -177,6 +177,7 @@ export const dockerContainersRequestHandler = createWidgetRequestHandler({
     }
     return await getContainersWithStatsAsync();
   },
+  cacheTtlMs: 20_000,
 });
 
 const extractImage = (container: ContainerInfo) => extractContainerImageName(container.Image);

--- a/packages/request-handler/src/downloads.ts
+++ b/packages/request-handler/src/downloads.ts
@@ -13,4 +13,5 @@ export const downloadClientRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getClientJobsAndStatusAsync(input);
   },
+  cacheTtlMs: 5_000,
 });

--- a/packages/request-handler/src/duckduckgo-bangs.ts
+++ b/packages/request-handler/src/duckduckgo-bangs.ts
@@ -69,4 +69,5 @@ export const duckDuckGoBangsRequestHandler = createRequestHandler({
 
     return normalized;
   },
+  cacheTtlMs: 86_400_000,
 });

--- a/packages/request-handler/src/firewall.ts
+++ b/packages/request-handler/src/firewall.ts
@@ -18,6 +18,7 @@ export const firewallCpuRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return integrationInstance.getFirewallCpuAsync();
   },
+  cacheTtlMs: 5_000,
 });
 
 export const firewallMemoryRequestHandler = createIntegrationRequestHandler<
@@ -29,6 +30,7 @@ export const firewallMemoryRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getFirewallMemoryAsync();
   },
+  cacheTtlMs: 15_000,
 });
 
 export const firewallInterfacesRequestHandler = createIntegrationRequestHandler<
@@ -40,6 +42,7 @@ export const firewallInterfacesRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getFirewallInterfacesAsync();
   },
+  cacheTtlMs: 30_000,
 });
 
 export const firewallVersionRequestHandler = createIntegrationRequestHandler<
@@ -51,4 +54,5 @@ export const firewallVersionRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getFirewallVersionAsync();
   },
+  cacheTtlMs: 3_600_000,
 });

--- a/packages/request-handler/src/health-monitoring.ts
+++ b/packages/request-handler/src/health-monitoring.ts
@@ -13,6 +13,7 @@ export const systemInfoRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getSystemInfoAsync();
   },
+  cacheTtlMs: 5_000,
 });
 
 export const clusterInfoRequestHandler = createIntegrationRequestHandler<
@@ -24,4 +25,5 @@ export const clusterInfoRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getClusterInfoAsync();
   },
+  cacheTtlMs: 5_000,
 });

--- a/packages/request-handler/src/immich.ts
+++ b/packages/request-handler/src/immich.ts
@@ -13,6 +13,7 @@ export const immichStatsRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getServerStatsAsync();
   },
+  cacheTtlMs: 900_000,
 });
 
 export const immichAlbumsRequestHandler = createIntegrationRequestHandler<
@@ -28,6 +29,7 @@ export const immichAlbumsRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getAlbumsAsync();
   },
+  cacheTtlMs: 900_000,
 });
 
 export const immichAlbumRequestHandler = createIntegrationRequestHandler<
@@ -39,4 +41,5 @@ export const immichAlbumRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getAlbumAsync(input.albumId);
   },
+  cacheTtlMs: 900_000,
 });

--- a/packages/request-handler/src/indexer-manager.ts
+++ b/packages/request-handler/src/indexer-manager.ts
@@ -13,4 +13,5 @@ export const indexerManagerRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getIndexersAsync();
   },
+  cacheTtlMs: 300_000,
 });

--- a/packages/request-handler/src/lib/widget-request-handler.ts
+++ b/packages/request-handler/src/lib/widget-request-handler.ts
@@ -2,6 +2,7 @@ import { createRequestHandler } from "./request-handler";
 
 interface Options<TData, TInput extends Record<string, unknown>> {
   requestAsync: (input: TInput) => Promise<TData>;
+  cacheTtlMs?: number;
 }
 
 export const createWidgetRequestHandler = <TData, TInput extends Record<string, unknown>>(
@@ -10,5 +11,6 @@ export const createWidgetRequestHandler = <TData, TInput extends Record<string, 
   handler: (widgetOptions: TInput) =>
     createRequestHandler<TData, TInput>({
       requestAsync: options.requestAsync,
+      cacheTtlMs: options.cacheTtlMs,
     }).handler(widgetOptions),
 });

--- a/packages/request-handler/src/media-release.ts
+++ b/packages/request-handler/src/media-release.ts
@@ -13,4 +13,5 @@ export const mediaReleaseRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getMediaReleasesAsync();
   },
+  cacheTtlMs: 300_000,
 });

--- a/packages/request-handler/src/media-request-stats.ts
+++ b/packages/request-handler/src/media-request-stats.ts
@@ -16,4 +16,5 @@ export const mediaRequestStatsRequestHandler = createIntegrationRequestHandler<
       users: await integrationInstance.getUsersAsync(),
     };
   },
+  cacheTtlMs: 60_000,
 });

--- a/packages/request-handler/src/media-server.ts
+++ b/packages/request-handler/src/media-server.ts
@@ -15,4 +15,5 @@ export const mediaServerRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getCurrentSessionsAsync({ showOnlyPlaying: input.showOnlyPlaying });
   },
+  cacheTtlMs: 5_000,
 });

--- a/packages/request-handler/src/media-transcoding.ts
+++ b/packages/request-handler/src/media-transcoding.ts
@@ -17,6 +17,7 @@ export const mediaTranscodingRequestHandler = createIntegrationRequestHandler<
       statistics: await integrationInstance.getStatisticsAsync(),
     };
   },
+  cacheTtlMs: 300_000,
 });
 
 export interface MediaTranscoding {

--- a/packages/request-handler/src/minecraft-server-status.ts
+++ b/packages/request-handler/src/minecraft-server-status.ts
@@ -14,6 +14,7 @@ export const minecraftServerStatusRequestHandler = createWidgetRequestHandler({
     );
     return responseSchema.parse(await response.json());
   },
+  cacheTtlMs: 300_000,
 });
 
 const responseSchema = z

--- a/packages/request-handler/src/navidrome.ts
+++ b/packages/request-handler/src/navidrome.ts
@@ -12,4 +12,5 @@ export const navidromeRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getDashboardDataAsync();
   },
+  cacheTtlMs: 600_000,
 });

--- a/packages/request-handler/src/network-controller.ts
+++ b/packages/request-handler/src/network-controller.ts
@@ -13,4 +13,5 @@ export const networkControllerRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getNetworkSummaryAsync();
   },
+  cacheTtlMs: 300_000,
 });

--- a/packages/request-handler/src/notifications.ts
+++ b/packages/request-handler/src/notifications.ts
@@ -13,4 +13,5 @@ export const notificationsRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getNotificationsAsync();
   },
+  cacheTtlMs: 300_000,
 });

--- a/packages/request-handler/src/paperless-ngx.ts
+++ b/packages/request-handler/src/paperless-ngx.ts
@@ -12,4 +12,5 @@ export const paperlessNgxStatsRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getStatsAsync();
   },
+  cacheTtlMs: 900_000,
 });

--- a/packages/request-handler/src/rss-feeds.ts
+++ b/packages/request-handler/src/rss-feeds.ts
@@ -28,6 +28,7 @@ export const rssFeedsRequestHandler = createWidgetRequestHandler({
       entries: result.entries?.map((entry) => ({ ...entry, feedUrl: input.url })).slice(0, input.count) ?? [],
     };
   },
+  cacheTtlMs: 300_000,
 });
 
 const attemptGetImageFromEntry = (feedUrl: string, entry: object) => {

--- a/packages/request-handler/src/smart-home-entity-state.ts
+++ b/packages/request-handler/src/smart-home-entity-state.ts
@@ -18,4 +18,5 @@ export const smartHomeEntityStateRequestHandler = createIntegrationRequestHandle
 
     return result.data.state;
   },
+  cacheTtlMs: 60_000,
 });

--- a/packages/request-handler/src/speedtest-tracker.ts
+++ b/packages/request-handler/src/speedtest-tracker.ts
@@ -12,4 +12,5 @@ export const speedtestTrackerRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getDashboardDataAsync();
   },
+  cacheTtlMs: 600_000,
 });

--- a/packages/request-handler/src/stock-price.ts
+++ b/packages/request-handler/src/stock-price.ts
@@ -39,6 +39,7 @@ export const fetchStockPriceHandler = createWidgetRequestHandler({
       shortName: firstResult.meta.shortName,
     };
   },
+  cacheTtlMs: 300_000,
 });
 
 const dataSchema = z

--- a/packages/request-handler/src/tracearr.ts
+++ b/packages/request-handler/src/tracearr.ts
@@ -12,4 +12,5 @@ export const tracearrRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getDashboardDataAsync();
   },
+  cacheTtlMs: 5_000,
 });

--- a/packages/request-handler/src/umami.ts
+++ b/packages/request-handler/src/umami.ts
@@ -12,6 +12,7 @@ export const umamiRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getVisitorStatsAsync(input.websiteId, input.timeFrame, input.eventName);
   },
+  cacheTtlMs: 300_000,
 });
 
 export const umamiEventNamesRequestHandler = createIntegrationRequestHandler<string[], "umami", { websiteId: string }>({
@@ -19,6 +20,7 @@ export const umamiEventNamesRequestHandler = createIntegrationRequestHandler<str
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getEventNamesAsync(input.websiteId);
   },
+  cacheTtlMs: 300_000,
 });
 
 export const umamiTopPagesRequestHandler = createIntegrationRequestHandler<
@@ -30,6 +32,7 @@ export const umamiTopPagesRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getTopPagesAsync(input.websiteId, input.timeFrame, input.limit);
   },
+  cacheTtlMs: 300_000,
 });
 
 export const umamiTopReferrersRequestHandler = createIntegrationRequestHandler<
@@ -41,6 +44,7 @@ export const umamiTopReferrersRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getTopReferrersAsync(input.websiteId, input.timeFrame, input.limit);
   },
+  cacheTtlMs: 300_000,
 });
 
 export const umamiMultiEventRequestHandler = createIntegrationRequestHandler<
@@ -52,6 +56,7 @@ export const umamiMultiEventRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getMultiEventTimeSeriesAsync(input.websiteId, input.timeFrame, input.eventNames);
   },
+  cacheTtlMs: 300_000,
 });
 
 export const umamiActiveVisitorsRequestHandler = createIntegrationRequestHandler<
@@ -63,4 +68,5 @@ export const umamiActiveVisitorsRequestHandler = createIntegrationRequestHandler
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getActiveVisitorsAsync(input.websiteId);
   },
+  cacheTtlMs: 30_000,
 });

--- a/packages/request-handler/src/ups.ts
+++ b/packages/request-handler/src/ups.ts
@@ -13,4 +13,5 @@ export const upsSummariesRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getUpsSummariesAsync();
   },
+  cacheTtlMs: 60_000,
 });

--- a/packages/request-handler/src/uptime-kuma.ts
+++ b/packages/request-handler/src/uptime-kuma.ts
@@ -12,4 +12,5 @@ export const uptimeKumaRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getDashboardDataAsync();
   },
+  cacheTtlMs: 60_000,
 });

--- a/packages/request-handler/src/vpn.ts
+++ b/packages/request-handler/src/vpn.ts
@@ -25,4 +25,5 @@ export const vpnSummaryHandler = createIntegrationRequestHandler<
       return null;
     }
   },
+  cacheTtlMs: 300_000,
 });

--- a/packages/request-handler/src/weather.ts
+++ b/packages/request-handler/src/weather.ts
@@ -31,6 +31,7 @@ export const weatherRequestHandler = createWidgetRequestHandler({
       }),
     } satisfies Weather;
   },
+  cacheTtlMs: 60_000,
 });
 
 const atLocationOutput = z.object({


### PR DESCRIPTION
## Summary

Fixes #6268 — Since v1.69.0, the caching refactor dropped all per-handler cache duration values, defaulting everything to 10s. Combined with the 30s client polling interval, this caused widgets like Dashdot/health-monitoring (previously 5s cache) to refresh much less frequently.

### Root cause

The v1.69.0 caching refactor (`f19033e0d`) replaced the old Redis-backed `createCachedIntegrationRequestHandler` with a simpler in-memory `createIntegrationRequestHandler`. Every handler that previously specified `cacheDuration: dayjs.duration(N, "seconds/minutes")` lost that value and fell back to the `DEFAULT_TTL_MS = 10_000` (10s) default.

Additionally, `createWidgetRequestHandler` never supported `cacheTtlMs`, so widget handlers (docker, rss-feeds, stock-price, weather, minecraft) had no way to set a custom TTL even after the refactor.

### Changes

- Added `cacheTtlMs` support to `createWidgetRequestHandler`
- Restored `cacheTtlMs` for all affected request handlers to match their pre-v1.69.0 `cacheDuration` values:

| Handler | Old cacheDuration | Restored cacheTtlMs |
|---------|------------------|-------------------|
| health-monitoring | 5s | 5_000 |
| dns-hole | 5s | 5_000 |
| downloads | 5s | 5_000 |
| media-server | 5s | 5_000 |
| tracearr | 5s | 5_000 |
| firewall (cpu/memory/interfaces/version) | 5s/15s/30s/1h | 5_000/15_000/30_000/3_600_000 |
| docker | 20s | 20_000 |
| anchor-notes | 15s | 15_000 |
| umami (active visitors) | 30s | 30_000 |
| calendar | 1min | 60_000 |
| media-request-stats | 1min | 60_000 |
| smart-home-entity-state | 1min | 60_000 |
| ups | 1min | 60_000 |
| uptime-kuma | 1min | 60_000 |
| weather | 1min | 60_000 |
| coolify | 30s | 30_000 |
| umami (most handlers) | 5min | 300_000 |
| indexer-manager | 5min | 300_000 |
| media-release | 5min | 300_000 |
| media-transcoding | 5min | 300_000 |
| network-controller | 5min | 300_000 |
| notifications | 5min | 300_000 |
| rss-feeds | 5min | 300_000 |
| stock-price | 5min | 300_000 |
| minecraft-server-status | 5min | 300_000 |
| vpn | 5min | 300_000 |
| archive-team-warrior | 5min | 300_000 |
| audiobookshelf | 10min | 600_000 |
| navidrome | 10min | 600_000 |
| speedtest-tracker | 10min | 600_000 |
| immich (3 handlers) | 15min | 900_000 |
| paperless-ngx | 15min | 900_000 |
| duckduckgo-bangs | 1day | 86_400_000 |

**Not touched:** Beszel handlers (have their own cache handling), releases/timetable/update-checker (already had `cacheTtlMs` set).

### Testing
- `pnpm exec turbo typecheck --filter=@homarr/request-handler` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable response caching across many dashboard, integration, widget, and data request handlers.
  * Improved responsiveness for repeated requests by reusing recent results for appropriate periods.
  * Added cache configuration support for widget-based requests.
* **Performance**
  * Applied tailored cache durations, ranging from a few seconds to 24 hours, based on the type and freshness needs of each request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->