### PR TITLE
fix(widgets): add typed refetchInterval presets to WidgetDefinition

### DIFF
--- a/apps/nextjs/src/app/[locale]/_client-providers/trpc.tsx
+++ b/apps/nextjs/src/app/[locale]/_client-providers/trpc.tsx
@@ -2,6 +2,7 @@
 
 import type { PropsWithChildren } from "react";
 import { useState } from "react";
+import type { QueryKey } from "@tanstack/react-query";
 import { QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { ReactQueryStreamedHydration } from "@tanstack/react-query-next-experimental";
@@ -33,6 +34,7 @@ import {
 import { createHeadersCallbackForSource, getTrpcUrl } from "@homarr/api/shared";
 import { env } from "@homarr/common/env";
 import { showWarningNotification } from "@homarr/notifications";
+import { widgetImports } from "@homarr/widgets";
 
 import { createWidgetQueryPersister } from "./query-cache-persister";
 
@@ -90,6 +92,13 @@ export function TRPCReactProvider(props: PropsWithChildren) {
       },
     });
     client.setQueryDefaults([["widget"]], { refetchInterval: queryCacheDefaultRefetchIntervalMs });
+    for (const { definition } of Object.values(widgetImports)) {
+      const def = definition as { refetchInterval?: number | false; queryKey?: QueryKey; kind: string };
+      if (def.refetchInterval === undefined) continue;
+      const key = def.queryKey ?? [["widget", def.kind]];
+      const interval = def.refetchInterval === false ? false : def.refetchInterval * 1000;
+      client.setQueryDefaults(key, { refetchInterval: interval });
+    }
     return client;
   });
 

--- a/packages/widgets/src/definition.ts
+++ b/packages/widgets/src/definition.ts
@@ -67,9 +67,17 @@ export const createWidgetDefinition = <TKind extends WidgetKind, TDefinition ext
   withDynamicImport: createWithDynamicImport(kind, definition),
 });
 
+export const widgetRefetchInterval = {
+  fiveSeconds: 5,
+  never: false,
+} as const;
+
+export type WidgetRefetchInterval = (typeof widgetRefetchInterval)[keyof typeof widgetRefetchInterval];
+
 export interface WidgetDefinition {
   icon: TablerIcon;
   queryKey?: QueryKey;
+  refetchInterval?: WidgetRefetchInterval;
   supportedIntegrations?: IntegrationKind[];
   integrationsRequired?: boolean;
   maxIntegrations?: number;

--- a/packages/widgets/src/dns-hole/controls/index.ts
+++ b/packages/widgets/src/dns-hole/controls/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../../definition";
 import { IconDeviceGamepad, IconServerOff } from "@tabler/icons-react";
 
 import { getIntegrationKindsByCategory } from "@homarr/definitions";
@@ -9,6 +10,8 @@ export const widgetKind = "dnsHoleControls";
 
 export const { definition, componentLoader } = createWidgetDefinition(widgetKind, {
   icon: IconDeviceGamepad,
+  queryKey: [["widget", "dnsHole"]],
+  refetchInterval: widgetRefetchInterval.fiveSeconds,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       showToggleAllButtons: factory.switch({

--- a/packages/widgets/src/dns-hole/summary/index.ts
+++ b/packages/widgets/src/dns-hole/summary/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../../definition";
 import { IconAd, IconServerOff } from "@tabler/icons-react";
 
 import { getIntegrationKindsByCategory } from "@homarr/definitions";
@@ -9,6 +10,8 @@ export const widgetKind = "dnsHoleSummary";
 
 export const { definition, componentLoader } = createWidgetDefinition(widgetKind, {
   icon: IconAd,
+  queryKey: [["widget", "dnsHole"]],
+  refetchInterval: widgetRefetchInterval.fiveSeconds,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       usePiHoleColors: factory.switch({

--- a/packages/widgets/src/docker/component.tsx
+++ b/packages/widgets/src/docker/component.tsx
@@ -188,9 +188,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
     data,
     refetch,
     isFetching,
-  } = clientApi.docker.getContainers.useQuery(undefined, {
-    refetchInterval: 30_000,
-  });
+  } = clientApi.docker.getContainers.useQuery();
   const containers = data?.containers ?? [];
   const timestamp = useMemo(() => data?.timestamp ?? new Date(), [data?.timestamp]);
   const relativeTime = useTimeAgo(timestamp);

--- a/packages/widgets/src/docker/component.tsx
+++ b/packages/widgets/src/docker/component.tsx
@@ -184,11 +184,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
   const t = useScopedI18n("docker");
   const isTiny = width <= 256;
 
-  const {
-    data,
-    refetch,
-    isFetching,
-  } = clientApi.docker.getContainers.useQuery();
+  const { data, refetch, isFetching } = clientApi.docker.getContainers.useQuery();
   const containers = data?.containers ?? [];
   const timestamp = useMemo(() => data?.timestamp ?? new Date(), [data?.timestamp]);
   const relativeTime = useTimeAgo(timestamp);
@@ -302,9 +298,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
               {t("table.totalMemory", { memory: formatBytes(totals.memory) })}
             </Text>
 
-            <Tooltip
-              label={t("table.refresh.lastUpdated", { when: relativeTime })}
-            >
+            <Tooltip label={t("table.refresh.lastUpdated", { when: relativeTime })}>
               <ActionIcon
                 size="sm"
                 variant="transparent"

--- a/packages/widgets/src/downloads/index.ts
+++ b/packages/widgets/src/downloads/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconDownload } from "@tabler/icons-react";
 import { z } from "zod/v4";
 
@@ -33,6 +34,7 @@ const columnsSort = columnsList.filter((column) =>
 
 export const { definition, componentLoader } = createWidgetDefinition("downloads", {
   icon: IconDownload,
+  refetchInterval: widgetRefetchInterval.fiveSeconds,
   createOptions() {
     return optionsBuilder.from(
       (factory) => ({

--- a/packages/widgets/src/firewall/index.ts
+++ b/packages/widgets/src/firewall/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconWall, IconWallOff } from "@tabler/icons-react";
 
 import { getIntegrationKindsByCategory } from "@homarr/definitions";
@@ -7,6 +8,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("firewall", {
   icon: IconWall,
+  refetchInterval: widgetRefetchInterval.fiveSeconds,
   createOptions() {
     return optionsBuilder.from(() => ({}));
   },

--- a/packages/widgets/src/health-monitoring/index.ts
+++ b/packages/widgets/src/health-monitoring/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconHeartRateMonitor, IconServerOff } from "@tabler/icons-react";
 
 import { getIntegrationKindsByCategory } from "@homarr/definitions";
@@ -8,6 +9,7 @@ import { createStorageVolumeMultiSelectOptions } from "../storage-volume-options
 
 export const { definition, componentLoader } = createWidgetDefinition("healthMonitoring", {
   icon: IconHeartRateMonitor,
+  refetchInterval: widgetRefetchInterval.fiveSeconds,
   createOptions() {
     return optionsBuilder.from(
       (factory) => ({

--- a/packages/widgets/src/immich/album-carousel/index.ts
+++ b/packages/widgets/src/immich/album-carousel/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../../definition";
 import { IconPhoto } from "@tabler/icons-react";
 import z from "zod";
 
@@ -8,6 +9,8 @@ import { optionsBuilder } from "../../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("immich-albumCarousel", {
   icon: IconPhoto,
+  queryKey: [["widget", "immich"]],
+  refetchInterval: widgetRefetchInterval.never,
   supportedIntegrations: ["immich"],
   integrationsRequired: true,
   createOptions() {

--- a/packages/widgets/src/immich/server-stats/index.ts
+++ b/packages/widgets/src/immich/server-stats/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../../definition";
 import { IconGraphFilled } from "@tabler/icons-react";
 
 import { createWidgetDefinition } from "../../definition";
@@ -5,6 +6,8 @@ import { optionsBuilder } from "../../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("immich-serverStats", {
   icon: IconGraphFilled,
+  queryKey: [["widget", "immich"]],
+  refetchInterval: widgetRefetchInterval.never,
   supportedIntegrations: ["immich"],
   integrationsRequired: true,
   createOptions() {

--- a/packages/widgets/src/index.tsx
+++ b/packages/widgets/src/index.tsx
@@ -70,7 +70,9 @@ export type {
   WidgetContextMenuAction,
   WidgetContextActionProps,
   WidgetOptionsSettings,
+  WidgetRefetchInterval,
 } from "./definition";
+export { widgetRefetchInterval } from "./definition";
 export type { WidgetComponentProps };
 export type { WidgetOptionDefinition, WidgetOptionType } from "./options";
 

--- a/packages/widgets/src/indexer-manager/index.ts
+++ b/packages/widgets/src/indexer-manager/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconReportSearch, IconServerOff } from "@tabler/icons-react";
 
 import { getIntegrationKindsByCategory } from "@homarr/definitions";
@@ -7,6 +8,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("indexerManager", {
   icon: IconReportSearch,
+  refetchInterval: widgetRefetchInterval.never,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       openIndexerSiteInNewTab: factory.switch({

--- a/packages/widgets/src/media-releases/index.ts
+++ b/packages/widgets/src/media-releases/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconTicket } from "@tabler/icons-react";
 
 import { createWidgetDefinition } from "../definition";
@@ -5,6 +6,8 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("mediaReleases", {
   icon: IconTicket,
+  queryKey: [["widget", "mediaRelease"]],
+  refetchInterval: widgetRefetchInterval.never,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       layout: factory.select({

--- a/packages/widgets/src/media-server/index.ts
+++ b/packages/widgets/src/media-server/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconVideo } from "@tabler/icons-react";
 
 import { getIntegrationKindsByCategory } from "@homarr/definitions";
@@ -7,6 +8,7 @@ import { optionsBuilder } from "../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("mediaServer", {
   icon: IconVideo,
+  refetchInterval: widgetRefetchInterval.fiveSeconds,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       showOnlyPlaying: factory.switch({ defaultValue: true, withDescription: true }),

--- a/packages/widgets/src/media-transcoding/index.ts
+++ b/packages/widgets/src/media-transcoding/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconTransform } from "@tabler/icons-react";
 import { z } from "zod/v4";
 
@@ -11,6 +12,7 @@ export const views = ["workers", "queue", "statistics"] as const;
 
 export const { componentLoader, definition } = createWidgetDefinition("mediaTranscoding", {
   icon: IconTransform,
+  refetchInterval: widgetRefetchInterval.never,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       defaultView: factory.select({

--- a/packages/widgets/src/minecraft/server-status/index.ts
+++ b/packages/widgets/src/minecraft/server-status/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../../definition";
 import { IconBrandMinecraft } from "@tabler/icons-react";
 import { z } from "zod/v4";
 
@@ -6,6 +7,8 @@ import { optionsBuilder } from "../../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("minecraftServerStatus", {
   icon: IconBrandMinecraft,
+  queryKey: [["widget", "minecraft"]],
+  refetchInterval: widgetRefetchInterval.never,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       title: factory.text({ defaultValue: "" }),

--- a/packages/widgets/src/network-controller/network-status/index.ts
+++ b/packages/widgets/src/network-controller/network-status/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../../definition";
 import { IconServerOff, IconTopologyFull } from "@tabler/icons-react";
 
 import { getIntegrationKindsByCategory } from "@homarr/definitions";
@@ -7,6 +8,8 @@ import { optionsBuilder } from "../../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("networkControllerStatus", {
   icon: IconTopologyFull,
+  queryKey: [["widget", "networkController"]],
+  refetchInterval: widgetRefetchInterval.never,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       content: factory.select({

--- a/packages/widgets/src/network-controller/summary/index.ts
+++ b/packages/widgets/src/network-controller/summary/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../../definition";
 import { IconServerOff, IconTopologyFull } from "@tabler/icons-react";
 
 import { getIntegrationKindsByCategory } from "@homarr/definitions";
@@ -7,6 +8,8 @@ import { optionsBuilder } from "../../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("networkControllerSummary", {
   icon: IconTopologyFull,
+  queryKey: [["widget", "networkController"]],
+  refetchInterval: widgetRefetchInterval.never,
   createOptions() {
     return optionsBuilder.from(() => ({}));
   },

--- a/packages/widgets/src/notifications/index.ts
+++ b/packages/widgets/src/notifications/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconMessage } from "@tabler/icons-react";
 
 import { getIntegrationKindsByCategory } from "@homarr/definitions";
@@ -7,6 +8,7 @@ import { optionsBuilder } from "../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("notifications", {
   icon: IconMessage,
+  refetchInterval: widgetRefetchInterval.never,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       hideLogos: factory.switch({ defaultValue: false }),

--- a/packages/widgets/src/paperless-ngx/index.ts
+++ b/packages/widgets/src/paperless-ngx/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconFileText, IconServerOff } from "@tabler/icons-react";
 
 import { createWidgetDefinition } from "../definition";
@@ -5,6 +6,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("paperlessNgx", {
   icon: IconFileText,
+  refetchInterval: widgetRefetchInterval.never,
   supportedIntegrations: ["paperlessNgx"],
   integrationsRequired: true,
   createOptions() {

--- a/packages/widgets/src/releases/index.ts
+++ b/packages/widgets/src/releases/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconRocket } from "@tabler/icons-react";
 import { z } from "zod/v4";
 
@@ -14,6 +15,7 @@ const relativeDateSchema = z
 
 export const { definition, componentLoader } = createWidgetDefinition("releases", {
   icon: IconRocket,
+  refetchInterval: widgetRefetchInterval.never,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       newReleaseWithin: factory.text({

--- a/packages/widgets/src/rssFeed/index.ts
+++ b/packages/widgets/src/rssFeed/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconRss } from "@tabler/icons-react";
 import { z } from "zod/v4";
 
@@ -12,6 +13,7 @@ import { optionsBuilder } from "../options";
  */
 export const { definition, componentLoader } = createWidgetDefinition("rssFeed", {
   icon: IconRss,
+  refetchInterval: widgetRefetchInterval.never,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       feedUrls: factory.multiText({

--- a/packages/widgets/src/speedtest-tracker/index.ts
+++ b/packages/widgets/src/speedtest-tracker/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconServerOff, IconSpeedboat } from "@tabler/icons-react";
 
 import { createWidgetDefinition } from "../definition";
@@ -5,6 +6,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("speedtestTracker", {
   icon: IconSpeedboat,
+  refetchInterval: widgetRefetchInterval.never,
   createOptions() {
     return optionsBuilder.from(
       (factory) => ({

--- a/packages/widgets/src/stocks/index.ts
+++ b/packages/widgets/src/stocks/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconBuildingBank } from "@tabler/icons-react";
 
 import { createWidgetDefinition } from "../definition";
@@ -13,6 +14,7 @@ const timeIntervalOptions = stockPriceTimeFrames.interval;
 
 export const { definition, componentLoader } = createWidgetDefinition("stockPrice", {
   icon: IconBuildingBank,
+  refetchInterval: widgetRefetchInterval.never,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       stock: factory.text({

--- a/packages/widgets/src/system-disks/index.ts
+++ b/packages/widgets/src/system-disks/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconServer2 } from "@tabler/icons-react";
 
 import { createWidgetDefinition } from "../definition";
@@ -6,6 +7,8 @@ import { createStorageVolumeMultiSelectOptions } from "../storage-volume-options
 
 export const { definition, componentLoader } = createWidgetDefinition("systemDisks", {
   icon: IconServer2,
+  queryKey: [["widget", "healthMonitoring"]],
+  refetchInterval: widgetRefetchInterval.fiveSeconds,
   supportedIntegrations: ["dashDot", "openmediavault", "truenas", "unraid", "synology"],
   createOptions() {
     return optionsBuilder.from(

--- a/packages/widgets/src/system-resources/index.ts
+++ b/packages/widgets/src/system-resources/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconAlignLeft, IconEyeOff, IconGraphFilled, IconListDetails, IconPhoto } from "@tabler/icons-react";
 
 import { objectEntries } from "@homarr/common";
@@ -14,6 +15,8 @@ const labelDisplayModeOptions = {
 
 export const { definition, componentLoader } = createWidgetDefinition("systemResources", {
   icon: IconGraphFilled,
+  queryKey: [["widget", "healthMonitoring"]],
+  refetchInterval: widgetRefetchInterval.fiveSeconds,
   supportedIntegrations: ["dashDot", "openmediavault", "truenas", "unraid", "glances", "synology"],
   createOptions() {
     return optionsBuilder.from((factory) => ({

--- a/packages/widgets/src/tracearr/index.ts
+++ b/packages/widgets/src/tracearr/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconActivityHeartbeat, IconServerOff } from "@tabler/icons-react";
 
 import { createWidgetDefinition } from "../definition";
@@ -5,6 +6,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("tracearr", {
   icon: IconActivityHeartbeat,
+  refetchInterval: widgetRefetchInterval.fiveSeconds,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       showStreams: factory.switch({

--- a/packages/widgets/src/umami/index.ts
+++ b/packages/widgets/src/umami/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconChartBar, IconServerOff } from "@tabler/icons-react";
 import { z } from "zod/v4";
 
@@ -8,6 +9,7 @@ export const timeFrameValues = ["today", "24h", "7d", "30d", "month", "lastMonth
 
 export const { definition, componentLoader } = createWidgetDefinition("umami", {
   icon: IconChartBar,
+  refetchInterval: widgetRefetchInterval.never,
   supportedIntegrations: ["umami"],
   createOptions() {
     return optionsBuilder.from(

--- a/packages/widgets/src/vpn/index.ts
+++ b/packages/widgets/src/vpn/index.ts
@@ -1,3 +1,4 @@
+import { widgetRefetchInterval } from "../definition";
 import { IconShieldLock } from "@tabler/icons-react";
 
 import { getIntegrationKindsByCategory } from "@homarr/definitions";
@@ -7,6 +8,7 @@ import { optionsBuilder } from "../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("vpn", {
   icon: IconShieldLock,
+  refetchInterval: widgetRefetchInterval.never,
   createOptions() {
     return optionsBuilder.from(() => ({}));
   },


### PR DESCRIPTION
## Summary

Fixes #6268 — Since v1.69.0, the caching refactor replaced Redis pub/sub push with a global 30s client polling interval. Live monitoring widgets (health-monitoring/Dashdot at 5s, dns-hole at 5s) were stuck refreshing every 30s.

### Changes

**Added typed `WidgetRefetchInterval` preset** to `WidgetDefinition`:

```ts
export const widgetRefetchInterval = {
  fiveSeconds: 5,
  never: false,
} as const;
```

- `fiveSeconds` — poll every 5 seconds (live monitoring)
- `never` — fetch on mount only, no background polling (manual refresh via context menu still works)
- `undefined` (absent) — use the global 30s default

**9 widgets get `fiveSeconds`** (live monitoring that needs fast updates):
healthMonitoring, systemResources, systemDisks, dnsHoleSummary, dnsHoleControls, downloads, mediaServer, tracearr, firewall

**16 widgets get `never`** (slow data, fetch-on-mount is enough — context menu refetch + page reload cover the rest):
indexerManager, mediaReleases, mediaTranscoding, networkControllerSummary, networkControllerStatus, notifications, rssFeed, stockPrice, minecraftServerStatus, vpn, umami, releases, speedtestTracker, immich-albumCarousel, immich-serverStats, paperlessNgx

**Remaining widgets** use the 30s global default (calendar, mediaRequests, smartHome, ups, uptimeKuma, weather, timetable, coolify, anchorNote, docker, etc.)

**Also changed:**
- Removed inline `refetchInterval: 30_000` from docker widget component (now uses 30s global default)
- Widgets whose kind doesn't match their tRPC path set `queryKey` explicitly (e.g. `dnsHoleSummary` → `queryKey: [["widget", "dnsHole"]]`)

### Testing
- `pnpm exec turbo typecheck --filter=@homarr/widgets --filter=@homarr/nextjs` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable refresh intervals for widgets.
  * Enabled automatic five-second updates for selected monitoring and status widgets.
  * Disabled automatic refresh for widgets where periodic updates are unnecessary.
  * Improved query consistency for related widget data.
* **Bug Fixes**
  * Removed redundant automatic polling from the Docker widget to reduce unnecessary refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->