### PR TITLE
docs(immich): list Asset View permission

### DIFF
--- a/apps/docs/docs/integrations/immich/index.mdx
+++ b/apps/docs/docs/integrations/immich/index.mdx
@@ -50,12 +50,11 @@ import { immichServerStatsWidget } from '../../widgets/immich-server-stats';
     <code>user.read</code>,{" "}
     <code>user.update</code>,{" "}
     <code>asset.read</code>,{" "}
+    <code>asset.view</code>,{" "}
     <code>asset.download</code>,{" "}
     <code>asset.statistics</code>,{" "}
     <code>server.statistics</code>,{" "}
     <code>server.about</code>.
-    <br />
-    The <strong>Asset View</strong> permission is required for the Immich Album Carousel to load image thumbnails. Select it when creating the API key, or use the <strong>All permissions</strong> preset. Without it, Immich returns a <code>403 Forbidden</code> response for thumbnail requests.
   </span>
 
 ),


### PR DESCRIPTION
Adds the required `asset.view` permission to the existing Immich API-key permissions list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Immich integration guide with additional permissions required when creating an API key.
  * Removed outdated explanatory text about thumbnail loading and related error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->