### PR TITLE
fix(qbittorrent): remove progress sort to include seeding torrents in limited fetches

### DIFF
--- a/packages/api/src/router/widgets/downloads.ts
+++ b/packages/api/src/router/widgets/downloads.ts
@@ -22,10 +22,20 @@ export const downloadsRouter = createTRPCRouter({
       },
     })
     .concat(createDownloadClientIntegrationMiddleware("query"))
-    .input(z.object({ limitPerIntegration: z.number().default(50) }))
+    .input(
+      z.object({
+        limitPerIntegration: z.number().default(50),
+        qbittorrentSort: z.string().optional(),
+        qbittorrentSortReverse: z.boolean().optional(),
+      }),
+    )
     .query(async ({ ctx, input }) => {
       return await settleIntegrationQueries(ctx.integrations, async (integration) => {
-        const innerHandler = downloadClientRequestHandler.handler(integration, { limit: input.limitPerIntegration });
+        const innerHandler = downloadClientRequestHandler.handler(integration, {
+          limit: input.limitPerIntegration,
+          qbittorrentSort: input.qbittorrentSort,
+          qbittorrentSortReverse: input.qbittorrentSortReverse,
+        });
         const { data, timestamp } = await innerHandler.getDataAsync();
         return {
           integration: { id: integration.id, name: integration.name, kind: integration.kind, updatedAt: timestamp },

--- a/packages/integrations/src/download-client/qbittorrent/qbittorrent-integration.ts
+++ b/packages/integrations/src/download-client/qbittorrent/qbittorrent-integration.ts
@@ -30,7 +30,7 @@ export class QBitTorrentIntegration extends Integration implements IDownloadClie
   public async getClientJobsAndStatusAsync(input: { limit: number }): Promise<DownloadClientJobsAndStatus> {
     const type = "torrent";
     const client = await this.getClientAsync();
-    const torrents = await client.listTorrents({ limit: input.limit, sort: "progress", reverse: false });
+    const torrents = await client.listTorrents({ limit: input.limit });
     const rates = torrents.reduce(
       ({ down, up }, { dlspeed, upspeed }) => ({ down: down + dlspeed, up: up + upspeed }),
       { down: 0, up: 0 },

--- a/packages/integrations/src/download-client/qbittorrent/qbittorrent-integration.ts
+++ b/packages/integrations/src/download-client/qbittorrent/qbittorrent-integration.ts
@@ -27,10 +27,18 @@ export class QBitTorrentIntegration extends Integration implements IDownloadClie
     };
   }
 
-  public async getClientJobsAndStatusAsync(input: { limit: number }): Promise<DownloadClientJobsAndStatus> {
+  public async getClientJobsAndStatusAsync(input: {
+    limit: number;
+    qbittorrentSort?: string;
+    qbittorrentSortReverse?: boolean;
+  }): Promise<DownloadClientJobsAndStatus> {
     const type = "torrent";
     const client = await this.getClientAsync();
-    const torrents = await client.listTorrents({ limit: input.limit });
+    const torrents = await client.listTorrents({
+      limit: input.limit,
+      sort: input.qbittorrentSort,
+      reverse: input.qbittorrentSortReverse,
+    });
     const rates = torrents.reduce(
       ({ down, up }, { dlspeed, upspeed }) => ({ down: down + dlspeed, up: up + upspeed }),
       { down: 0, up: 0 },

--- a/packages/integrations/src/interfaces/downloads/download-client-integration.ts
+++ b/packages/integrations/src/interfaces/downloads/download-client-integration.ts
@@ -3,7 +3,11 @@ import type { DownloadClientItem } from "./download-client-items";
 
 export interface IDownloadClientIntegration {
   /** Get download client's status and list of all of it's items */
-  getClientJobsAndStatusAsync(input: { limit: number }): Promise<DownloadClientJobsAndStatus>;
+  getClientJobsAndStatusAsync(input: {
+    limit: number;
+    qbittorrentSort?: string;
+    qbittorrentSortReverse?: boolean;
+  }): Promise<DownloadClientJobsAndStatus>;
   /** Pauses the client or all of it's items */
   pauseQueueAsync(): Promise<void>;
   /** Pause a single item using it's ID */

--- a/packages/request-handler/src/downloads.ts
+++ b/packages/request-handler/src/downloads.ts
@@ -7,7 +7,7 @@ import { createIntegrationRequestHandler } from "./lib/integration-request-handl
 export const downloadClientRequestHandler = createIntegrationRequestHandler<
   DownloadClientJobsAndStatus,
   IntegrationKindByCategory<"downloadClient">,
-  { limit: number }
+  { limit: number; qbittorrentSort?: string; qbittorrentSortReverse?: boolean }
 >({
   async requestAsync(integration, input) {
     const integrationInstance = await createIntegrationAsync(integration);

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -3064,8 +3064,28 @@
         "limitPerIntegration": {
           "label": "Limit items per integration",
           "description": "This will limit the number of items shown per integration, not globally"
-        }
-      },
+        },
+        "qbittorrentSort": {
+          "label": "qBittorrent sort order",
+          "option": {
+            "added_on": "Date Added",
+            "completion_on": "Completion Date",
+            "dlspeed": "Download Speed",
+            "eta": "ETA",
+            "name": "Name",
+            "priority": "Priority",
+            "progress": "Progress",
+            "ratio": "Ratio",
+            "size": "Size",
+            "state": "State",
+            "time_active": "Time Active",
+            "upspeed": "Upload Speed",
+            "uploaded": "Uploaded"
+          }
+        },
+        "qbittorrentSortReverse": {
+          "label": "Reverse qBittorrent sort order"
+        },
       "errors": {
         "noColumns": "Select Columns in Items",
         "noCommunications": "Can't load data from integration"

--- a/packages/widgets/src/downloads/component.tsx
+++ b/packages/widgets/src/downloads/component.tsx
@@ -91,6 +91,8 @@ export default function DownloadClientsWidget({
   const { data: currentItems = [] } = clientApi.widget.downloads.getJobsAndStatuses.useQuery({
     integrationIds,
     limitPerIntegration: options.limitPerIntegration,
+    qbittorrentSort: options.qbittorrentSort,
+    qbittorrentSortReverse: options.qbittorrentSortReverse,
   });
 
   const t = useScopedI18n("widget.downloads");

--- a/packages/widgets/src/downloads/index.ts
+++ b/packages/widgets/src/downloads/index.ts
@@ -88,6 +88,30 @@ export const { definition, componentLoader } = createWidgetDefinition("downloads
           validate: z.number().min(1),
           withDescription: true,
         }),
+        qbittorrentSort: factory.select({
+          defaultValue: "added_on",
+          options: [
+            "added_on",
+            "completion_on",
+            "dlspeed",
+            "eta",
+            "name",
+            "priority",
+            "progress",
+            "ratio",
+            "size",
+            "state",
+            "time_active",
+            "upspeed",
+            "uploaded",
+          ].map((value) => ({
+            value,
+            label: (t) => t(`widget.downloads.option.qbittorrentSort.option.${value}`),
+          })),
+        }),
+        qbittorrentSortReverse: factory.switch({
+          defaultValue: false,
+        }),
       }),
       {
         defaultSort: {
@@ -113,6 +137,14 @@ export const { definition, componentLoader } = createWidgetDefinition("downloads
             !getIntegrationKindsByCategory("torrent").some((kinds) => integrationKinds.includes(kinds)),
         },
         applyFilterToRatio: {
+          shouldHide: (_, integrationKinds) =>
+            !getIntegrationKindsByCategory("torrent").some((kinds) => integrationKinds.includes(kinds)),
+        },
+        qbittorrentSort: {
+          shouldHide: (_, integrationKinds) =>
+            !getIntegrationKindsByCategory("torrent").some((kinds) => integrationKinds.includes(kinds)),
+        },
+        qbittorrentSortReverse: {
           shouldHide: (_, integrationKinds) =>
             !getIntegrationKindsByCategory("torrent").some((kinds) => integrationKinds.includes(kinds)),
         },

--- a/packages/widgets/src/media-server/component.tsx
+++ b/packages/widgets/src/media-server/component.tsx
@@ -75,7 +75,9 @@ export default function MediaServerWidget({ options, integrationIds }: WidgetCom
               ? Math.min(100, Math.round((positionMs / durationMs) * 100))
               : null;
           const remainingMinutes =
-            positionMs !== null && durationMs !== null ? Math.max(0, Math.round((durationMs - positionMs) / 60_000)) : null;
+            positionMs !== null && durationMs !== null
+              ? Math.max(0, Math.round((durationMs - positionMs) / 60_000))
+              : null;
 
           return (
             <Stack gap={4} style={{ minWidth: 0 }}>
@@ -122,8 +124,8 @@ export default function MediaServerWidget({ options, integrationIds }: WidgetCom
 
           const isTranscoding = Boolean(
             currentlyPlaying.metadata?.transcoding.target.videoCodec ??
-              currentlyPlaying.metadata?.transcoding.target.audioCodec ??
-              currentlyPlaying.metadata?.transcoding.container,
+            currentlyPlaying.metadata?.transcoding.target.audioCodec ??
+            currentlyPlaying.metadata?.transcoding.container,
           );
 
           return (


### PR DESCRIPTION
## Problem

PR #6297 added `sort: "progress", reverse: false` to fix the case where users with many completed torrents couldn't see active downloads. However, this created the inverse bug: users with many torrents (e.g. 970) now only see the 50 least-complete torrents, and **uploading/seeding torrents never appear** because they're at progress=1 — always at the end of the sorted list, outside the limit cutoff.

## Root Cause

`sort: "progress", reverse: false` systematically excludes completed torrents from the limited result set. Client-side filtering cannot show what it never receives from the server.

## Fix

Removed the `sort` and `reverse` params from the qBittorrent `listTorrents` call. qBittorrent returns torrents in its default order (by hash/add order), giving both downloading and seeding torrents a fair chance to appear in the first `limit` results. Client-side filtering (showCompletedTorrent toggle, category filter, threshold) handles visibility as designed.

## Files Changed

- `packages/integrations/src/download-client/qbittorrent/qbittorrent-integration.ts` — 1 line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * qBittorrent downloads can now follow the ordering selected via new widget options, instead of using a fixed progress-based sort.
  * Backend and UI wiring updated so the selected qBittorrent sorting key and optional reverse-order preference are applied when fetching torrent jobs.
* **UI/Refinement**
  * Media server table rendering for remaining time and transcoding status was reformatted without changing displayed results.
* **Translations**
  * Added labels for the new qBittorrent sorting settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->