### PR TITLE
fix: stop auto-seeding ArchiveTeam Warrior integration and widget on default dashboards

### DIFF
--- a/packages/definitions/src/integration.ts
+++ b/packages/definitions/src/integration.ts
@@ -467,7 +467,6 @@ export const integrationDefs = {
     iconUrl: "https://cdn.jsdelivr.net/gh/selfhst/icons/png/archiveteam-warrior.png",
     category: ["archiving"],
     documentationUrl: null,
-    defaultUrl: "http://localhost:8001",
   },
   // This integration only returns mock data, it is used during development (but can also be used in production by directly going to the create page)
   mock: {


### PR DESCRIPTION
Removes `defaultUrl` from the ArchiveTeam Warrior integration definition.

**Why this fixes the widget appearing on dashboards:**

The seed pipeline works in two steps:
1. `seedDefaultIntegrationsAsync` auto-creates any integration that has both a `defaultUrl` and a no-auth option
2. `placeAllWidgetsAsync` iterates ALL integrations and places their corresponding widgets on the default board

Removing `defaultUrl` prevents step 1 (the integration is no longer auto-created), which means step 2 has no integration to create a widget for. The demo mode (`buildDemoWidgets`) doesn't include ArchiveTeam Warrior either.

Users who want it can still add the integration and widget manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an incorrect default connection address from the TeamWarrior archive integration.
  * Integration setup now relies on the configured connection details instead of an unintended local address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->