### PR TITLE
fix(custom-widgets): fix v2 editor crash and definition-not-found race

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/custom-widgets/_form-error-boundary.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/custom-widgets/_form-error-boundary.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import type { ErrorInfo, ReactNode } from "react";
+import { Component } from "react";
+import { Alert, Button, Stack, Text } from "@mantine/core";
+import { IconAlertTriangle } from "@tabler/icons-react";
+
+import { useScopedI18n } from "@homarr/translation/client";
+
+interface FormErrorBoundaryState {
+  error: Error | null;
+}
+
+interface FormErrorBoundaryProps {
+  children: ReactNode;
+}
+
+export class FormErrorBoundary extends Component<FormErrorBoundaryProps, FormErrorBoundaryState> {
+  public state: FormErrorBoundaryState = { error: null };
+
+  public static getDerivedStateFromError(error: Error): FormErrorBoundaryState {
+    return { error };
+  }
+
+  public componentDidCatch(error: Error, _info: ErrorInfo) {
+    console.error("Custom widget form error:", error);
+  }
+
+  public render() {
+    if (this.state.error) {
+      return <FormErrorFallback error={this.state.error} reset={() => this.setState({ error: null })} />;
+    }
+    return this.props.children;
+  }
+}
+
+function FormErrorFallback({ error, reset }: { error: Error; reset: () => void }) {
+  const t = useScopedI18n("customWidget");
+  return (
+    <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />} p="md">
+      <Stack gap="xs">
+        <Text size="sm" fw={600}>
+          {t("editor.errorBoundary.title")}
+        </Text>
+        <Text size="xs" c="dimmed" style={{ fontFamily: "monospace" }}>
+          {error.message}
+        </Text>
+        <Button size="xs" variant="light" color="red" onClick={reset}>
+          {t("editor.errorBoundary.retry")}
+        </Button>
+      </Stack>
+    </Alert>
+  );
+}

--- a/apps/nextjs/src/app/[locale]/manage/custom-widgets/edit/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/custom-widgets/edit/[id]/page.tsx
@@ -9,6 +9,7 @@ import { DynamicBreadcrumb } from "~/components/navigation/dynamic-breadcrumb";
 import { catchTrpcNotFound } from "~/errors/trpc-catch-error";
 import { CustomWidgetBetaBanner } from "../../_beta-banner";
 import { CustomWidgetForm } from "../../_custom-widget-form";
+import { FormErrorBoundary } from "../../_form-error-boundary";
 
 const authTypeExpectedSecrets: Record<string, string[]> = {
   bearer: ["apiKey"],
@@ -52,22 +53,24 @@ export default async function EditCustomWidgetPage(props: EditCustomWidgetPagePr
         <Stack>
           <Title>{definition.name}</Title>
           <CustomWidgetBetaBanner />
-          <CustomWidgetForm
-            mode="edit"
-            definitionId={params.id}
-            initialValues={{
-              name: definition.name,
-              description: definition.description ?? "",
-              iconUrl: definition.iconUrl ?? "",
-              url: definition.url,
-              authType: definition.authType,
-              headerName: definition.headerName ?? "",
-              method: definition.method,
-              requestBody: definition.requestBody ?? "",
-              ...displayValues,
-              secrets: buildInitialSecrets(definition.authType, definition.secrets),
-            }}
-          />
+          <FormErrorBoundary>
+            <CustomWidgetForm
+              mode="edit"
+              definitionId={params.id}
+              initialValues={{
+                name: definition.name,
+                description: definition.description ?? "",
+                iconUrl: definition.iconUrl ?? "",
+                url: definition.url,
+                authType: definition.authType,
+                headerName: definition.headerName ?? "",
+                method: definition.method,
+                requestBody: definition.requestBody ?? "",
+                ...displayValues,
+                secrets: buildInitialSecrets(definition.authType, definition.secrets),
+              }}
+            />
+          </FormErrorBoundary>
         </Stack>
       </Container>
     </>

--- a/apps/nextjs/src/app/[locale]/manage/custom-widgets/new/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/custom-widgets/new/page.tsx
@@ -7,6 +7,7 @@ import { getScopedI18n } from "@homarr/translation/server";
 import { DynamicBreadcrumb } from "~/components/navigation/dynamic-breadcrumb";
 import { CustomWidgetBetaBanner } from "../_beta-banner";
 import { CustomWidgetForm } from "../_custom-widget-form";
+import { FormErrorBoundary } from "../_form-error-boundary";
 
 export default async function NewCustomWidgetPage() {
   const session = await auth();
@@ -28,7 +29,9 @@ export default async function NewCustomWidgetPage() {
             </Text>
           </div>
           <CustomWidgetBetaBanner />
-          <CustomWidgetForm mode="create" />
+          <FormErrorBoundary>
+            <CustomWidgetForm mode="create" />
+          </FormErrorBoundary>
         </Stack>
       </Container>
     </>

--- a/e2e/custom-widgets-custom-jsx.spec.ts
+++ b/e2e/custom-widgets-custom-jsx.spec.ts
@@ -80,4 +80,71 @@ describe("Custom JSX custom widgets", () => {
       await mockApi.stop();
     }
   }, 120_000);
+
+  test("newly added custom widget does not show definition not found before reload", async () => {
+    const mockApi = await startMockApiContainerAsync({
+      title: "Board Widget",
+      status: "running",
+      value: 7,
+    });
+
+    const { db, localMountPath } = await createSqliteDbFileAsync();
+    await seedAdminUserAsync(db, adminCredentials);
+
+    const homarrContainer = await createHomarrContainer({
+      environment: {
+        AUTH_PROVIDERS: "credentials",
+      },
+      mounts: {
+        "/appdata": localMountPath,
+      },
+    }).start();
+
+    const baseUrl = `http://${homarrContainer.getHost()}:${homarrContainer.getMappedPort(7575)}`;
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    try {
+      await page.goto(`${baseUrl}/auth/login`);
+      await page.getByLabel("Username").fill(adminCredentials.username);
+      await page.locator("#password").fill(adminCredentials.password);
+      await page.locator("css=button[type='submit']").click();
+      await page.waitForURL(baseUrl, { timeout: 15_000 });
+
+      await page.goto(`${baseUrl}/manage/custom-widgets/new`);
+      await page.waitForURL("**/manage/custom-widgets/new", { timeout: 15_000 });
+      await page.getByRole("textbox", { name: "Name" }).fill("Board Widget");
+      await page.getByRole("textbox", { name: "URL", exact: true }).fill(`${mockApi.url}/status`);
+      await page.getByRole("button", { name: /Custom JSX/u }).click();
+      await page.getByRole("combobox", { name: "Network scope" }).click();
+      await page.getByRole("option", { name: "Private networks" }).click();
+      await page.getByLabel("JSX Template").fill(initialTemplate);
+      await page.getByRole("button", { name: "Create" }).first().click();
+      await expect(page.getByText(/created successfully/u)).toBeVisible({ timeout: 15_000 });
+
+      await page.goto(baseUrl);
+      await page.waitForLoadState("networkidle");
+
+      await page.getByRole("button", { name: /edit mode|Edit mode|pencil/iu }).first().click();
+
+      await page.getByRole("button", { name: /Add widget|Add item/iu }).first().click();
+      await page.getByRole("button", { name: /Custom API|Custom Widget/iu }).first().click();
+
+      const addDialog = page.getByRole("dialog").last();
+      await addDialog.getByText("Board Widget").first().click();
+
+      await expect(page.getByText("Widget definition not found")).not.toBeVisible({ timeout: 10_000 });
+
+      await page.getByRole("button", { name: /edit mode|Edit mode|pencil/iu }).first().click();
+      await page.waitForLoadState("networkidle");
+
+      await expect(page.getByText("Board Widget")).toBeVisible({ timeout: 15_000 });
+      await expect(page.getByText("Widget definition not found")).not.toBeVisible({ timeout: 10_000 });
+    } finally {
+      await browser.close();
+      await homarrContainer.stop();
+      await mockApi.stop();
+    }
+  }, 180_000);
 });

--- a/e2e/custom-widgets-custom-jsx.spec.ts
+++ b/e2e/custom-widgets-custom-jsx.spec.ts
@@ -126,17 +126,29 @@ describe("Custom JSX custom widgets", () => {
       await page.goto(baseUrl);
       await page.waitForLoadState("networkidle");
 
-      await page.getByRole("button", { name: /edit mode|Edit mode|pencil/iu }).first().click();
+      await page
+        .getByRole("button", { name: /edit mode|Edit mode|pencil/iu })
+        .first()
+        .click();
 
-      await page.getByRole("button", { name: /Add widget|Add item/iu }).first().click();
-      await page.getByRole("button", { name: /Custom API|Custom Widget/iu }).first().click();
+      await page
+        .getByRole("button", { name: /Add widget|Add item/iu })
+        .first()
+        .click();
+      await page
+        .getByRole("button", { name: /Custom API|Custom Widget/iu })
+        .first()
+        .click();
 
       const addDialog = page.getByRole("dialog").last();
       await addDialog.getByText("Board Widget").first().click();
 
       await expect(page.getByText("Widget definition not found")).not.toBeVisible({ timeout: 10_000 });
 
-      await page.getByRole("button", { name: /edit mode|Edit mode|pencil/iu }).first().click();
+      await page
+        .getByRole("button", { name: /edit mode|Edit mode|pencil/iu })
+        .first()
+        .click();
       await page.waitForLoadState("networkidle");
 
       await expect(page.getByText("Board Widget")).toBeVisible({ timeout: 15_000 });

--- a/packages/custom-widgets/src/core/display-form.ts
+++ b/packages/custom-widgets/src/core/display-form.ts
@@ -253,6 +253,12 @@ export function buildDisplayConfigFromFormValues(values: CustomWidgetDisplayForm
 }
 
 function parseRequestManifest(value: string) {
-  const parsed: unknown = JSON.parse(value);
-  return customJsxRequestSchema.array().parse(parsed);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return [];
+  }
+  const result = customJsxRequestSchema.array().safeParse(parsed);
+  return result.success ? result.data : [];
 }

--- a/packages/custom-widgets/src/test/display-form.spec.ts
+++ b/packages/custom-widgets/src/test/display-form.spec.ts
@@ -62,4 +62,16 @@ describe("custom-widget display form contracts", () => {
       requests: [{ id: "status", kind: "query", method: "GET" }],
     });
   });
+
+  test("does not throw on invalid request manifest JSON while serializing v2 form state", () => {
+    const values = requiredFormValues("customJsx");
+    values.jsxApiVersion = "2";
+
+    for (const invalidManifest of ["[invalid", "{not an array}", "", '{"id":1}', "null"]) {
+      values.requestManifest = invalidManifest;
+      expect(() => buildDisplayConfigFromFormValues(values)).not.toThrow();
+      const config = buildDisplayConfigFromFormValues(values) as { requests?: unknown };
+      expect(config.requests).toEqual([]);
+    }
+  });
 });

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -803,6 +803,10 @@
     "editor": {
       "saveBlocked": "Resolve the editor errors before saving.",
       "saveReady": "The configuration is ready to save.",
+      "errorBoundary": {
+        "title": "Something went wrong",
+        "retry": "Try again"
+      },
       "language": {
         "jsx": "JSX",
         "json": "JSON"
@@ -4084,6 +4088,7 @@
       },
       "noDefinition": "No definition selected",
       "definitionNotFound": "Widget definition not found. It may have been deleted.",
+      "editModePending": "Save the board to load this widget.",
       "noDisplayOutput": "No display output",
       "openJson": "Open in browser JSON viewer",
       "execute": "Execute",

--- a/packages/widgets/src/custom-api/component.tsx
+++ b/packages/widgets/src/custom-api/component.tsx
@@ -129,7 +129,7 @@ function CustomApiWidgetInner({
   const { data, isLoading, error } = clientApi.widget.customApi.getData.useQuery(
     { itemId: itemId ?? "" },
     {
-      enabled: Boolean(itemId),
+      enabled: Boolean(itemId) && !isEditMode,
       refetchInterval: (query) => {
         const result = query.state.data as Record<string, unknown> | undefined;
         if (
@@ -170,7 +170,18 @@ function CustomApiWidgetInner({
     );
   }
 
-  if (!data) return null;
+  if (!data) {
+    if (isEditMode) {
+      return (
+        <Center h="100%">
+          <Text c="dimmed" size="sm" ta="center">
+            {t("editModePending")}
+          </Text>
+        </Center>
+      );
+    }
+    return null;
+  }
 
   const widgetData = data as Record<string, unknown>;
   const dataType = widgetData.type as string | undefined;


### PR DESCRIPTION
## Summary

Fixes two bugs affecting custom JSX widget v2:

### Bug 1: Editor crashes with "Unexpected error" on invalid code

Typing invalid JSON in the **request manifest** field (v2 only) crashed the page with a Next.js "Unexpected error" overlay.

**Root cause:** `parseRequestManifest` in `display-form.ts` called `JSON.parse` + zod `.parse()` which **threw** on invalid input. This ran on **every render** via `buildDisplayConfigFromFormValues` -> `getInput()` in the preview hook. Since `CustomWidgetForm` had no error boundary, the throw escaped to the React root.

**Fix:**

- Made `parseRequestManifest` defensive (try/catch -> empty array), mirroring the safe version in `workbench/analyzer.ts`
- Wrapped `CustomWidgetForm` in a `FormErrorBoundary` component (defense-in-depth) in both `new/page.tsx` and `edit/[id]/page.tsx`
- Added unit tests for invalid manifest inputs (`"[invalid"`, `"{}"`, `""`, `"null"`, `"{not an array}"`)

### Bug 2: New custom widget shows "definition not found" until reload

After creating/importing a custom widget and adding it to a board in edit mode, it displayed "Widget definition not found. It may have been deleted." until the page was reloaded.

**Root cause:** `handleAddCustomWidget` only writes the item to **local TanStack cache** (`createItem`/`updateItemOptions`). The item isn't persisted to the DB `items` table until `saveBoard` runs on edit-mode exit. But `getData` fired immediately (`enabled: Boolean(itemId)`), queried `items.findFirst` in the DB -> returned nothing -> threw `NOT_FOUND` -> `retry: false` for NOT_FOUND -> stuck until reload.

**Fix:**

- Gated the `getData` query with `!isEditMode` so it only fires for persisted items. On edit-mode exit, `saveBoard` persists items **before** `close()` flips `isEditMode` to false, so `getData` succeeds.
- Added an edit-mode placeholder ("Save the board to load this widget.") instead of an empty box
- Added an e2e regression test verifying no "not found" appears before reload

## Test plan

- [x] `pnpm --filter @homarr/custom-widgets exec vitest run src/test/display-form.spec.ts` -- 13/13 pass
- [x] `pnpm turbo typecheck` -- all 3 affected packages pass
- [x] `pnpm lint` -- changed files lint-clean
- [x] `pnpm format` -- all packages pass
- [ ] E2E: `pnpm test:e2e` -- e2e requires Docker, run in CI

## Files changed

| File                                                                          | Change                                          |
| ----------------------------------------------------------------------------- | ----------------------------------------------- |
| `packages/custom-widgets/src/core/display-form.ts`                            | Defensive `parseRequestManifest`                |
| `packages/custom-widgets/src/test/display-form.spec.ts`                       | Invalid-manifest regression tests               |
| `apps/nextjs/src/app/[locale]/manage/custom-widgets/_form-error-boundary.tsx` | New error boundary component                    |
| `apps/nextjs/src/app/[locale]/manage/custom-widgets/new/page.tsx`             | Wrap form in error boundary                     |
| `apps/nextjs/src/app/[locale]/manage/custom-widgets/edit/[id]/page.tsx`       | Wrap form in error boundary                     |
| `packages/widgets/src/custom-api/component.tsx`                               | Gate `getData` with `!isEditMode` + placeholder |
| `e2e/custom-widgets-custom-jsx.spec.ts`                                       | E2e regression test                             |
| `packages/translation/src/lang/en.json`                                       | `editModePending` + `editor.errorBoundary` keys |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear error state with localized messaging and a “Try again” action for custom widget forms.
  * Added an edit-mode message indicating when a board must be saved before a custom API widget can load.
* **Bug Fixes**
  * Custom widget configurations with invalid request data now fail gracefully instead of causing errors.
  * Prevented unnecessary widget loading during editing and resolved transient “Widget definition not found” messages.
* **Tests**
  * Added coverage for invalid configuration data and custom JSX widget editing flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->