### PR TITLE
fix(widgets): restore per-widget refetch intervals lost in v1.69.0 refactor

### DIFF
--- a/apps/nextjs/src/app/[locale]/_client-providers/trpc.tsx
+++ b/apps/nextjs/src/app/[locale]/_client-providers/trpc.tsx
@@ -29,6 +29,7 @@ import {
   queryCacheDefaultGcTimeMs,
   queryCacheDefaultRefetchIntervalMs,
   queryCacheDefaultStaleTimeMs,
+  widgetRefetchIntervalOverrides,
 } from "@homarr/api/query-cache";
 import { createHeadersCallbackForSource, getTrpcUrl } from "@homarr/api/shared";
 import { env } from "@homarr/common/env";
@@ -90,6 +91,9 @@ export function TRPCReactProvider(props: PropsWithChildren) {
       },
     });
     client.setQueryDefaults([["widget"]], { refetchInterval: queryCacheDefaultRefetchIntervalMs });
+    for (const [path, interval] of Object.entries(widgetRefetchIntervalOverrides)) {
+      client.setQueryDefaults([path.split(".")], { refetchInterval: interval });
+    }
     return client;
   });
 

--- a/packages/api/src/query-cache.ts
+++ b/packages/api/src/query-cache.ts
@@ -7,6 +7,44 @@ export const queryCacheMaxValueBytes = 1024 * 1024;
 export const queryCacheStoragePrefix = "homarr-widget-query";
 export const queryCacheBuster = "v2-superjson";
 
+export const widgetRefetchIntervalOverrides: Record<string, number> = {
+  "widget.healthMonitoring": 5_000,
+  "widget.dnsHole": 5_000,
+  "widget.downloads": 5_000,
+  "widget.mediaServer": 5_000,
+  "widget.tracearr": 5_000,
+  "widget.firewall.getFirewallCpuStatus": 5_000,
+  "widget.firewall.getFirewallMemoryStatus": 15_000,
+  "widget.firewall.getFirewallInterfacesStatus": 30_000,
+  "widget.firewall.getFirewallVersionStatus": 3_600_000,
+  "widget.anchorNotes": 15_000,
+  "widget.coolify": 30_000,
+  "widget.umami.getActiveVisitors": 30_000,
+  "widget.umami": 300_000,
+  "widget.calendar": 60_000,
+  "widget.mediaRequests": 60_000,
+  "widget.smartHome": 60_000,
+  "widget.ups": 60_000,
+  "widget.uptimeKuma": 60_000,
+  "widget.weather": 60_000,
+  "widget.timetable": 60_000,
+  "widget.indexerManager": 300_000,
+  "widget.mediaRelease": 300_000,
+  "widget.mediaTranscoding": 300_000,
+  "widget.networkController": 300_000,
+  "widget.notifications": 300_000,
+  "widget.rssFeed": 300_000,
+  "widget.stockPrice": 300_000,
+  "widget.minecraft": 300_000,
+  "widget.vpn": 300_000,
+  "widget.archiveTeamWarrior": 300_000,
+  "widget.audiobookshelf": 600_000,
+  "widget.navidrome": 600_000,
+  "widget.speedtestTracker": 600_000,
+  "widget.immich": 900_000,
+  "widget.paperlessNgx": 900_000,
+};
+
 let activeQueryCacheBoardId: string | null = null;
 
 export const setActiveQueryCacheBoardId = (boardId: string | null) => {

--- a/packages/request-handler/src/anchor-notes.ts
+++ b/packages/request-handler/src/anchor-notes.ts
@@ -12,6 +12,7 @@ export const anchorNotesListRequestHandler = createIntegrationRequestHandler<
     const instance = await createIntegrationAsync(integration);
     return instance.listNotesAsync(input);
   },
+  cacheTtlMs: 15_000,
 });
 
 export const anchorNoteRequestHandler = createIntegrationRequestHandler<AnchorNote, "anchor", { noteId: string }>({
@@ -19,4 +20,5 @@ export const anchorNoteRequestHandler = createIntegrationRequestHandler<AnchorNo
     const instance = await createIntegrationAsync(integration);
     return instance.getNoteAsync(input.noteId);
   },
+  cacheTtlMs: 15_000,
 });

--- a/packages/request-handler/src/archive-team-warrior.ts
+++ b/packages/request-handler/src/archive-team-warrior.ts
@@ -13,4 +13,5 @@ export const archiveTeamWarriorRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getStatusAsync();
   },
+  cacheTtlMs: 300_000,
 });

--- a/packages/request-handler/src/audiobookshelf.ts
+++ b/packages/request-handler/src/audiobookshelf.ts
@@ -12,4 +12,5 @@ export const audiobookshelfRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getDashboardDataAsync();
   },
+  cacheTtlMs: 600_000,
 });

--- a/packages/request-handler/src/calendar.ts
+++ b/packages/request-handler/src/calendar.ts
@@ -23,4 +23,5 @@ export const calendarMonthRequestHandler = createIntegrationRequestHandler<
       input.showUnmonitored,
     );
   },
+  cacheTtlMs: 60_000,
 });

--- a/packages/request-handler/src/coolify.ts
+++ b/packages/request-handler/src/coolify.ts
@@ -12,4 +12,5 @@ export const coolifyRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getInstanceInfoAsync();
   },
+  cacheTtlMs: 30_000,
 });

--- a/packages/request-handler/src/dns-hole.ts
+++ b/packages/request-handler/src/dns-hole.ts
@@ -13,4 +13,5 @@ export const dnsHoleRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getSummaryAsync();
   },
+  cacheTtlMs: 5_000,
 });

--- a/packages/request-handler/src/docker.ts
+++ b/packages/request-handler/src/docker.ts
@@ -177,6 +177,7 @@ export const dockerContainersRequestHandler = createWidgetRequestHandler({
     }
     return await getContainersWithStatsAsync();
   },
+  cacheTtlMs: 20_000,
 });
 
 const extractImage = (container: ContainerInfo) => extractContainerImageName(container.Image);

--- a/packages/request-handler/src/downloads.ts
+++ b/packages/request-handler/src/downloads.ts
@@ -13,4 +13,5 @@ export const downloadClientRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getClientJobsAndStatusAsync(input);
   },
+  cacheTtlMs: 5_000,
 });

--- a/packages/request-handler/src/duckduckgo-bangs.ts
+++ b/packages/request-handler/src/duckduckgo-bangs.ts
@@ -69,4 +69,5 @@ export const duckDuckGoBangsRequestHandler = createRequestHandler({
 
     return normalized;
   },
+  cacheTtlMs: 86_400_000,
 });

--- a/packages/request-handler/src/firewall.ts
+++ b/packages/request-handler/src/firewall.ts
@@ -18,6 +18,7 @@ export const firewallCpuRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return integrationInstance.getFirewallCpuAsync();
   },
+  cacheTtlMs: 5_000,
 });
 
 export const firewallMemoryRequestHandler = createIntegrationRequestHandler<
@@ -29,6 +30,7 @@ export const firewallMemoryRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getFirewallMemoryAsync();
   },
+  cacheTtlMs: 15_000,
 });
 
 export const firewallInterfacesRequestHandler = createIntegrationRequestHandler<
@@ -40,6 +42,7 @@ export const firewallInterfacesRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getFirewallInterfacesAsync();
   },
+  cacheTtlMs: 30_000,
 });
 
 export const firewallVersionRequestHandler = createIntegrationRequestHandler<
@@ -51,4 +54,5 @@ export const firewallVersionRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getFirewallVersionAsync();
   },
+  cacheTtlMs: 3_600_000,
 });

--- a/packages/request-handler/src/health-monitoring.ts
+++ b/packages/request-handler/src/health-monitoring.ts
@@ -13,6 +13,7 @@ export const systemInfoRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getSystemInfoAsync();
   },
+  cacheTtlMs: 5_000,
 });
 
 export const clusterInfoRequestHandler = createIntegrationRequestHandler<
@@ -24,4 +25,5 @@ export const clusterInfoRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getClusterInfoAsync();
   },
+  cacheTtlMs: 5_000,
 });

--- a/packages/request-handler/src/immich.ts
+++ b/packages/request-handler/src/immich.ts
@@ -13,6 +13,7 @@ export const immichStatsRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getServerStatsAsync();
   },
+  cacheTtlMs: 900_000,
 });
 
 export const immichAlbumsRequestHandler = createIntegrationRequestHandler<
@@ -28,6 +29,7 @@ export const immichAlbumsRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getAlbumsAsync();
   },
+  cacheTtlMs: 900_000,
 });
 
 export const immichAlbumRequestHandler = createIntegrationRequestHandler<
@@ -39,4 +41,5 @@ export const immichAlbumRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getAlbumAsync(input.albumId);
   },
+  cacheTtlMs: 900_000,
 });

--- a/packages/request-handler/src/indexer-manager.ts
+++ b/packages/request-handler/src/indexer-manager.ts
@@ -13,4 +13,5 @@ export const indexerManagerRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getIndexersAsync();
   },
+  cacheTtlMs: 300_000,
 });

--- a/packages/request-handler/src/lib/widget-request-handler.ts
+++ b/packages/request-handler/src/lib/widget-request-handler.ts
@@ -2,6 +2,7 @@ import { createRequestHandler } from "./request-handler";
 
 interface Options<TData, TInput extends Record<string, unknown>> {
   requestAsync: (input: TInput) => Promise<TData>;
+  cacheTtlMs?: number;
 }
 
 export const createWidgetRequestHandler = <TData, TInput extends Record<string, unknown>>(
@@ -10,5 +11,6 @@ export const createWidgetRequestHandler = <TData, TInput extends Record<string, 
   handler: (widgetOptions: TInput) =>
     createRequestHandler<TData, TInput>({
       requestAsync: options.requestAsync,
+      cacheTtlMs: options.cacheTtlMs,
     }).handler(widgetOptions),
 });

--- a/packages/request-handler/src/media-release.ts
+++ b/packages/request-handler/src/media-release.ts
@@ -13,4 +13,5 @@ export const mediaReleaseRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getMediaReleasesAsync();
   },
+  cacheTtlMs: 300_000,
 });

--- a/packages/request-handler/src/media-request-stats.ts
+++ b/packages/request-handler/src/media-request-stats.ts
@@ -16,4 +16,5 @@ export const mediaRequestStatsRequestHandler = createIntegrationRequestHandler<
       users: await integrationInstance.getUsersAsync(),
     };
   },
+  cacheTtlMs: 60_000,
 });

--- a/packages/request-handler/src/media-server.ts
+++ b/packages/request-handler/src/media-server.ts
@@ -15,4 +15,5 @@ export const mediaServerRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getCurrentSessionsAsync({ showOnlyPlaying: input.showOnlyPlaying });
   },
+  cacheTtlMs: 5_000,
 });

--- a/packages/request-handler/src/media-transcoding.ts
+++ b/packages/request-handler/src/media-transcoding.ts
@@ -17,6 +17,7 @@ export const mediaTranscodingRequestHandler = createIntegrationRequestHandler<
       statistics: await integrationInstance.getStatisticsAsync(),
     };
   },
+  cacheTtlMs: 300_000,
 });
 
 export interface MediaTranscoding {

--- a/packages/request-handler/src/minecraft-server-status.ts
+++ b/packages/request-handler/src/minecraft-server-status.ts
@@ -14,6 +14,7 @@ export const minecraftServerStatusRequestHandler = createWidgetRequestHandler({
     );
     return responseSchema.parse(await response.json());
   },
+  cacheTtlMs: 300_000,
 });
 
 const responseSchema = z

--- a/packages/request-handler/src/navidrome.ts
+++ b/packages/request-handler/src/navidrome.ts
@@ -12,4 +12,5 @@ export const navidromeRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getDashboardDataAsync();
   },
+  cacheTtlMs: 600_000,
 });

--- a/packages/request-handler/src/network-controller.ts
+++ b/packages/request-handler/src/network-controller.ts
@@ -13,4 +13,5 @@ export const networkControllerRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getNetworkSummaryAsync();
   },
+  cacheTtlMs: 300_000,
 });

--- a/packages/request-handler/src/notifications.ts
+++ b/packages/request-handler/src/notifications.ts
@@ -13,4 +13,5 @@ export const notificationsRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getNotificationsAsync();
   },
+  cacheTtlMs: 300_000,
 });

--- a/packages/request-handler/src/paperless-ngx.ts
+++ b/packages/request-handler/src/paperless-ngx.ts
@@ -12,4 +12,5 @@ export const paperlessNgxStatsRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getStatsAsync();
   },
+  cacheTtlMs: 900_000,
 });

--- a/packages/request-handler/src/rss-feeds.ts
+++ b/packages/request-handler/src/rss-feeds.ts
@@ -28,6 +28,7 @@ export const rssFeedsRequestHandler = createWidgetRequestHandler({
       entries: result.entries?.map((entry) => ({ ...entry, feedUrl: input.url })).slice(0, input.count) ?? [],
     };
   },
+  cacheTtlMs: 300_000,
 });
 
 const attemptGetImageFromEntry = (feedUrl: string, entry: object) => {

--- a/packages/request-handler/src/smart-home-entity-state.ts
+++ b/packages/request-handler/src/smart-home-entity-state.ts
@@ -18,4 +18,5 @@ export const smartHomeEntityStateRequestHandler = createIntegrationRequestHandle
 
     return result.data.state;
   },
+  cacheTtlMs: 60_000,
 });

--- a/packages/request-handler/src/speedtest-tracker.ts
+++ b/packages/request-handler/src/speedtest-tracker.ts
@@ -12,4 +12,5 @@ export const speedtestTrackerRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getDashboardDataAsync();
   },
+  cacheTtlMs: 600_000,
 });

--- a/packages/request-handler/src/stock-price.ts
+++ b/packages/request-handler/src/stock-price.ts
@@ -39,6 +39,7 @@ export const fetchStockPriceHandler = createWidgetRequestHandler({
       shortName: firstResult.meta.shortName,
     };
   },
+  cacheTtlMs: 300_000,
 });
 
 const dataSchema = z

--- a/packages/request-handler/src/tracearr.ts
+++ b/packages/request-handler/src/tracearr.ts
@@ -12,4 +12,5 @@ export const tracearrRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getDashboardDataAsync();
   },
+  cacheTtlMs: 5_000,
 });

--- a/packages/request-handler/src/umami.ts
+++ b/packages/request-handler/src/umami.ts
@@ -12,6 +12,7 @@ export const umamiRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getVisitorStatsAsync(input.websiteId, input.timeFrame, input.eventName);
   },
+  cacheTtlMs: 300_000,
 });
 
 export const umamiEventNamesRequestHandler = createIntegrationRequestHandler<string[], "umami", { websiteId: string }>({
@@ -19,6 +20,7 @@ export const umamiEventNamesRequestHandler = createIntegrationRequestHandler<str
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getEventNamesAsync(input.websiteId);
   },
+  cacheTtlMs: 300_000,
 });
 
 export const umamiTopPagesRequestHandler = createIntegrationRequestHandler<
@@ -30,6 +32,7 @@ export const umamiTopPagesRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getTopPagesAsync(input.websiteId, input.timeFrame, input.limit);
   },
+  cacheTtlMs: 300_000,
 });
 
 export const umamiTopReferrersRequestHandler = createIntegrationRequestHandler<
@@ -41,6 +44,7 @@ export const umamiTopReferrersRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getTopReferrersAsync(input.websiteId, input.timeFrame, input.limit);
   },
+  cacheTtlMs: 300_000,
 });
 
 export const umamiMultiEventRequestHandler = createIntegrationRequestHandler<
@@ -52,6 +56,7 @@ export const umamiMultiEventRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getMultiEventTimeSeriesAsync(input.websiteId, input.timeFrame, input.eventNames);
   },
+  cacheTtlMs: 300_000,
 });
 
 export const umamiActiveVisitorsRequestHandler = createIntegrationRequestHandler<
@@ -63,4 +68,5 @@ export const umamiActiveVisitorsRequestHandler = createIntegrationRequestHandler
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getActiveVisitorsAsync(input.websiteId);
   },
+  cacheTtlMs: 30_000,
 });

--- a/packages/request-handler/src/ups.ts
+++ b/packages/request-handler/src/ups.ts
@@ -13,4 +13,5 @@ export const upsSummariesRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getUpsSummariesAsync();
   },
+  cacheTtlMs: 60_000,
 });

--- a/packages/request-handler/src/uptime-kuma.ts
+++ b/packages/request-handler/src/uptime-kuma.ts
@@ -12,4 +12,5 @@ export const uptimeKumaRequestHandler = createIntegrationRequestHandler<
     const integrationInstance = await createIntegrationAsync(integration);
     return await integrationInstance.getDashboardDataAsync();
   },
+  cacheTtlMs: 60_000,
 });

--- a/packages/request-handler/src/vpn.ts
+++ b/packages/request-handler/src/vpn.ts
@@ -25,4 +25,5 @@ export const vpnSummaryHandler = createIntegrationRequestHandler<
       return null;
     }
   },
+  cacheTtlMs: 300_000,
 });

--- a/packages/request-handler/src/weather.ts
+++ b/packages/request-handler/src/weather.ts
@@ -31,6 +31,7 @@ export const weatherRequestHandler = createWidgetRequestHandler({
       }),
     } satisfies Weather;
   },
+  cacheTtlMs: 60_000,
 });
 
 const atLocationOutput = z.object({

--- a/packages/widgets/src/docker/component.tsx
+++ b/packages/widgets/src/docker/component.tsx
@@ -189,7 +189,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
     refetch,
     isFetching,
   } = clientApi.docker.getContainers.useQuery(undefined, {
-    refetchInterval: 30_000,
+    refetchInterval: 20_000,
   });
   const containers = data?.containers ?? [];
   const timestamp = useMemo(() => data?.timestamp ?? new Date(), [data?.timestamp]);

--- a/packages/widgets/src/docker/component.tsx
+++ b/packages/widgets/src/docker/component.tsx
@@ -184,11 +184,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
   const t = useScopedI18n("docker");
   const isTiny = width <= 256;
 
-  const {
-    data,
-    refetch,
-    isFetching,
-  } = clientApi.docker.getContainers.useQuery(undefined, {
+  const { data, refetch, isFetching } = clientApi.docker.getContainers.useQuery(undefined, {
     refetchInterval: 20_000,
   });
   const containers = data?.containers ?? [];
@@ -304,9 +300,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
               {t("table.totalMemory", { memory: formatBytes(totals.memory) })}
             </Text>
 
-            <Tooltip
-              label={t("table.refresh.lastUpdated", { when: relativeTime })}
-            >
+            <Tooltip label={t("table.refresh.lastUpdated", { when: relativeTime })}>
               <ActionIcon
                 size="sm"
                 variant="transparent"


### PR DESCRIPTION
## Summary

Fixes #6268 — Since v1.69.0, the caching refactor replaced the old Redis pub/sub push mechanism with a global 30s client-side polling interval. This caused widgets that previously refreshed every 5s (e.g. health-monitoring/Dashdot, dns-hole, downloads) to only refresh every 30s.

### Root cause

The v1.69.0 caching refactor (`f19033e0d`) made two key changes:
1. **Removed Redis pub/sub subscriptions** — the old system pushed updates to the client as soon as the server-side cache refreshed
2. **Set a global `refetchInterval: 30_000`** for all widget queries — replacing the per-widget refresh rates that were implicitly determined by each handler's `cacheDuration`

### Changes

**Client-side per-widget refetch intervals (2 files):**
- Added `widgetRefetchIntervalOverrides` map in `query-cache.ts` mapping tRPC path prefixes to refetch intervals, matching pre-v1.69.0 values
- Updated `trpc.tsx` to apply these overrides via `setQueryDefaults` after the global 30s default

| tRPC path prefix | Old cacheDuration | refetchInterval |
|-----------------|-------------------|-----------------|
| widget.healthMonitoring | 5s | 5_000 |
| widget.dnsHole | 5s | 5_000 |
| widget.downloads | 5s | 5_000 |
| widget.mediaServer | 5s | 5_000 |
| widget.tracearr | 5s | 5_000 |
| widget.firewall.getFirewallCpuStatus | 5s | 5_000 |
| widget.firewall.getFirewallMemoryStatus | 15s | 15_000 |
| widget.firewall.getFirewallInterfacesStatus | 30s | 30_000 |
| widget.firewall.getFirewallVersionStatus | 1h | 3_600_000 |
| widget.anchorNotes | 15s | 15_000 |
| widget.coolify | 30s | 30_000 |
| widget.umami.getActiveVisitors | 30s | 30_000 |
| widget.calendar | 1min | 60_000 |
| widget.mediaRequests | 1min | 60_000 |
| widget.smartHome | 1min | 60_000 |
| widget.ups | 1min | 60_000 |
| widget.uptimeKuma | 1min | 60_000 |
| widget.weather | 1min | 60_000 |
| widget.timetable | 1min | 60_000 |
| widget.umami (others) | 5min | 300_000 |
| widget.indexerManager | 5min | 300_000 |
| widget.mediaRelease | 5min | 300_000 |
| widget.mediaTranscoding | 5min | 300_000 |
| widget.networkController | 5min | 300_000 |
| widget.notifications | 5min | 300_000 |
| widget.rssFeed | 5min | 300_000 |
| widget.stockPrice | 5min | 300_000 |
| widget.minecraft | 5min | 300_000 |
| widget.vpn | 5min | 300_000 |
| widget.archiveTeamWarrior | 5min | 300_000 |
| widget.audiobookshelf | 10min | 600_000 |
| widget.navidrome | 10min | 600_000 |
| widget.speedtestTracker | 10min | 600_000 |
| widget.immich | 15min | 900_000 |
| widget.paperlessNgx | 15min | 900_000 |

**Server-side cacheTtlMs restoration (33 files):**
- Restored `cacheTtlMs` on all request handlers to match pre-v1.69.0 `cacheDuration` values, preventing duplicate upstream API calls between client polls
- Added `cacheTtlMs` support to `createWidgetRequestHandler`

**Docker widget (1 file):**
- Updated inline `refetchInterval` from 30s to 20s to match pre-v1.69.0 value

**Not touched:** Beszel handlers (have their own cache handling).

### Testing
- `pnpm exec turbo typecheck --filter=@homarr/request-handler --filter=@homarr/nextjs --filter=@homarr/api` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable refresh intervals for individual widgets, improving data freshness while reducing unnecessary requests.
  * Added response caching across many integration-powered widgets, with tailored cache durations for different data types.
* **Bug Fixes**
  * Improved Docker widget refresh timing for more responsive container status updates.
* **Performance**
  * Reduced repeated data fetching and improved dashboard responsiveness through optimized caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->