### PR TITLE
fix(widgets): add per-widget refetchIntervalSeconds to WidgetDefinition

### DIFF
--- a/apps/nextjs/src/app/[locale]/_client-providers/trpc.tsx
+++ b/apps/nextjs/src/app/[locale]/_client-providers/trpc.tsx
@@ -2,6 +2,7 @@
 
 import type { PropsWithChildren } from "react";
 import { useState } from "react";
+import type { QueryKey } from "@tanstack/react-query";
 import { QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { ReactQueryStreamedHydration } from "@tanstack/react-query-next-experimental";
@@ -33,6 +34,7 @@ import {
 import { createHeadersCallbackForSource, getTrpcUrl } from "@homarr/api/shared";
 import { env } from "@homarr/common/env";
 import { showWarningNotification } from "@homarr/notifications";
+import { widgetImports } from "@homarr/widgets";
 
 import { createWidgetQueryPersister } from "./query-cache-persister";
 
@@ -90,6 +92,12 @@ export function TRPCReactProvider(props: PropsWithChildren) {
       },
     });
     client.setQueryDefaults([["widget"]], { refetchInterval: queryCacheDefaultRefetchIntervalMs });
+    for (const { definition } of Object.values(widgetImports)) {
+      const def = definition as { refetchIntervalSeconds?: number; queryKey?: QueryKey; kind: string };
+      if (!def.refetchIntervalSeconds) continue;
+      const key = def.queryKey ?? [["widget", def.kind]];
+      client.setQueryDefaults(key, { refetchInterval: def.refetchIntervalSeconds * 1000 });
+    }
     return client;
   });
 

--- a/packages/widgets/src/anchor-note/index.ts
+++ b/packages/widgets/src/anchor-note/index.ts
@@ -5,6 +5,8 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("anchorNote", {
   icon: IconNotes,
+  queryKey: [["widget", "anchorNotes"]],
+  refetchIntervalSeconds: 15,
   supportedIntegrations: ["anchor"],
   createOptions() {
     return optionsBuilder.from((factory) => ({

--- a/packages/widgets/src/archive-team-warrior/index.ts
+++ b/packages/widgets/src/archive-team-warrior/index.ts
@@ -5,6 +5,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("archiveTeamWarrior", {
   icon: IconArchive,
+  refetchIntervalSeconds: 300,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       showBroadcastMessage: factory.switch({

--- a/packages/widgets/src/audio-stats/index.ts
+++ b/packages/widgets/src/audio-stats/index.ts
@@ -14,6 +14,7 @@ const hideUnlessAudiobookshelf = {
 
 export const { definition, componentLoader } = createWidgetDefinition("audioStats", {
   icon: IconHeadphones,
+  refetchIntervalSeconds: 600,
   supportedIntegrations: ["navidrome", "audiobookshelf"],
   integrationsRequired: true,
   maxIntegrations: 1,

--- a/packages/widgets/src/calendar/index.ts
+++ b/packages/widgets/src/calendar/index.ts
@@ -9,6 +9,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("calendar", {
   icon: IconCalendar,
+  refetchIntervalSeconds: 60,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       releaseType: factory.multiSelect({

--- a/packages/widgets/src/coolify/index.ts
+++ b/packages/widgets/src/coolify/index.ts
@@ -5,6 +5,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("coolify", {
   icon: IconCloud,
+  refetchIntervalSeconds: 30,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       showServers: factory.switch({

--- a/packages/widgets/src/definition.ts
+++ b/packages/widgets/src/definition.ts
@@ -70,6 +70,7 @@ export const createWidgetDefinition = <TKind extends WidgetKind, TDefinition ext
 export interface WidgetDefinition {
   icon: TablerIcon;
   queryKey?: QueryKey;
+  refetchIntervalSeconds?: number;
   supportedIntegrations?: IntegrationKind[];
   integrationsRequired?: boolean;
   maxIntegrations?: number;

--- a/packages/widgets/src/dns-hole/controls/index.ts
+++ b/packages/widgets/src/dns-hole/controls/index.ts
@@ -9,6 +9,8 @@ export const widgetKind = "dnsHoleControls";
 
 export const { definition, componentLoader } = createWidgetDefinition(widgetKind, {
   icon: IconDeviceGamepad,
+  queryKey: [["widget", "dnsHole"]],
+  refetchIntervalSeconds: 5,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       showToggleAllButtons: factory.switch({

--- a/packages/widgets/src/dns-hole/summary/index.ts
+++ b/packages/widgets/src/dns-hole/summary/index.ts
@@ -9,6 +9,8 @@ export const widgetKind = "dnsHoleSummary";
 
 export const { definition, componentLoader } = createWidgetDefinition(widgetKind, {
   icon: IconAd,
+  queryKey: [["widget", "dnsHole"]],
+  refetchIntervalSeconds: 5,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       usePiHoleColors: factory.switch({

--- a/packages/widgets/src/docker/component.tsx
+++ b/packages/widgets/src/docker/component.tsx
@@ -184,11 +184,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
   const t = useScopedI18n("docker");
   const isTiny = width <= 256;
 
-  const {
-    data,
-    refetch,
-    isFetching,
-  } = clientApi.docker.getContainers.useQuery(undefined, {});
+  const { data, refetch, isFetching } = clientApi.docker.getContainers.useQuery(undefined, {});
   const containers = data?.containers ?? [];
   const timestamp = useMemo(() => data?.timestamp ?? new Date(), [data?.timestamp]);
   const relativeTime = useTimeAgo(timestamp);
@@ -302,9 +298,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
               {t("table.totalMemory", { memory: formatBytes(totals.memory) })}
             </Text>
 
-            <Tooltip
-              label={t("table.refresh.lastUpdated", { when: relativeTime })}
-            >
+            <Tooltip label={t("table.refresh.lastUpdated", { when: relativeTime })}>
               <ActionIcon
                 size="sm"
                 variant="transparent"

--- a/packages/widgets/src/docker/component.tsx
+++ b/packages/widgets/src/docker/component.tsx
@@ -188,9 +188,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
     data,
     refetch,
     isFetching,
-  } = clientApi.docker.getContainers.useQuery(undefined, {
-    refetchInterval: 30_000,
-  });
+  } = clientApi.docker.getContainers.useQuery(undefined, {});
   const containers = data?.containers ?? [];
   const timestamp = useMemo(() => data?.timestamp ?? new Date(), [data?.timestamp]);
   const relativeTime = useTimeAgo(timestamp);

--- a/packages/widgets/src/docker/index.ts
+++ b/packages/widgets/src/docker/index.ts
@@ -26,6 +26,7 @@ const columnTranslationKeyMap = {
 export const { definition, componentLoader } = createWidgetDefinition("dockerContainers", {
   icon: IconBrandDocker,
   queryKey: [["docker", "getContainers"]],
+  refetchIntervalSeconds: 20,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       columns: factory.multiSelect({

--- a/packages/widgets/src/downloads/index.ts
+++ b/packages/widgets/src/downloads/index.ts
@@ -33,6 +33,7 @@ const columnsSort = columnsList.filter((column) =>
 
 export const { definition, componentLoader } = createWidgetDefinition("downloads", {
   icon: IconDownload,
+  refetchIntervalSeconds: 5,
   createOptions() {
     return optionsBuilder.from(
       (factory) => ({

--- a/packages/widgets/src/firewall/index.ts
+++ b/packages/widgets/src/firewall/index.ts
@@ -7,6 +7,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("firewall", {
   icon: IconWall,
+  refetchIntervalSeconds: 5,
   createOptions() {
     return optionsBuilder.from(() => ({}));
   },

--- a/packages/widgets/src/health-monitoring/index.ts
+++ b/packages/widgets/src/health-monitoring/index.ts
@@ -8,6 +8,7 @@ import { createStorageVolumeMultiSelectOptions } from "../storage-volume-options
 
 export const { definition, componentLoader } = createWidgetDefinition("healthMonitoring", {
   icon: IconHeartRateMonitor,
+  refetchIntervalSeconds: 5,
   createOptions() {
     return optionsBuilder.from(
       (factory) => ({

--- a/packages/widgets/src/immich/album-carousel/index.ts
+++ b/packages/widgets/src/immich/album-carousel/index.ts
@@ -8,6 +8,8 @@ import { optionsBuilder } from "../../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("immich-albumCarousel", {
   icon: IconPhoto,
+  queryKey: [["widget", "immich"]],
+  refetchIntervalSeconds: 900,
   supportedIntegrations: ["immich"],
   integrationsRequired: true,
   createOptions() {

--- a/packages/widgets/src/immich/server-stats/index.ts
+++ b/packages/widgets/src/immich/server-stats/index.ts
@@ -5,6 +5,8 @@ import { optionsBuilder } from "../../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("immich-serverStats", {
   icon: IconGraphFilled,
+  queryKey: [["widget", "immich"]],
+  refetchIntervalSeconds: 900,
   supportedIntegrations: ["immich"],
   integrationsRequired: true,
   createOptions() {

--- a/packages/widgets/src/indexer-manager/index.ts
+++ b/packages/widgets/src/indexer-manager/index.ts
@@ -7,6 +7,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("indexerManager", {
   icon: IconReportSearch,
+  refetchIntervalSeconds: 300,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       openIndexerSiteInNewTab: factory.switch({

--- a/packages/widgets/src/media-releases/index.ts
+++ b/packages/widgets/src/media-releases/index.ts
@@ -5,6 +5,8 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("mediaReleases", {
   icon: IconTicket,
+  queryKey: [["widget", "mediaRelease"]],
+  refetchIntervalSeconds: 300,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       layout: factory.select({

--- a/packages/widgets/src/media-requests/list/index.ts
+++ b/packages/widgets/src/media-requests/list/index.ts
@@ -8,6 +8,8 @@ import { optionsBuilder } from "../../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("mediaRequests-requestList", {
   icon: IconZoomQuestion,
+  queryKey: [["widget", "mediaRequests"]],
+  refetchIntervalSeconds: 60,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       linksTargetNewTab: factory.switch({

--- a/packages/widgets/src/media-requests/stats/index.ts
+++ b/packages/widgets/src/media-requests/stats/index.ts
@@ -7,6 +7,8 @@ import { createWidgetDefinition } from "../../definition";
 
 export const { componentLoader, definition } = createWidgetDefinition("mediaRequests-requestStats", {
   icon: IconChartBar,
+  queryKey: [["widget", "mediaRequests"]],
+  refetchIntervalSeconds: 60,
   createOptions() {
     return {};
   },

--- a/packages/widgets/src/media-server/index.ts
+++ b/packages/widgets/src/media-server/index.ts
@@ -7,6 +7,7 @@ import { optionsBuilder } from "../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("mediaServer", {
   icon: IconVideo,
+  refetchIntervalSeconds: 5,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       showOnlyPlaying: factory.switch({ defaultValue: true, withDescription: true }),

--- a/packages/widgets/src/media-transcoding/index.ts
+++ b/packages/widgets/src/media-transcoding/index.ts
@@ -11,6 +11,7 @@ export const views = ["workers", "queue", "statistics"] as const;
 
 export const { componentLoader, definition } = createWidgetDefinition("mediaTranscoding", {
   icon: IconTransform,
+  refetchIntervalSeconds: 300,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       defaultView: factory.select({

--- a/packages/widgets/src/minecraft/server-status/index.ts
+++ b/packages/widgets/src/minecraft/server-status/index.ts
@@ -6,6 +6,7 @@ import { optionsBuilder } from "../../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("minecraftServerStatus", {
   icon: IconBrandMinecraft,
+  refetchIntervalSeconds: 300,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       title: factory.text({ defaultValue: "" }),

--- a/packages/widgets/src/network-controller/network-status/index.ts
+++ b/packages/widgets/src/network-controller/network-status/index.ts
@@ -7,6 +7,8 @@ import { optionsBuilder } from "../../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("networkControllerStatus", {
   icon: IconTopologyFull,
+  queryKey: [["widget", "networkController"]],
+  refetchIntervalSeconds: 300,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       content: factory.select({

--- a/packages/widgets/src/network-controller/summary/index.ts
+++ b/packages/widgets/src/network-controller/summary/index.ts
@@ -7,6 +7,7 @@ import { optionsBuilder } from "../../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("networkControllerSummary", {
   icon: IconTopologyFull,
+  refetchIntervalSeconds: 300,
   createOptions() {
     return optionsBuilder.from(() => ({}));
   },

--- a/packages/widgets/src/notifications/index.ts
+++ b/packages/widgets/src/notifications/index.ts
@@ -7,6 +7,7 @@ import { optionsBuilder } from "../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("notifications", {
   icon: IconMessage,
+  refetchIntervalSeconds: 300,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       hideLogos: factory.switch({ defaultValue: false }),

--- a/packages/widgets/src/paperless-ngx/index.ts
+++ b/packages/widgets/src/paperless-ngx/index.ts
@@ -5,6 +5,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("paperlessNgx", {
   icon: IconFileText,
+  refetchIntervalSeconds: 900,
   supportedIntegrations: ["paperlessNgx"],
   integrationsRequired: true,
   createOptions() {

--- a/packages/widgets/src/releases/index.ts
+++ b/packages/widgets/src/releases/index.ts
@@ -14,6 +14,7 @@ const relativeDateSchema = z
 
 export const { definition, componentLoader } = createWidgetDefinition("releases", {
   icon: IconRocket,
+  refetchIntervalSeconds: 300,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       newReleaseWithin: factory.text({

--- a/packages/widgets/src/rssFeed/index.ts
+++ b/packages/widgets/src/rssFeed/index.ts
@@ -12,6 +12,7 @@ import { optionsBuilder } from "../options";
  */
 export const { definition, componentLoader } = createWidgetDefinition("rssFeed", {
   icon: IconRss,
+  refetchIntervalSeconds: 300,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       feedUrls: factory.multiText({

--- a/packages/widgets/src/smart-home/entity-state/index.ts
+++ b/packages/widgets/src/smart-home/entity-state/index.ts
@@ -7,6 +7,8 @@ import { optionsBuilder } from "../../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("smartHome-entityState", {
   icon: IconBinaryTree,
+  queryKey: [["widget", "smartHome"]],
+  refetchIntervalSeconds: 60,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       entityId: factory.text({

--- a/packages/widgets/src/speedtest-tracker/index.ts
+++ b/packages/widgets/src/speedtest-tracker/index.ts
@@ -5,6 +5,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("speedtestTracker", {
   icon: IconSpeedboat,
+  refetchIntervalSeconds: 600,
   createOptions() {
     return optionsBuilder.from(
       (factory) => ({

--- a/packages/widgets/src/stocks/index.ts
+++ b/packages/widgets/src/stocks/index.ts
@@ -13,6 +13,7 @@ const timeIntervalOptions = stockPriceTimeFrames.interval;
 
 export const { definition, componentLoader } = createWidgetDefinition("stockPrice", {
   icon: IconBuildingBank,
+  refetchIntervalSeconds: 300,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       stock: factory.text({

--- a/packages/widgets/src/system-disks/index.ts
+++ b/packages/widgets/src/system-disks/index.ts
@@ -6,6 +6,8 @@ import { createStorageVolumeMultiSelectOptions } from "../storage-volume-options
 
 export const { definition, componentLoader } = createWidgetDefinition("systemDisks", {
   icon: IconServer2,
+  queryKey: [["widget", "healthMonitoring"]],
+  refetchIntervalSeconds: 5,
   supportedIntegrations: ["dashDot", "openmediavault", "truenas", "unraid", "synology"],
   createOptions() {
     return optionsBuilder.from(

--- a/packages/widgets/src/system-resources/index.ts
+++ b/packages/widgets/src/system-resources/index.ts
@@ -14,6 +14,8 @@ const labelDisplayModeOptions = {
 
 export const { definition, componentLoader } = createWidgetDefinition("systemResources", {
   icon: IconGraphFilled,
+  queryKey: [["widget", "healthMonitoring"]],
+  refetchIntervalSeconds: 5,
   supportedIntegrations: ["dashDot", "openmediavault", "truenas", "unraid", "glances", "synology"],
   createOptions() {
     return optionsBuilder.from((factory) => ({

--- a/packages/widgets/src/timetable/index.ts
+++ b/packages/widgets/src/timetable/index.ts
@@ -8,6 +8,7 @@ import { optionsBuilder } from "../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("timetable", {
   icon: IconBusStop,
+  refetchIntervalSeconds: 60,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       baseUrl: factory.text({

--- a/packages/widgets/src/tracearr/index.ts
+++ b/packages/widgets/src/tracearr/index.ts
@@ -5,6 +5,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("tracearr", {
   icon: IconActivityHeartbeat,
+  refetchIntervalSeconds: 5,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       showStreams: factory.switch({

--- a/packages/widgets/src/umami/index.ts
+++ b/packages/widgets/src/umami/index.ts
@@ -8,6 +8,7 @@ export const timeFrameValues = ["today", "24h", "7d", "30d", "month", "lastMonth
 
 export const { definition, componentLoader } = createWidgetDefinition("umami", {
   icon: IconChartBar,
+  refetchIntervalSeconds: 300,
   supportedIntegrations: ["umami"],
   createOptions() {
     return optionsBuilder.from(

--- a/packages/widgets/src/ups/index.ts
+++ b/packages/widgets/src/ups/index.ts
@@ -7,6 +7,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("ups", {
   icon: IconBatteryCharging,
+  refetchIntervalSeconds: 60,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       showBattery: factory.switch({

--- a/packages/widgets/src/uptime-kuma/index.ts
+++ b/packages/widgets/src/uptime-kuma/index.ts
@@ -5,6 +5,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("uptimeKuma", {
   icon: IconHeartbeat,
+  refetchIntervalSeconds: 60,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       showAverageUptime: factory.switch({

--- a/packages/widgets/src/vpn/index.ts
+++ b/packages/widgets/src/vpn/index.ts
@@ -7,6 +7,7 @@ import { optionsBuilder } from "../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("vpn", {
   icon: IconShieldLock,
+  refetchIntervalSeconds: 300,
   createOptions() {
     return optionsBuilder.from(() => ({}));
   },

--- a/packages/widgets/src/weather/index.ts
+++ b/packages/widgets/src/weather/index.ts
@@ -7,6 +7,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("weather", {
   icon: IconCloud,
+  refetchIntervalSeconds: 60,
   createOptions() {
     return optionsBuilder.from(
       (factory) => ({


### PR DESCRIPTION
## Summary

Fixes #6268 — Since v1.69.0, the caching refactor replaced Redis pub/sub push with a global 30s client-side polling interval. This caused fast-refresh widgets (health-monitoring/Dashdot at 5s, dns-hole at 5s, etc.) to only update every 30s.

### Root cause

The v1.69.0 caching refactor (`f19033e0d`) removed Redis pub/sub subscriptions and replaced them with a single global `refetchInterval: 30_000` for all widget queries. The old system implicitly had per-widget refresh rates driven by each handler's `cacheDuration` — some as fast as 5 seconds.

### Changes

**Added `refetchIntervalSeconds` to `WidgetDefinition`** (`packages/widgets/src/definition.ts`)

Each widget that needs a non-default interval now declares it directly in its definition. The TRPC provider iterates all widget definitions and calls `setQueryDefaults` with the widget's `queryKey` (or auto-derived from widget kind as `["widget", kind]`).

Widgets whose kind doesn't match their tRPC path set `queryKey` explicitly (e.g. `dnsHoleSummary` → `queryKey: [["widget", "dnsHole"]]`, `systemResources` → `queryKey: [["widget", "healthMonitoring"]]`). Beszel already does this for cache sharing.

**Per-widget intervals (matching pre-v1.69.0 values):**

| Seconds | Widgets |
|---------|---------|
| 5 | healthMonitoring, systemResources, systemDisks, dnsHoleSummary, dnsHoleControls, downloads, mediaServer, tracearr, firewall |
| 15 | anchorNote |
| 20 | dockerContainers |
| 30 | coolify |
| 60 | calendar, mediaRequests-requestList, mediaRequests-requestStats, smartHome-entityState, ups, uptimeKuma, weather, timetable |
| 300 | indexerManager, mediaReleases, mediaTranscoding, networkControllerSummary, networkControllerStatus, notifications, rssFeed, stockPrice, minecraftServerStatus, vpn, archiveTeamWarrior, umami, releases |
| 600 | audioStats, speedtestTracker |
| 900 | immich-albumCarousel, immich-serverStats, paperlessNgx |

**Also changed:**
- Removed inline `refetchInterval: 30_000` from docker widget component (now on definition at 20s)
- No server-side `cacheTtlMs` changes — the global 10s default is sufficient for request dedup

### Testing
- `pnpm exec turbo typecheck --filter=@homarr/widgets --filter=@homarr/nextjs` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic, per-widget data refresh intervals across many widgets to keep dashboards up to date without manual reloads.
  - Improved refresh coordination by standardizing widget refresh behavior with consistent query identification.
  - Refresh cadences are now tailored per widget (from a few seconds to several minutes).

- **Bug Fixes**
  - Updated the Docker widget to stop its extra built-in polling, relying on the standard widget refresh configuration instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->