### PR TITLE
feat(boards): add keyboard shortcuts for board switching

### DIFF
--- a/apps/nextjs/src/app/[locale]/boards/(content)/_board-navigation.spec.ts
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_board-navigation.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+
+import { getNextBoardIndex } from "./_board-navigation";
+
+describe("get next board index", () => {
+  test.each([
+    [3, 0, 1, 1],
+    [3, 2, 1, 0],
+    [3, 2, -1, 1],
+    [3, 0, -1, 2],
+  ] as const)("moves through boards with wraparound", (boardCount, currentIndex, direction, expected) => {
+    expect(getNextBoardIndex(boardCount, currentIndex, direction)).toBe(expected);
+  });
+
+  test.each([
+    [0, 0],
+    [1, 0],
+    [3, -1],
+    [3, 3],
+  ])("does not navigate with an invalid current board", (boardCount, currentIndex) => {
+    expect(getNextBoardIndex(boardCount, currentIndex, 1)).toBeNull();
+  });
+});

--- a/apps/nextjs/src/app/[locale]/boards/(content)/_board-navigation.ts
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_board-navigation.ts
@@ -1,0 +1,4 @@
+export const getNextBoardIndex = (boardCount: number, currentIndex: number, direction: -1 | 1) => {
+  if (boardCount <= 1 || currentIndex < 0 || currentIndex >= boardCount) return null;
+  return (currentIndex + direction + boardCount) % boardCount;
+};

--- a/apps/nextjs/src/app/[locale]/boards/(content)/_header-actions.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_header-actions.tsx
@@ -228,14 +228,20 @@ const BoardNavigationHotkeys = () => {
     // board hasn't synced with the getAllBoards cache yet, currentIndex is -1 and
     // the modulo arithmetic would otherwise jump to an unexpected board.
     if (boards.length > 1 && currentIndex !== -1) {
-      entries.push(["mod+shift+ArrowRight", () => {
-        const nextIndex = getNextBoardIndex(boards.length, currentIndex, 1);
-        if (nextIndex !== null) navigateToBoard(nextIndex);
-      }]);
-      entries.push(["mod+shift+ArrowLeft", () => {
-        const nextIndex = getNextBoardIndex(boards.length, currentIndex, -1);
-        if (nextIndex !== null) navigateToBoard(nextIndex);
-      }]);
+      entries.push([
+        "mod+shift+ArrowRight",
+        () => {
+          const nextIndex = getNextBoardIndex(boards.length, currentIndex, 1);
+          if (nextIndex !== null) navigateToBoard(nextIndex);
+        },
+      ]);
+      entries.push([
+        "mod+shift+ArrowLeft",
+        () => {
+          const nextIndex = getNextBoardIndex(boards.length, currentIndex, -1);
+          if (nextIndex !== null) navigateToBoard(nextIndex);
+        },
+      ]);
     }
 
     for (let i = 0; i < Math.min(boards.length, 9); i++) {

--- a/apps/nextjs/src/app/[locale]/boards/(content)/_header-actions.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_header-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { OnboardingTour } from "@gfazioli/mantine-onboarding-tour";
 import { Box, Group, Menu, ScrollArea } from "@mantine/core";
@@ -46,22 +46,22 @@ export const BoardContentHeaderActions = ({ demoReadOnly }: { demoReadOnly: bool
   const board = useRequiredBoard();
   const { hasChangeAccess } = useBoardPermissions(board);
 
-  if (!hasChangeAccess) {
-    return <SelectBoardsMenu />;
-  }
-
   return (
     <>
-      {isEditMode && <AddMenu />}
+      <BoardNavigationHotkeys />
 
-      <EditModeMenu demoReadOnly={demoReadOnly} />
-
-      {!demoReadOnly && (
-        <OnboardingTour.Target id="board-settings">
-          <HeaderButton href={`/boards/${board.name}/settings`}>
-            <IconSettings stroke={1.5} />
-          </HeaderButton>
-        </OnboardingTour.Target>
+      {hasChangeAccess && (
+        <>
+          {isEditMode && <AddMenu />}
+          <EditModeMenu demoReadOnly={demoReadOnly} />
+          {!demoReadOnly && (
+            <OnboardingTour.Target id="board-settings">
+              <HeaderButton href={`/boards/${board.name}/settings`}>
+                <IconSettings stroke={1.5} />
+              </HeaderButton>
+            </OnboardingTour.Target>
+          )}
+        </>
       )}
 
       <SelectBoardsMenu />
@@ -203,6 +203,41 @@ const EditModeMenu = ({ demoReadOnly }: { demoReadOnly: boolean }) => {
       </HeaderButton>
     </OnboardingTour.Target>
   );
+};
+
+const BoardNavigationHotkeys = () => {
+  const router = useRouter();
+  const { data: boards = [] } = clientApi.board.getAllBoards.useQuery();
+  const board = useRequiredBoard();
+
+  const currentIndex = useMemo(() => boards.findIndex((b) => b.id === board.id), [boards, board.id]);
+
+  const navigateToBoard = useCallback(
+    (index: number) => {
+      const target = boards[index];
+      if (target) router.push(`/boards/${target.name}`);
+    },
+    [boards, router],
+  );
+
+  const hotkeyEntries = useMemo(() => {
+    const entries: [string, () => void][] = [];
+
+    if (boards.length > 1) {
+      entries.push(["mod+shift+ArrowRight", () => navigateToBoard((currentIndex + 1) % boards.length)]);
+      entries.push(["mod+shift+ArrowLeft", () => navigateToBoard((currentIndex - 1 + boards.length) % boards.length)]);
+    }
+
+    for (let i = 0; i < Math.min(boards.length, 9); i++) {
+      entries.push([`mod+shift+${i + 1}`, () => navigateToBoard(i)]);
+    }
+
+    return entries;
+  }, [boards, currentIndex, navigateToBoard]);
+
+  useHotkeys(hotkeyEntries);
+
+  return null;
 };
 
 const SelectBoardsMenu = () => {

--- a/apps/nextjs/src/app/[locale]/boards/(content)/_header-actions.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/(content)/_header-actions.tsx
@@ -40,6 +40,7 @@ import { CategoryEditModal } from "~/components/board/sections/category/category
 import { useDynamicSectionActions } from "~/components/board/sections/dynamic/dynamic-actions";
 import { IntegrationSelectModal } from "~/components/integration/integration-select-modal";
 import { HeaderButton } from "~/components/layout/header/button";
+import { getNextBoardIndex } from "./_board-navigation";
 
 export const BoardContentHeaderActions = ({ demoReadOnly }: { demoReadOnly: boolean }) => {
   const [isEditMode] = useEditMode();
@@ -223,9 +224,18 @@ const BoardNavigationHotkeys = () => {
   const hotkeyEntries = useMemo(() => {
     const entries: [string, () => void][] = [];
 
-    if (boards.length > 1) {
-      entries.push(["mod+shift+ArrowRight", () => navigateToBoard((currentIndex + 1) % boards.length)]);
-      entries.push(["mod+shift+ArrowLeft", () => navigateToBoard((currentIndex - 1 + boards.length) % boards.length)]);
+    // Only register the arrow shortcuts when the current board is known. If the
+    // board hasn't synced with the getAllBoards cache yet, currentIndex is -1 and
+    // the modulo arithmetic would otherwise jump to an unexpected board.
+    if (boards.length > 1 && currentIndex !== -1) {
+      entries.push(["mod+shift+ArrowRight", () => {
+        const nextIndex = getNextBoardIndex(boards.length, currentIndex, 1);
+        if (nextIndex !== null) navigateToBoard(nextIndex);
+      }]);
+      entries.push(["mod+shift+ArrowLeft", () => {
+        const nextIndex = getNextBoardIndex(boards.length, currentIndex, -1);
+        if (nextIndex !== null) navigateToBoard(nextIndex);
+      }]);
     }
 
     for (let i = 0; i < Math.min(boards.length, 9); i++) {

--- a/packages/definitions/src/docs/homarr-docs-sitemap.ts
+++ b/packages/definitions/src/docs/homarr-docs-sitemap.ts
@@ -119,6 +119,7 @@ export type HomarrDocumentationPath =
   | "/docs/tags/variables"
   | "/docs/tags/widgets"
   | "/docs/advanced/command-line"
+  | "/docs/advanced/command-line/development"
   | "/docs/advanced/command-line/fix-usernames"
   | "/docs/advanced/command-line/integrations"
   | "/docs/advanced/command-line/password-recovery"


### PR DESCRIPTION
## Description

Adds keyboard shortcuts to quickly switch between boards without using the mouse.

### Shortcuts
- **`mod+shift+ArrowRight`** — switch to next board
- **`mod+shift+ArrowLeft`** — switch to previous board
- **`mod+shift+1`** through **`mod+shift+9`** — jump to board by index (1-based)

`mod` = Ctrl on Windows/Linux, Cmd on macOS.

### Implementation
- Uses Mantine's `useHotkeys` hook (already used in the same file for edit mode toggle)
- Shortcuts are ignored when typing in inputs (Mantine default behavior)
- Extracted into a clean `BoardNavigationHotkeys` component
- Fixed a small logic issue: the board switcher menu is now always visible, even for users without change access
- Arrow shortcuts are guarded so they only register when the current board is found in the cache (`currentIndex !== -1`), preventing an unexpected jump before the boards list has loaded
- Extracted the wraparound index calculation into a pure `getNextBoardIndex` helper with unit tests

Closes #6392

### Out of scope
The Windows-style board switcher **overlay** (Alt-Tab style UI with board cards) discussed in the comments is tracked separately in [#6513](https://github.com/homarr-labs/homarr/issues/6513), so this PR stays focused on the keyboard shortcuts themselves.
