### PR TITLE
fix(widgets): restore proportional column widths in the downloads widget

### DIFF
--- a/packages/widgets/src/downloads/component.tsx
+++ b/packages/widgets/src/downloads/component.tsx
@@ -291,6 +291,10 @@ export default function DownloadClientsWidget({
         accessorKey: key,
         header: key,
         size: columnsRatios[key],
+        // Also pin minSize to the ratio: mantine-react-table clamps size up to the
+        // default minSize (40px), which flattens every column to equal width and
+        // nullifies columnsRatios (e.g. the wide "name" column). See #4157.
+        minSize: columnsRatios[key],
         Header: () =>
           showHeader ? (
             <Text fz="xs" fw={700}>


### PR DESCRIPTION
## What

The download-client widget defines a `columnsRatios` table (e.g. `name: 16`) and applies it via the column `size`, but never sets `minSize`. mantine-react-table clamps `size` **up** to its default `minSize` (40px), so every column ends up the same width and the ratios — including the wide **Job Name** column — are silently ignored. That is also why the reporter's `--col-name-size` custom-CSS workaround was needed: it overwrites the clamped variable directly.

## Fix

Pin `minSize` to the same ratio value, so the clamp becomes a no-op and each column keeps its intended proportion (the name column gets the largest share). Icon-only columns don't collapse because the table layout floors them at their content width.

Fixes #4157

### Checklist
- [x] Targets the `dev` branch
- [x] Conventional commit
- [x] Typechecked `@homarr/widgets` locally (clean). Purely a layout change — no tests reference column sizing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved downloads table column sizing to preserve the intended width ratios.
  * Prevented columns from being compressed or flattened when displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->