### PR TITLE
test(request-handler): cover LSIO release-history delegation to GitHub

### DIFF
--- a/packages/request-handler/src/test/release-providers.spec.ts
+++ b/packages/request-handler/src/test/release-providers.spec.ts
@@ -246,7 +246,117 @@ describe("getLatestMatchingReleaseAsync for LinuxServer.io", () => {
     });
     expect(mockedFetch.mock.calls.length).toBeGreaterThan(1);
   });
+
+  test("delegates to GitHub so a version filter can surface an older release while keeping LSIO metadata", async () => {
+    mockLinuxServerIOResponses({
+      image: {
+        name: "radarr",
+        github_url: "https://github.com/linuxserver/docker-radarr",
+        description: "A LinuxServer.io image of Radarr",
+        version: "5.14.0",
+        version_timestamp: "2026-06-01T00:00:00.000Z",
+        initial_date: "2020-01-01T00:00:00.000Z",
+        stars: 300,
+        deprecated: false,
+      },
+      githubRepo: "linuxserver/docker-radarr",
+      githubReleases: [
+        { tag_name: "5.14.0", published_at: "2026-06-01T00:00:00.000Z" },
+        { tag_name: "5.13.0", published_at: "2026-05-01T00:00:00.000Z" },
+        { tag_name: "5.12.0", published_at: "2026-04-01T00:00:00.000Z" },
+      ],
+      // GitHub metadata is intentionally different so the assertions prove LSIO's own values win.
+      githubDetails: {
+        html_url: "https://github.com/linuxserver/docker-radarr",
+        description: "GitHub description that must be overridden by LSIO",
+        fork: false,
+        archived: true,
+        created_at: "2015-01-01T00:00:00.000Z",
+        stargazers_count: 999,
+        open_issues_count: 7,
+        forks_count: 42,
+      },
+    });
+
+    const result = await getLatestMatchingReleaseAsync({
+      id: "radarr",
+      provider: "linuxServerIO",
+      identifier: "lscr.io/linuxserver/radarr:latest",
+      // The latest LSIO version is 5.14.0; this filter can only match via GitHub's release history.
+      versionRegex: "^5\\.12\\.[0-9]+$",
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    // Version filtering picked the older release that LSIO's /api/v1/images alone could not expose.
+    expect(result.data.latestRelease).toBe("5.12.0");
+    expect(result.data.latestReleaseAt).toEqual(new Date("2026-04-01T00:00:00.000Z"));
+    // LSIO image metadata is preserved over GitHub's.
+    expect(result.data.projectUrl).toBe("https://github.com/linuxserver/docker-radarr");
+    expect(result.data.projectDescription).toBe("A LinuxServer.io image of Radarr");
+    expect(result.data.isArchived).toBe(false);
+    expect(result.data.starsCount).toBe(300);
+    expect(result.data.createdAt).toEqual(new Date("2020-01-01T00:00:00.000Z"));
+  });
 });
+
+interface MockLinuxServerIOResponsesInput {
+  image: {
+    name: string;
+    github_url: string;
+    description: string;
+    version: string;
+    version_timestamp: string;
+    initial_date?: string;
+    stars: number;
+    deprecated: boolean;
+  };
+  githubRepo: string;
+  githubReleases: { tag_name: string; published_at: string }[];
+  githubDetails: {
+    html_url: string;
+    description: string;
+    fork: boolean;
+    archived: boolean;
+    created_at: string;
+    stargazers_count: number;
+    open_issues_count: number;
+    forks_count: number;
+  };
+}
+
+const mockLinuxServerIOResponses = ({
+  image,
+  githubRepo,
+  githubReleases,
+  githubDetails,
+}: MockLinuxServerIOResponsesInput) => {
+  mockedFetch.mockImplementation(async (input) => {
+    const url = new URL(input.toString());
+    const path = url.pathname;
+
+    if (url.hostname === "api.linuxserver.io" && path === "/api/v1/images") {
+      return createJsonResponse({ data: { repositories: { linuxserver: [image] } } });
+    }
+
+    if (url.hostname === "api.github.com" && path === `/repos/${githubRepo}/releases`) {
+      return createJsonResponse(
+        githubReleases.map((release) => ({
+          ...release,
+          html_url: `https://github.com/${githubRepo}/releases/tag/${release.tag_name}`,
+          body: null,
+          prerelease: false,
+        })),
+      );
+    }
+
+    if (url.hostname === "api.github.com" && path === `/repos/${githubRepo}`) {
+      return createJsonResponse(githubDetails);
+    }
+
+    return createJsonResponse({ error: "not found" }, { status: 404, statusText: "Not Found" });
+  });
+};
 
 interface MockGhcrResponsesInput {
   registryOrigin?: string;


### PR DESCRIPTION
Follow-up to #6376 (merged), which delegated LinuxServer.io release-history lookups to the GitHub provider. CodeRabbit asked for test coverage on that PR and it merged without one; this adds the missing case (referencing #6376, not closing it).

### Root cause
LSIO's `/api/v1/images` endpoint only exposes the single latest version, so a version filter could never surface an older release (#4351). #6376 fixed this by delegating to `getGithubReleaseAsync` when the image has a `github.com` repository, applying the filter against the real release history while preserving LSIO's own image metadata. That new branch shipped untested.

### Fix
Add one focused vitest case to `packages/request-handler/src/test/release-providers.spec.ts`, matching the existing GHCR test style. Both LSIO's `fetchProvider` and the GitHub Octokit client route through the same mocked `fetchWithTrustedCertificatesAsync`, so a single `mockImplementation` drives:

- LSIO `/api/v1/images` (latest version `5.14.0`, with LSIO description/stars/`initial_date`/`deprecated`)
- GitHub `/repos/{owner}/{repo}/releases` (history including older `5.13.0` and `5.12.0`)
- GitHub `/repos/{owner}/{repo}` details (deliberately different metadata)

The test asserts that a `^5\.12\.[0-9]+$` filter — unmatchable from LSIO alone — resolves to `5.12.0` via the delegated GitHub history, and that LSIO's `projectUrl`, `projectDescription`, `isArchived`, `starsCount`, and `createdAt` are preserved over GitHub's values.

### Verification
- `tsc --noEmit` on `@homarr/request-handler`: passes
- `oxlint` + `oxfmt --check` on the spec file: clean
- `vitest run packages/request-handler/src/test/release-providers.spec.ts`: 6 passed (5 existing + the new LSIO case)

No production code changed; this is test-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure older matching LinuxServer release tags are correctly found using GitHub release history.
  * Verified that LinuxServer-provided metadata (project details, archived status, stars, and created date) properly takes precedence over mocked GitHub release/repository information for matched results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->