### PR TITLE
fix(releases): let LinuxServer.io version filters find older releases via GitHub

### DIFF
--- a/packages/request-handler/src/release-providers.ts
+++ b/packages/request-handler/src/release-providers.ts
@@ -745,6 +745,19 @@ const linuxServerIOReleasesSchema = z.object({
   }),
 });
 
+// Parse a github.com project URL (as returned by the LSIO registry) into an
+// "owner/repo" identifier, or null if it is not a github.com repository URL.
+const parseGithubRepo = (url: string): string | null => {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== "github.com") return null;
+    const [owner, repo] = parsed.pathname.replace(/^\/+/, "").split("/");
+    return owner && repo ? `${owner}/${repo}` : null;
+  } catch {
+    return null;
+  }
+};
+
 const getLinuxServerIOReleaseAsync = async (
   baseUrl: string,
   identifier: string,
@@ -773,6 +786,29 @@ const getLinuxServerIOReleaseAsync = async (
       success: false,
       error: { code: "noReleasesFound", message: `Image "${parsed.name}" not found in LinuxServer.io registry` },
     };
+
+  // LSIO's /api/v1/images only exposes the single latest version, so a version
+  // filter can never surface an older release (#4351). When the image has a GitHub
+  // repository, delegate to the GitHub release provider to fetch the real release
+  // history and apply the filter, while keeping LSIO's own image metadata. Any
+  // GitHub failure (no repo, no releases, rate limit) falls back to the LSIO latest.
+  const githubRepo = parseGithubRepo(release.github_url);
+  if (githubRepo) {
+    const githubResult = await getGithubReleaseAsync(getReleaseProviderDefaultUrl("github"), githubRepo, versionRegex);
+    if (githubResult.success) {
+      return {
+        success: true,
+        data: {
+          ...githubResult.data,
+          projectUrl: release.github_url,
+          projectDescription: release.description,
+          isArchived: release.deprecated,
+          starsCount: release.stars,
+          createdAt: release.initial_date ?? githubResult.data.createdAt,
+        },
+      };
+    }
+  }
 
   const regex = compileVersionRegex(versionRegex);
   if (versionRegex && !regex) {


### PR DESCRIPTION
## What

The LinuxServer.io release provider queries `/api/v1/images`, which only ever returns the **single latest** version per image (no version history). So a version filter can never surface an older release, and it also fails whenever the UI's anchored regex doesn't match the LSIO version string (e.g. `1.2.3.4-ls123`). Every other provider fetches a full list and runs `getLatestRelease(releases, versionRegex)`; LSIO could only ever satisfy a filter for the newest build.

## Fix

When the LSIO image has a GitHub repository (`github_url`), delegate to the existing GitHub release provider to fetch the real release history and apply the version filter, while keeping LSIO's own image metadata (description, stars, deprecated flag, project URL). Any GitHub failure (no repo, no releases, rate limit) falls back to LSIO's single latest version — so this is never worse than today.

This implements the approach you proposed in the issue.

**Tradeoff to flag:** it adds an unauthenticated GitHub call per LSIO image, subject to the 60 req/hr per-IP limit you mentioned — boards with several LSIO release entries could hit it (the Octokit throttle plugin already backs off, and results are cached). Happy to gate this behind a token/setting or adjust the approach however you prefer.

Fixes #4351

### Checklist
- [x] Targets the `dev` branch
- [x] Conventional commit
- [x] Typechecked `@homarr/request-handler` locally (clean).
- [ ] No test added yet: the change adds a branch that delegates to the already-exercised GitHub provider path, and my local vitest env has a `vitest.setup.ts` path-resolution issue, so I didn't want to ship an unverified test. I'll gladly add an LSIO case (mocking the LSIO `/api/v1/images` + GitHub responses) once you're happy with the approach and the rate-limit question above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LinuxServer.io release matching by using associated GitHub release history when available.
  * Ensured version patterns select the latest compatible release more accurately.
  * Preserved existing fallback behavior and release metadata when GitHub information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->