### PR TITLE
fix(search): let public dashboards use generic custom search engines

### DIFF
--- a/packages/api/src/router/search-engine/search-engine-router.ts
+++ b/packages/api/src/router/search-engine/search-engine-router.ts
@@ -3,7 +3,7 @@ import { z } from "zod/v4";
 
 import { createId } from "@homarr/common";
 import { createLogger } from "@homarr/core/infrastructure/logs";
-import { asc, eq, like } from "@homarr/db";
+import { and, asc, eq, like } from "@homarr/db";
 import { getServerSettingByKeyAsync, updateServerSettingByKeyAsync } from "@homarr/db/queries";
 import { searchEngines, users } from "@homarr/db/schema";
 import { byIdSchema, paginatedSchema, searchSchema } from "@homarr/validation/common";
@@ -130,9 +130,15 @@ export const searchEngineRouter = createTRPCRouter({
 
     return null;
   }),
-  search: protectedProcedure.input(searchSchema).query(async ({ ctx, input }) => {
+  search: publicProcedure.input(searchSchema).query(async ({ ctx, input }) => {
     return await ctx.db.query.searchEngines.findMany({
-      where: like(searchEngines.short, `${input.query.toLowerCase().trim()}%`),
+      // Public dashboards have no session: restrict anonymous users to generic
+      // (non-integration) engines so custom search engines work there too (#4132),
+      // while integration-backed engines stay available only when signed in.
+      where: and(
+        like(searchEngines.short, `${input.query.toLowerCase().trim()}%`),
+        ctx.session?.user ? undefined : eq(searchEngines.type, "generic"),
+      ),
       with: {
         integration: {
           columns: {


### PR DESCRIPTION
## What

The `searchEngine.search` procedure is a `protectedProcedure`, so anonymous visitors on a public dashboard get `UNAUTHORIZED` and no custom search-engine results. The default engine (`getDefaultSearchEngine`) and DuckDuckGo bangs still work because they're public, which is why custom engines specifically appear broken on public boards.

## Fix

Make `search` a `publicProcedure` and, when there is no session user, restrict results to `generic` (non-integration) engines — mirroring the existing `getSelectable` pattern (`eq(searchEngines.type, "generic")`). Integration-backed engines stay signed-in only, consistent with `integration.searchInIntegration` remaining protected.

This is the first step you proposed in the issue. It does make generic custom engines publicly queryable on public dashboards (their name / short / URL template), which is acceptable for generic engines but worth calling out; the fuller per-group permission model you floated could layer on top of this later.

Fixes #4132

### Checklist
- [x] Targets the `dev` branch
- [x] Conventional commit
- [x] Typechecked `@homarr/api` locally (clean).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search is now available without signing in.
  * Anonymous searches are limited to generic search engines, while signed-in users can access all matching engines.

* **Bug Fixes**
  * Improved search filtering to apply the correct access restrictions based on sign-in status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->