### PR TITLE
fix(integrations): stop auto-seeding ArchiveTeam Warrior on first install

### DIFF
--- a/packages/definitions/src/integration.ts
+++ b/packages/definitions/src/integration.ts
@@ -467,7 +467,6 @@ export const integrationDefs = {
     iconUrl: "https://cdn.jsdelivr.net/gh/selfhst/icons/png/archiveteam-warrior.png",
     category: ["archiving"],
     documentationUrl: null,
-    defaultUrl: "http://localhost:8001",
   },
   // This integration only returns mock data, it is used during development (but can also be used in production by directly going to the create page)
   mock: {


### PR DESCRIPTION
Removes defaultUrl from the ArchiveTeam Warrior integration definition so it is no longer auto-created as a default integration on first install.

The seeding logic auto-creates any integration that has both a `defaultUrl` and a no-auth option. ArchiveTeam Warrior had both, causing it to be seeded on every new install even though it's a niche service. Users who want it can still add it manually.

- Removed `defaultUrl: "http://localhost:8001"` from `archiveTeamWarrior` definition in `packages/definitions/src/integration.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an outdated fallback URL from the TeamWarrior integration configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->