### PR TITLE
fix(docker): disable the broken full-screen toggle on the container table

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/tools/docker/docker-table.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/tools/docker/docker-table.tsx
@@ -193,6 +193,10 @@ export function DockerTable({ initialData }: DockerTableProps) {
     positionToolbarAlertBanner: "top",
     enableTableFooter: false,
     enableBottomToolbar: false,
+    // MRT's built-in full-screen mode does not stretch the table to fill the
+    // viewport, so with few containers it renders as a thin strip (#6230). Disable
+    // it, matching the other management tables (users, invites).
+    enableFullScreenToggle: false,
     positionGlobalFilter: "right",
     mantineSearchTextInputProps: {
       placeholder: tDocker("table.search", { count: String(containers.length) }),


### PR DESCRIPTION
## What

The Docker management table leaves mantine-react-table's default full-screen toggle enabled. MRT's full-screen mode doesn't stretch the table to fill the viewport, so with only a few containers it renders as a thin strip across the top of the screen (#6230).

## Fix

Add `enableFullScreenToggle: false`, matching the convention already used across the app — the users and invites management tables, the Docker widget and the media-server widget all set exactly this.

Fixes #6230

### Checklist
- [x] Targets the `dev` branch
- [x] Conventional commit
- [x] One-line change matching the existing tables; no tests reference this table.

> Note: the same strip behaviour affects a few other management tables (Kubernetes, tasks, groups) which likewise omit the flag. Kept out of scope here to stay focused on #6230, but happy to disable it there too in a follow-up if you'd like.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the table’s full-screen toggle to prevent the Docker container list from displaying incorrectly in full-screen mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->