### PR TITLE
feat: restrict apps management to board modifiers

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/apps/edit/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/apps/edit/[id]/page.tsx
@@ -16,7 +16,10 @@ export default async function AppEditPage(props: AppEditPageProps) {
   const params = await props.params;
   const session = await auth();
 
-  if (!session?.user.permissions.includes("app-modify-all")) {
+  if (
+    !session?.user.permissions.includes("board-modify-all") ||
+    !session?.user.permissions.includes("app-modify-all")
+  ) {
     notFound();
   }
   const app = await api.app.byId({ id: params.id });

--- a/apps/nextjs/src/app/[locale]/manage/apps/new/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/apps/new/page.tsx
@@ -10,7 +10,7 @@ import { DynamicBreadcrumb } from "~/components/navigation/dynamic-breadcrumb";
 export default async function AppNewPage() {
   const session = await auth();
 
-  if (!session?.user.permissions.includes("app-create")) {
+  if (!session?.user.permissions.includes("board-modify-all") || !session?.user.permissions.includes("app-create")) {
     notFound();
   }
 

--- a/apps/nextjs/src/app/[locale]/manage/apps/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/apps/page.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from "react";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { ActionIcon, ActionIconGroup, Anchor, Avatar, Card, Group, Stack, Text } from "@mantine/core";
 import { IconBox, IconPencil } from "@tabler/icons-react";
 import { z } from "zod/v4";
@@ -32,6 +32,9 @@ export default async function AppsPage(props: AppsPageProps) {
 
   if (!session) {
     redirect("/auth/login");
+  }
+  if (!session.user.permissions.includes("board-modify-all")) {
+    notFound();
   }
 
   const searchParams = searchParamsSchema.parse(await props.searchParams);

--- a/apps/nextjs/src/app/[locale]/manage/layout.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/layout.tsx
@@ -61,7 +61,7 @@ export default async function ManageLayout({ children }: PropsWithChildren) {
       icon: IconBox,
       href: "/manage/apps",
       label: t("items.apps"),
-      hidden: !session,
+      hidden: !session?.user.permissions.includes("board-modify-all"),
       iconProps: {
         strokeWidth: 2.5,
       },

--- a/packages/api/src/router/app.ts
+++ b/packages/api/src/router/app.ts
@@ -18,7 +18,8 @@ import { AppAccessControl } from "./app/app-access-control";
 const defaultIcon = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/homarr.svg";
 
 export const appRouter = createTRPCRouter({
-  getPaginated: protectedProcedure
+  getPaginated: permissionRequiredProcedure
+    .requiresPermission("board-modify-all")
     .input(paginatedSchema)
     .output(z.object({ items: z.array(selectAppSchema), totalCount: z.number() }))
     .meta({

--- a/packages/api/src/router/home.ts
+++ b/packages/api/src/router/home.ts
@@ -101,7 +101,7 @@ export const homeRouter = createTRPCRouter({
       });
     }
 
-    if (ctx.session?.user) {
+    if (ctx.session?.user.permissions.includes("board-modify-all")) {
       statistics.push({
         titleKey: "app",
         subtitleKey: "resources",

--- a/packages/api/src/router/test/app.spec.ts
+++ b/packages/api/src/router/test/app.spec.ts
@@ -76,6 +76,33 @@ describe("all should return all apps", () => {
   });
 });
 
+describe("getPaginated should require board modification access", () => {
+  test("should throw FORBIDDEN without board-modify-all", async () => {
+    const caller = appRouter.createCaller({
+      db: createDb(),
+      deviceType: undefined,
+      session: createDefaultSession(),
+    });
+
+    await expect(caller.getPaginated({ page: 1, pageSize: 10 })).rejects.toThrow("Permission denied");
+  });
+
+  test("should return apps with board-modify-all", async () => {
+    const db = createDb();
+    const caller = appRouter.createCaller({
+      db,
+      deviceType: undefined,
+      session: createDefaultSession(["board-modify-all"]),
+    });
+    await db.insert(apps).values({ id: "1", name: "Homarr", iconUrl: "https://homarr.dev/icon.svg" });
+
+    await expect(caller.getPaginated({ page: 1, pageSize: 10 })).resolves.toMatchObject({
+      totalCount: 1,
+      items: [{ id: "1" }],
+    });
+  });
+});
+
 describe("byId should return an app by id", () => {
   test("should return an app by id when canUserSeeAppAsync returns true", async () => {
     // Arrange

--- a/packages/spotlight/src/modes/app-integration-board/index.tsx
+++ b/packages/spotlight/src/modes/app-integration-board/index.tsx
@@ -17,6 +17,10 @@ export const appIntegrationBoardMode = {
       return groups;
     }
 
-    return groups.concat([appsSearchGroup, integrationsSearchGroup]);
+    return groups.concat(
+      session.user.permissions.includes("board-modify-all")
+        ? [appsSearchGroup, integrationsSearchGroup]
+        : [integrationsSearchGroup],
+    );
   },
 } satisfies SearchMode;

--- a/packages/spotlight/src/modes/command/global-group.tsx
+++ b/packages/spotlight/src/modes/command/global-group.tsx
@@ -87,7 +87,8 @@ export const globalCommandGroup = createGroup<Command>({
         icon: IconBox,
         name: tOption("newApp.label"),
         useInteraction: interaction.link(() => ({ href: "/manage/apps/new" })),
-        hidden: !session?.user.permissions.includes("app-create"),
+        hidden:
+          !session?.user.permissions.includes("board-modify-all") || !session?.user.permissions.includes("app-create"),
       },
       {
         commandKey: "newIntegration",

--- a/packages/spotlight/src/modes/page/pages-search-group.tsx
+++ b/packages/spotlight/src/modes/page/pages-search-group.tsx
@@ -76,7 +76,7 @@ export const pagesSearchGroup = createGroup<{
         icon: IconBox,
         path: "/manage/apps",
         name: t("manageApp.label"),
-        hidden: !session,
+        hidden: !session?.user.permissions.includes("board-modify-all"),
       },
       {
         icon: IconPlug,


### PR DESCRIPTION
## Summary

- Hide the Apps management entry point unless the user has `board-modify-all`.
- Enforce the same permission on the Apps page, paginated list endpoint, management-home card, and Spotlight shortcuts.
- Add regression coverage for the paginated endpoint.

Closes #2126

## Validation

- `oxfmt --check` — passed.
- `git diff --check` — passed.
- Focused Vitest/typecheck could not run because this worktree has no installed dependency links and the environment provides Node 24.16 / pnpm 9.5, while the repository requires Node >=24.18 / pnpm >=11.13.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access Control**
  * Restricted app management pages and actions to users with board management permission.
  * Creating or editing apps now requires both board management and the relevant app permission.
  * App listing access and related API requests are denied without the required permission.

* **User Interface**
  * App navigation, search results, statistics, and commands now appear only for authorized users.

* **Tests**
  * Added coverage for authorized and unauthorized app listing requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->