### PR TITLE
fix(db): increase mysql migration test timeout to 120s

### DIFF
--- a/packages/db/test/mysql-migration.spec.ts
+++ b/packages/db/test/mysql-migration.spec.ts
@@ -37,5 +37,5 @@ describe("Mysql Migration", () => {
 
     connection.end();
     await mysqlContainer.stop();
-  }, 40_000);
+  }, 120_000);
 });


### PR DESCRIPTION
The MySQL container-based migration test was flaking with a 40s timeout. Bumped to 120s since container startup + image pull can exceed 40s in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the MySQL migration test timeout to improve reliability under slower execution conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->