### PR TITLE
fix(widgets): add refetchInterval to WidgetDefinition for per-widget polling

### DIFF
--- a/apps/nextjs/src/app/[locale]/_client-providers/trpc.tsx
+++ b/apps/nextjs/src/app/[locale]/_client-providers/trpc.tsx
@@ -2,6 +2,7 @@
 
 import type { PropsWithChildren } from "react";
 import { useState } from "react";
+import type { QueryKey } from "@tanstack/react-query";
 import { QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { ReactQueryStreamedHydration } from "@tanstack/react-query-next-experimental";
@@ -33,6 +34,7 @@ import {
 import { createHeadersCallbackForSource, getTrpcUrl } from "@homarr/api/shared";
 import { env } from "@homarr/common/env";
 import { showWarningNotification } from "@homarr/notifications";
+import { widgetImports } from "@homarr/widgets";
 
 import { createWidgetQueryPersister } from "./query-cache-persister";
 
@@ -90,6 +92,13 @@ export function TRPCReactProvider(props: PropsWithChildren) {
       },
     });
     client.setQueryDefaults([["widget"]], { refetchInterval: queryCacheDefaultRefetchIntervalMs });
+    for (const { definition } of Object.values(widgetImports)) {
+      const def = definition as { refetchInterval?: number | null; queryKey?: QueryKey; kind: string };
+      if (def.refetchInterval === undefined) continue;
+      const key = def.queryKey ?? [["widget", def.kind]];
+      const interval = def.refetchInterval === null ? false : def.refetchInterval * 1000;
+      client.setQueryDefaults(key, { refetchInterval: interval });
+    }
     return client;
   });
 

--- a/packages/widgets/src/definition.ts
+++ b/packages/widgets/src/definition.ts
@@ -70,6 +70,7 @@ export const createWidgetDefinition = <TKind extends WidgetKind, TDefinition ext
 export interface WidgetDefinition {
   icon: TablerIcon;
   queryKey?: QueryKey;
+  refetchInterval?: number | null;
   supportedIntegrations?: IntegrationKind[];
   integrationsRequired?: boolean;
   maxIntegrations?: number;

--- a/packages/widgets/src/dns-hole/controls/index.ts
+++ b/packages/widgets/src/dns-hole/controls/index.ts
@@ -9,6 +9,8 @@ export const widgetKind = "dnsHoleControls";
 
 export const { definition, componentLoader } = createWidgetDefinition(widgetKind, {
   icon: IconDeviceGamepad,
+  queryKey: [["widget", "dnsHole"]],
+  refetchInterval: 5,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       showToggleAllButtons: factory.switch({

--- a/packages/widgets/src/dns-hole/summary/index.ts
+++ b/packages/widgets/src/dns-hole/summary/index.ts
@@ -9,6 +9,8 @@ export const widgetKind = "dnsHoleSummary";
 
 export const { definition, componentLoader } = createWidgetDefinition(widgetKind, {
   icon: IconAd,
+  queryKey: [["widget", "dnsHole"]],
+  refetchInterval: 5,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       usePiHoleColors: factory.switch({

--- a/packages/widgets/src/docker/component.tsx
+++ b/packages/widgets/src/docker/component.tsx
@@ -188,9 +188,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
     data,
     refetch,
     isFetching,
-  } = clientApi.docker.getContainers.useQuery(undefined, {
-    refetchInterval: 30_000,
-  });
+  } = clientApi.docker.getContainers.useQuery();
   const containers = data?.containers ?? [];
   const timestamp = useMemo(() => data?.timestamp ?? new Date(), [data?.timestamp]);
   const relativeTime = useTimeAgo(timestamp);

--- a/packages/widgets/src/docker/component.tsx
+++ b/packages/widgets/src/docker/component.tsx
@@ -184,11 +184,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
   const t = useScopedI18n("docker");
   const isTiny = width <= 256;
 
-  const {
-    data,
-    refetch,
-    isFetching,
-  } = clientApi.docker.getContainers.useQuery();
+  const { data, refetch, isFetching } = clientApi.docker.getContainers.useQuery();
   const containers = data?.containers ?? [];
   const timestamp = useMemo(() => data?.timestamp ?? new Date(), [data?.timestamp]);
   const relativeTime = useTimeAgo(timestamp);
@@ -302,9 +298,7 @@ export default function DockerWidget({ options, width, isEditMode }: WidgetCompo
               {t("table.totalMemory", { memory: formatBytes(totals.memory) })}
             </Text>
 
-            <Tooltip
-              label={t("table.refresh.lastUpdated", { when: relativeTime })}
-            >
+            <Tooltip label={t("table.refresh.lastUpdated", { when: relativeTime })}>
               <ActionIcon
                 size="sm"
                 variant="transparent"

--- a/packages/widgets/src/downloads/index.ts
+++ b/packages/widgets/src/downloads/index.ts
@@ -33,6 +33,7 @@ const columnsSort = columnsList.filter((column) =>
 
 export const { definition, componentLoader } = createWidgetDefinition("downloads", {
   icon: IconDownload,
+  refetchInterval: 5,
   createOptions() {
     return optionsBuilder.from(
       (factory) => ({

--- a/packages/widgets/src/firewall/index.ts
+++ b/packages/widgets/src/firewall/index.ts
@@ -7,6 +7,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("firewall", {
   icon: IconWall,
+  refetchInterval: 5,
   createOptions() {
     return optionsBuilder.from(() => ({}));
   },

--- a/packages/widgets/src/health-monitoring/index.ts
+++ b/packages/widgets/src/health-monitoring/index.ts
@@ -8,6 +8,7 @@ import { createStorageVolumeMultiSelectOptions } from "../storage-volume-options
 
 export const { definition, componentLoader } = createWidgetDefinition("healthMonitoring", {
   icon: IconHeartRateMonitor,
+  refetchInterval: 5,
   createOptions() {
     return optionsBuilder.from(
       (factory) => ({

--- a/packages/widgets/src/immich/album-carousel/index.ts
+++ b/packages/widgets/src/immich/album-carousel/index.ts
@@ -8,6 +8,8 @@ import { optionsBuilder } from "../../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("immich-albumCarousel", {
   icon: IconPhoto,
+  queryKey: [["widget", "immich"]],
+  refetchInterval: null,
   supportedIntegrations: ["immich"],
   integrationsRequired: true,
   createOptions() {

--- a/packages/widgets/src/immich/server-stats/index.ts
+++ b/packages/widgets/src/immich/server-stats/index.ts
@@ -5,6 +5,8 @@ import { optionsBuilder } from "../../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("immich-serverStats", {
   icon: IconGraphFilled,
+  queryKey: [["widget", "immich"]],
+  refetchInterval: null,
   supportedIntegrations: ["immich"],
   integrationsRequired: true,
   createOptions() {

--- a/packages/widgets/src/indexer-manager/index.ts
+++ b/packages/widgets/src/indexer-manager/index.ts
@@ -7,6 +7,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("indexerManager", {
   icon: IconReportSearch,
+  refetchInterval: null,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       openIndexerSiteInNewTab: factory.switch({

--- a/packages/widgets/src/media-releases/index.ts
+++ b/packages/widgets/src/media-releases/index.ts
@@ -5,6 +5,8 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("mediaReleases", {
   icon: IconTicket,
+  queryKey: [["widget", "mediaRelease"]],
+  refetchInterval: null,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       layout: factory.select({

--- a/packages/widgets/src/media-server/index.ts
+++ b/packages/widgets/src/media-server/index.ts
@@ -7,6 +7,7 @@ import { optionsBuilder } from "../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("mediaServer", {
   icon: IconVideo,
+  refetchInterval: 5,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       showOnlyPlaying: factory.switch({ defaultValue: true, withDescription: true }),

--- a/packages/widgets/src/media-transcoding/index.ts
+++ b/packages/widgets/src/media-transcoding/index.ts
@@ -11,6 +11,7 @@ export const views = ["workers", "queue", "statistics"] as const;
 
 export const { componentLoader, definition } = createWidgetDefinition("mediaTranscoding", {
   icon: IconTransform,
+  refetchInterval: null,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       defaultView: factory.select({

--- a/packages/widgets/src/minecraft/server-status/index.ts
+++ b/packages/widgets/src/minecraft/server-status/index.ts
@@ -6,6 +6,8 @@ import { optionsBuilder } from "../../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("minecraftServerStatus", {
   icon: IconBrandMinecraft,
+  queryKey: [["widget", "minecraft"]],
+  refetchInterval: null,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       title: factory.text({ defaultValue: "" }),

--- a/packages/widgets/src/network-controller/network-status/index.ts
+++ b/packages/widgets/src/network-controller/network-status/index.ts
@@ -7,6 +7,8 @@ import { optionsBuilder } from "../../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("networkControllerStatus", {
   icon: IconTopologyFull,
+  queryKey: [["widget", "networkController"]],
+  refetchInterval: null,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       content: factory.select({

--- a/packages/widgets/src/network-controller/summary/index.ts
+++ b/packages/widgets/src/network-controller/summary/index.ts
@@ -7,6 +7,8 @@ import { optionsBuilder } from "../../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("networkControllerSummary", {
   icon: IconTopologyFull,
+  queryKey: [["widget", "networkController"]],
+  refetchInterval: null,
   createOptions() {
     return optionsBuilder.from(() => ({}));
   },

--- a/packages/widgets/src/notifications/index.ts
+++ b/packages/widgets/src/notifications/index.ts
@@ -7,6 +7,7 @@ import { optionsBuilder } from "../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("notifications", {
   icon: IconMessage,
+  refetchInterval: null,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       hideLogos: factory.switch({ defaultValue: false }),

--- a/packages/widgets/src/paperless-ngx/index.ts
+++ b/packages/widgets/src/paperless-ngx/index.ts
@@ -5,6 +5,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("paperlessNgx", {
   icon: IconFileText,
+  refetchInterval: null,
   supportedIntegrations: ["paperlessNgx"],
   integrationsRequired: true,
   createOptions() {

--- a/packages/widgets/src/releases/index.ts
+++ b/packages/widgets/src/releases/index.ts
@@ -14,6 +14,7 @@ const relativeDateSchema = z
 
 export const { definition, componentLoader } = createWidgetDefinition("releases", {
   icon: IconRocket,
+  refetchInterval: null,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       newReleaseWithin: factory.text({

--- a/packages/widgets/src/rssFeed/index.ts
+++ b/packages/widgets/src/rssFeed/index.ts
@@ -12,6 +12,7 @@ import { optionsBuilder } from "../options";
  */
 export const { definition, componentLoader } = createWidgetDefinition("rssFeed", {
   icon: IconRss,
+  refetchInterval: null,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       feedUrls: factory.multiText({

--- a/packages/widgets/src/speedtest-tracker/index.ts
+++ b/packages/widgets/src/speedtest-tracker/index.ts
@@ -5,6 +5,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("speedtestTracker", {
   icon: IconSpeedboat,
+  refetchInterval: null,
   createOptions() {
     return optionsBuilder.from(
       (factory) => ({

--- a/packages/widgets/src/stocks/index.ts
+++ b/packages/widgets/src/stocks/index.ts
@@ -13,6 +13,7 @@ const timeIntervalOptions = stockPriceTimeFrames.interval;
 
 export const { definition, componentLoader } = createWidgetDefinition("stockPrice", {
   icon: IconBuildingBank,
+  refetchInterval: null,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       stock: factory.text({

--- a/packages/widgets/src/system-disks/index.ts
+++ b/packages/widgets/src/system-disks/index.ts
@@ -6,6 +6,8 @@ import { createStorageVolumeMultiSelectOptions } from "../storage-volume-options
 
 export const { definition, componentLoader } = createWidgetDefinition("systemDisks", {
   icon: IconServer2,
+  queryKey: [["widget", "healthMonitoring"]],
+  refetchInterval: 5,
   supportedIntegrations: ["dashDot", "openmediavault", "truenas", "unraid", "synology"],
   createOptions() {
     return optionsBuilder.from(

--- a/packages/widgets/src/system-resources/index.ts
+++ b/packages/widgets/src/system-resources/index.ts
@@ -14,6 +14,8 @@ const labelDisplayModeOptions = {
 
 export const { definition, componentLoader } = createWidgetDefinition("systemResources", {
   icon: IconGraphFilled,
+  queryKey: [["widget", "healthMonitoring"]],
+  refetchInterval: 5,
   supportedIntegrations: ["dashDot", "openmediavault", "truenas", "unraid", "glances", "synology"],
   createOptions() {
     return optionsBuilder.from((factory) => ({

--- a/packages/widgets/src/tracearr/index.ts
+++ b/packages/widgets/src/tracearr/index.ts
@@ -5,6 +5,7 @@ import { optionsBuilder } from "../options";
 
 export const { definition, componentLoader } = createWidgetDefinition("tracearr", {
   icon: IconActivityHeartbeat,
+  refetchInterval: 5,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       showStreams: factory.switch({

--- a/packages/widgets/src/umami/index.ts
+++ b/packages/widgets/src/umami/index.ts
@@ -8,6 +8,7 @@ export const timeFrameValues = ["today", "24h", "7d", "30d", "month", "lastMonth
 
 export const { definition, componentLoader } = createWidgetDefinition("umami", {
   icon: IconChartBar,
+  refetchInterval: null,
   supportedIntegrations: ["umami"],
   createOptions() {
     return optionsBuilder.from(

--- a/packages/widgets/src/vpn/index.ts
+++ b/packages/widgets/src/vpn/index.ts
@@ -7,6 +7,7 @@ import { optionsBuilder } from "../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("vpn", {
   icon: IconShieldLock,
+  refetchInterval: null,
   createOptions() {
     return optionsBuilder.from(() => ({}));
   },


### PR DESCRIPTION
## Summary

Tries to improve #6268 — Since v1.69.0, the caching refactor replaced Redis pub/sub push with a global 30s client polling interval. Live monitoring widgets (health-monitoring/Dashdot at 5s, dns-hole at 5s) were stuck refreshing every 30s.

### Changes

Added `refetchInterval?: number | null` to `WidgetDefinition`:
- `number` — poll every N seconds (e.g. `refetchInterval: 5` for live monitoring)
- `null` — fetch on mount only, no background polling (context menu refetch still works)
- `undefined` (absent) — use the global 30s default

**9 widgets set `refetchInterval: 5`** (live monitoring):
healthMonitoring, systemResources, systemDisks, dnsHoleSummary, dnsHoleControls, downloads, mediaServer, tracearr, firewall

**16 widgets set `refetchInterval: null`** (slow data, mount-only):
indexerManager, mediaReleases, mediaTranscoding, networkControllerSummary, networkControllerStatus, notifications, rssFeed, stockPrice, minecraftServerStatus, vpn, umami, releases, speedtestTracker, immich-albumCarousel, immich-serverStats, paperlessNgx

**Remaining widgets** use the 30s global default.

Also removed inline `refetchInterval: 30_000` from docker widget component.

### Testing
- `pnpm exec turbo typecheck --filter=@homarr/widgets --filter=@homarr/nextjs` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable refresh intervals for individual widgets.
  * Enabled automatic updates every five seconds for selected monitoring, networking, media, and download widgets.
  * Added explicit controls to disable automatic refreshing for widgets whose data does not require polling.
  * Improved data grouping for related widget information, supporting more consistent updates across the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->