### PR TITLE
fix(widgets): add 350ms hover delay before opening calendar day popover

### DIFF
--- a/packages/widgets/src/calendar/calender-day.module.css
+++ b/packages/widgets/src/calendar/calender-day.module.css
@@ -1,0 +1,7 @@
+.day {
+  border: 2px solid transparent;
+}
+
+.day[aria-expanded="true"] {
+  border-color: var(--mantine-primary-color-filled);
+}

--- a/packages/widgets/src/calendar/calender-day.module.css
+++ b/packages/widgets/src/calendar/calender-day.module.css
@@ -1,7 +1,0 @@
-.day {
-  border: 2px solid transparent;
-}
-
-.day[aria-expanded="true"] {
-  border-color: var(--mantine-primary-color-filled);
-}

--- a/packages/widgets/src/calendar/calender-day.tsx
+++ b/packages/widgets/src/calendar/calender-day.tsx
@@ -5,7 +5,6 @@ import { useRequiredBoard } from "@homarr/boards/context";
 import type { CalendarEvent } from "@homarr/integrations/types";
 
 import { CalendarEventList } from "./calendar-event-list";
-import classes from "./calender-day.module.css";
 
 interface CalendarDayProps {
   date: Date;
@@ -46,7 +45,6 @@ export const CalendarDay = ({ date, events, disabled, rootHeight, rootWidth }: C
           pb={isSmall ? 0 : 10}
           m={0}
           ref={ref}
-          className={classes.day}
           style={{
             alignContent: "center",
             borderRadius: actualItemRadius,

--- a/packages/widgets/src/calendar/calender-day.tsx
+++ b/packages/widgets/src/calendar/calender-day.tsx
@@ -1,5 +1,4 @@
 import { Box, Container, Flex, HoverCard, Text, useMantineTheme } from "@mantine/core";
-import { useElementSize } from "@mantine/hooks";
 
 import { useRequiredBoard } from "@homarr/boards/context";
 import type { CalendarEvent } from "@homarr/integrations/types";
@@ -15,7 +14,6 @@ interface CalendarDayProps {
 }
 
 export const CalendarDay = ({ date, events, disabled, rootHeight, rootWidth }: CalendarDayProps) => {
-  const { ref, height } = useElementSize();
   const board = useRequiredBoard();
   const mantineTheme = useMantineTheme();
   const actualItemRadius = mantineTheme.radius[board.itemRadius];
@@ -24,47 +22,43 @@ export const CalendarDay = ({ date, events, disabled, rootHeight, rootWidth }: C
   const shouldScaleDown = minAxisSize < 350;
   const isSmall = rootHeight < 256;
 
-  const isTooSmallForIndicators = height < 30;
-
   return (
-    <div ref={ref} style={{ width: "100%", height: "100%" }}>
-      <HoverCard
-        position="bottom"
-        withArrow
-        withinPortal
-        radius="lg"
-        shadow="sm"
-        transitionProps={{ transition: "pop" }}
-        openDelay={350}
-        closeDelay={200}
-        disabled={disabled}
-      >
-        <HoverCard.Target>
-          <Container
-            h="100%"
-            w="100%"
-            p={0}
-            pt={isSmall ? 0 : 10}
-            pb={isSmall ? 0 : 10}
-            m={0}
-            pos="relative"
-            style={{
-              alignContent: "center",
-              borderRadius: actualItemRadius,
-              cursor: disabled ? "default" : "pointer",
-            }}
-          >
-            <Text ta={"center"} size={shouldScaleDown ? "xs" : "md"} lh={1}>
-              {date.getDate()}
-            </Text>
-            {!isTooSmallForIndicators && <NotificationIndicator events={events} isSmall={isSmall} />}
-          </Container>
-        </HoverCard.Target>
-        <HoverCard.Dropdown maw="calc(100vw - 24px)" w={512} pe={4} pb={0} style={{ overflow: "hidden" }}>
-          <CalendarEventList events={events} />
-        </HoverCard.Dropdown>
-      </HoverCard>
-    </div>
+    <HoverCard
+      position="bottom"
+      withArrow
+      withinPortal
+      radius="lg"
+      shadow="sm"
+      transitionProps={{ transition: "pop" }}
+      openDelay={350}
+      closeDelay={400}
+      disabled={disabled}
+    >
+      <HoverCard.Target>
+        <Container
+          h="100%"
+          w="100%"
+          p={0}
+          pt={isSmall ? 0 : 10}
+          pb={isSmall ? 0 : 10}
+          m={0}
+          pos="relative"
+          style={{
+            alignContent: "center",
+            borderRadius: actualItemRadius,
+            cursor: disabled ? "default" : "pointer",
+          }}
+        >
+          <Text ta={"center"} size={shouldScaleDown ? "xs" : "md"} lh={1}>
+            {date.getDate()}
+          </Text>
+          <NotificationIndicator events={events} isSmall={isSmall} />
+        </Container>
+      </HoverCard.Target>
+      <HoverCard.Dropdown maw="calc(100vw - 24px)" w={512} pe={4} pb={0} style={{ overflow: "hidden" }}>
+        <CalendarEventList events={events} />
+      </HoverCard.Dropdown>
+    </HoverCard>
   );
 };
 

--- a/packages/widgets/src/calendar/calender-day.tsx
+++ b/packages/widgets/src/calendar/calender-day.tsx
@@ -27,40 +27,44 @@ export const CalendarDay = ({ date, events, disabled, rootHeight, rootWidth }: C
   const isTooSmallForIndicators = height < 30;
 
   return (
-    <HoverCard
-      position="bottom"
-      withArrow
-      withinPortal
-      radius="lg"
-      shadow="sm"
-      transitionProps={{ transition: "pop" }}
-      disabled={disabled}
-    >
-      <HoverCard.Target>
-        <Container
-          h="100%"
-          w="100%"
-          p={0}
-          pt={isSmall ? 0 : 10}
-          pb={isSmall ? 0 : 10}
-          m={0}
-          ref={ref}
-          style={{
-            alignContent: "center",
-            borderRadius: actualItemRadius,
-            cursor: disabled ? "default" : "pointer",
-          }}
-        >
-          <Text ta={"center"} size={shouldScaleDown ? "xs" : "md"} lh={1}>
-            {date.getDate()}
-          </Text>
-          {!isTooSmallForIndicators && <NotificationIndicator events={events} isSmall={isSmall} />}
-        </Container>
-      </HoverCard.Target>
-      <HoverCard.Dropdown maw="calc(100vw - 24px)" w={512} pe={4} pb={0} style={{ overflow: "hidden" }}>
-        <CalendarEventList events={events} />
-      </HoverCard.Dropdown>
-    </HoverCard>
+    <div ref={ref} style={{ width: "100%", height: "100%" }}>
+      <HoverCard
+        position="bottom"
+        withArrow
+        withinPortal
+        radius="lg"
+        shadow="sm"
+        transitionProps={{ transition: "pop" }}
+        openDelay={350}
+        closeDelay={200}
+        disabled={disabled}
+      >
+        <HoverCard.Target>
+          <Container
+            h="100%"
+            w="100%"
+            p={0}
+            pt={isSmall ? 0 : 10}
+            pb={isSmall ? 0 : 10}
+            m={0}
+            pos="relative"
+            style={{
+              alignContent: "center",
+              borderRadius: actualItemRadius,
+              cursor: disabled ? "default" : "pointer",
+            }}
+          >
+            <Text ta={"center"} size={shouldScaleDown ? "xs" : "md"} lh={1}>
+              {date.getDate()}
+            </Text>
+            {!isTooSmallForIndicators && <NotificationIndicator events={events} isSmall={isSmall} />}
+          </Container>
+        </HoverCard.Target>
+        <HoverCard.Dropdown maw="calc(100vw - 24px)" w={512} pe={4} pb={0} style={{ overflow: "hidden" }}>
+          <CalendarEventList events={events} />
+        </HoverCard.Dropdown>
+      </HoverCard>
+    </div>
   );
 };
 

--- a/packages/widgets/src/calendar/calender-day.tsx
+++ b/packages/widgets/src/calendar/calender-day.tsx
@@ -1,4 +1,4 @@
-import { Box, Container, Flex, Popover, Text, useMantineTheme } from "@mantine/core";
+import { Box, Container, Flex, HoverCard, Text, useMantineTheme } from "@mantine/core";
 import { useElementSize } from "@mantine/hooks";
 
 import { useRequiredBoard } from "@homarr/boards/context";
@@ -28,16 +28,17 @@ export const CalendarDay = ({ date, events, disabled, rootHeight, rootWidth }: C
   const isTooSmallForIndicators = height < 30;
 
   return (
-    <Popover
+    <HoverCard
       position="bottom"
       withArrow
       withinPortal
       radius="lg"
       shadow="sm"
       transitionProps={{ transition: "pop" }}
+      openDelay={350}
       disabled={disabled}
     >
-      <Popover.Target>
+      <HoverCard.Target>
         <Container
           h="100%"
           w="100%"
@@ -58,11 +59,11 @@ export const CalendarDay = ({ date, events, disabled, rootHeight, rootWidth }: C
           </Text>
           {!isTooSmallForIndicators && <NotificationIndicator events={events} isSmall={isSmall} />}
         </Container>
-      </Popover.Target>
-      <Popover.Dropdown maw="calc(100vw - 24px)" w={512} pe={4} pb={0} style={{ overflow: "hidden" }}>
+      </HoverCard.Target>
+      <HoverCard.Dropdown maw="calc(100vw - 24px)" w={512} pe={4} pb={0} style={{ overflow: "hidden" }}>
         <CalendarEventList events={events} />
-      </Popover.Dropdown>
-    </Popover>
+      </HoverCard.Dropdown>
+    </HoverCard>
   );
 };
 

--- a/packages/widgets/src/calendar/calender-day.tsx
+++ b/packages/widgets/src/calendar/calender-day.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useState } from "react";
 import { Box, Container, Flex, Popover, Text, useMantineTheme } from "@mantine/core";
 import { useElementSize } from "@mantine/hooks";
 
@@ -6,6 +5,7 @@ import { useRequiredBoard } from "@homarr/boards/context";
 import type { CalendarEvent } from "@homarr/integrations/types";
 
 import { CalendarEventList } from "./calendar-event-list";
+import classes from "./calender-day.module.css";
 
 interface CalendarDayProps {
   date: Date;
@@ -13,13 +13,9 @@ interface CalendarDayProps {
   disabled: boolean;
   rootWidth: number;
   rootHeight: number;
-  onOpen: (close: () => void) => void;
 }
 
-export const CalendarDay = ({ date, events, disabled, rootHeight, rootWidth, onOpen }: CalendarDayProps) => {
-  const [opened, setOpened] = useState(false);
-  const [pinned, setPinned] = useState(false);
-  const { primaryColor } = useMantineTheme();
+export const CalendarDay = ({ date, events, disabled, rootHeight, rootWidth }: CalendarDayProps) => {
   const { ref, height } = useElementSize();
   const board = useRequiredBoard();
   const mantineTheme = useMantineTheme();
@@ -31,19 +27,6 @@ export const CalendarDay = ({ date, events, disabled, rootHeight, rootWidth, onO
 
   const isTooSmallForIndicators = height < 30;
 
-  const handleMouseEnter = useCallback(() => {
-    if (disabled) return;
-    onOpen(() => {
-      setOpened(false);
-      setPinned(false);
-    });
-    setOpened(true);
-  }, [disabled, onOpen]);
-
-  const handleMouseLeave = useCallback(() => {
-    if (!pinned) setOpened(false);
-  }, [pinned]);
-
   return (
     <Popover
       position="bottom"
@@ -51,14 +34,7 @@ export const CalendarDay = ({ date, events, disabled, rootHeight, rootWidth, onO
       withinPortal
       radius="lg"
       shadow="sm"
-      transitionProps={{
-        transition: "pop",
-      }}
-      onChange={(value) => {
-        setOpened(value);
-        if (!value) setPinned(false);
-      }}
-      opened={opened}
+      transitionProps={{ transition: "pop" }}
       disabled={disabled}
     >
       <Popover.Target>
@@ -70,17 +46,12 @@ export const CalendarDay = ({ date, events, disabled, rootHeight, rootWidth, onO
           pb={isSmall ? 0 : 10}
           m={0}
           ref={ref}
-          bd={`2px solid ${opened && !disabled ? primaryColor : "transparent"}`}
+          className={classes.day}
           style={{
             alignContent: "center",
             borderRadius: actualItemRadius,
             cursor: disabled ? "default" : "pointer",
           }}
-          onClick={() => {
-            if (!disabled) setPinned((prev) => !prev);
-          }}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
         >
           <Text ta={"center"} size={shouldScaleDown ? "xs" : "md"} lh={1}>
             {date.getDate()}
@@ -88,16 +59,7 @@ export const CalendarDay = ({ date, events, disabled, rootHeight, rootWidth, onO
           {!isTooSmallForIndicators && <NotificationIndicator events={events} isSmall={isSmall} />}
         </Container>
       </Popover.Target>
-      {/* Popover has some offset on the left side, padding is removed because of scrollarea paddings */}
-      <Popover.Dropdown
-        maw="calc(100vw - 24px)"
-        w={512}
-        pe={4}
-        pb={0}
-        style={{ overflow: "hidden" }}
-        onMouseEnter={() => setOpened(true)}
-        onMouseLeave={handleMouseLeave}
-      >
+      <Popover.Dropdown maw="calc(100vw - 24px)" w={512} pe={4} pb={0} style={{ overflow: "hidden" }}>
         <CalendarEventList events={events} />
       </Popover.Dropdown>
     </Popover>
@@ -111,7 +73,6 @@ interface NotificationIndicatorProps {
 
 const NotificationIndicator = ({ events, isSmall }: NotificationIndicatorProps) => {
   const notificationEvents = [...new Set(events.map((event) => event.indicatorColor))].filter(String);
-  /* position bottom is lower when small to not be on top of number*/
   return (
     <Flex
       w="75%"

--- a/packages/widgets/src/calendar/calender-day.tsx
+++ b/packages/widgets/src/calendar/calender-day.tsx
@@ -35,7 +35,6 @@ export const CalendarDay = ({ date, events, disabled, rootHeight, rootWidth }: C
       radius="lg"
       shadow="sm"
       transitionProps={{ transition: "pop" }}
-      openDelay={350}
       disabled={disabled}
     >
       <HoverCard.Target>

--- a/packages/widgets/src/calendar/component.tsx
+++ b/packages/widgets/src/calendar/component.tsx
@@ -69,81 +69,81 @@ const CalendarBase = ({ isEditMode, events, month, setMonth, options }: Calendar
   return (
     <Calendar
       defaultDate={new Date()}
-        onPreviousMonth={(month) => setMonth(new Date(month))}
-        onNextMonth={(month) => setMonth(new Date(month))}
-        highlightToday
-        locale={locale}
-        hideWeekdays={false}
-        date={month}
-        maxLevel="month"
-        firstDayOfWeek={firstDayOfWeek}
-        static={isEditMode}
-        className={classes.calendar}
-        w="100%"
-        h="100%"
-        ref={ref}
-        styles={{
-          calendarHeaderControl: {
-            pointerEvents: isEditMode ? "none" : undefined,
-            borderRadius: "md",
-            height: isSmall ? "1.5rem" : undefined,
-            width: isSmall ? "1.5rem" : undefined,
-          },
-          calendarHeaderLevel: {
-            pointerEvents: "none",
-            fontSize: isSmall ? "0.75rem" : undefined,
-            height: "100%",
-          },
-          levelsGroup: {
-            height: "100%",
-            padding: "md",
-          },
-          calendarHeader: {
-            maxWidth: "unset",
-            marginBottom: 0,
-          },
-          monthCell: {
-            textAlign: "center",
-            position: "relative",
-          },
-          day: {
-            borderRadius: actualItemRadius,
-            width: "100%",
-            height: "100%",
-            position: "absolute",
-            top: 0,
-            left: 0,
-            bottom: 0,
-            right: 0,
-          },
-          month: {
-            height: "100%",
-          },
-          weekday: {
-            padding: 0,
-          },
-          weekdaysRow: {
-            height: 22,
-          },
-        }}
-        renderDay={(tileDate) => {
-          const eventsForDate = normalizedEvents
-            .filter((event) => dayjs(event.startDate).isSame(tileDate, "day"))
-            .filter(
-              (event) => event.metadata?.type !== "radarr" || options.releaseType.includes(event.metadata.releaseType),
-            )
-            .toSorted((eventA, eventB) => eventA.startDate.getTime() - eventB.startDate.getTime());
+      onPreviousMonth={(month) => setMonth(new Date(month))}
+      onNextMonth={(month) => setMonth(new Date(month))}
+      highlightToday
+      locale={locale}
+      hideWeekdays={false}
+      date={month}
+      maxLevel="month"
+      firstDayOfWeek={firstDayOfWeek}
+      static={isEditMode}
+      className={classes.calendar}
+      w="100%"
+      h="100%"
+      ref={ref}
+      styles={{
+        calendarHeaderControl: {
+          pointerEvents: isEditMode ? "none" : undefined,
+          borderRadius: "md",
+          height: isSmall ? "1.5rem" : undefined,
+          width: isSmall ? "1.5rem" : undefined,
+        },
+        calendarHeaderLevel: {
+          pointerEvents: "none",
+          fontSize: isSmall ? "0.75rem" : undefined,
+          height: "100%",
+        },
+        levelsGroup: {
+          height: "100%",
+          padding: "md",
+        },
+        calendarHeader: {
+          maxWidth: "unset",
+          marginBottom: 0,
+        },
+        monthCell: {
+          textAlign: "center",
+          position: "relative",
+        },
+        day: {
+          borderRadius: actualItemRadius,
+          width: "100%",
+          height: "100%",
+          position: "absolute",
+          top: 0,
+          left: 0,
+          bottom: 0,
+          right: 0,
+        },
+        month: {
+          height: "100%",
+        },
+        weekday: {
+          padding: 0,
+        },
+        weekdaysRow: {
+          height: 22,
+        },
+      }}
+      renderDay={(tileDate) => {
+        const eventsForDate = normalizedEvents
+          .filter((event) => dayjs(event.startDate).isSame(tileDate, "day"))
+          .filter(
+            (event) => event.metadata?.type !== "radarr" || options.releaseType.includes(event.metadata.releaseType),
+          )
+          .toSorted((eventA, eventB) => eventA.startDate.getTime() - eventB.startDate.getTime());
 
-          return (
-            <CalendarDay
-              date={dayjs(tileDate).toDate()}
-              events={eventsForDate}
-              disabled={isEditMode || eventsForDate.length === 0}
-              rootWidth={width}
-              rootHeight={height}
-            />
-          );
-        }}
+        return (
+          <CalendarDay
+            date={dayjs(tileDate).toDate()}
+            events={eventsForDate}
+            disabled={isEditMode || eventsForDate.length === 0}
+            rootWidth={width}
+            rootHeight={height}
+          />
+        );
+      }}
     />
   );
 };

--- a/packages/widgets/src/calendar/component.tsx
+++ b/packages/widgets/src/calendar/component.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useParams } from "next/navigation";
-import { useMantineTheme } from "@mantine/core";
+import { useMantineTheme, HoverCard } from "@mantine/core";
 import { Calendar } from "@mantine/dates";
 import { useElementSize } from "@mantine/hooks";
 import dayjs from "dayjs";
@@ -67,84 +67,86 @@ const CalendarBase = ({ isEditMode, events, month, setMonth, options }: Calendar
   const normalizedEvents = useMemo(() => splitEvents(events), [events]);
 
   return (
-    <Calendar
-      defaultDate={new Date()}
-      onPreviousMonth={(month) => setMonth(new Date(month))}
-      onNextMonth={(month) => setMonth(new Date(month))}
-      highlightToday
-      locale={locale}
-      hideWeekdays={false}
-      date={month}
-      maxLevel="month"
-      firstDayOfWeek={firstDayOfWeek}
-      static={isEditMode}
-      className={classes.calendar}
-      w="100%"
-      h="100%"
-      ref={ref}
-      styles={{
-        calendarHeaderControl: {
-          pointerEvents: isEditMode ? "none" : undefined,
-          borderRadius: "md",
-          height: isSmall ? "1.5rem" : undefined,
-          width: isSmall ? "1.5rem" : undefined,
-        },
-        calendarHeaderLevel: {
-          pointerEvents: "none",
-          fontSize: isSmall ? "0.75rem" : undefined,
-          height: "100%",
-        },
-        levelsGroup: {
-          height: "100%",
-          padding: "md",
-        },
-        calendarHeader: {
-          maxWidth: "unset",
-          marginBottom: 0,
-        },
-        monthCell: {
-          textAlign: "center",
-          position: "relative",
-        },
-        day: {
-          borderRadius: actualItemRadius,
-          width: "100%",
-          height: "100%",
-          position: "absolute",
-          top: 0,
-          left: 0,
-          bottom: 0,
-          right: 0,
-        },
-        month: {
-          height: "100%",
-        },
-        weekday: {
-          padding: 0,
-        },
-        weekdaysRow: {
-          height: 22,
-        },
-      }}
-      renderDay={(tileDate) => {
-        const eventsForDate = normalizedEvents
-          .filter((event) => dayjs(event.startDate).isSame(tileDate, "day"))
-          .filter(
-            (event) => event.metadata?.type !== "radarr" || options.releaseType.includes(event.metadata.releaseType),
-          )
-          .toSorted((eventA, eventB) => eventA.startDate.getTime() - eventB.startDate.getTime());
+    <HoverCard.Group openDelay={350} closeDelay={200}>
+      <Calendar
+        defaultDate={new Date()}
+        onPreviousMonth={(month) => setMonth(new Date(month))}
+        onNextMonth={(month) => setMonth(new Date(month))}
+        highlightToday
+        locale={locale}
+        hideWeekdays={false}
+        date={month}
+        maxLevel="month"
+        firstDayOfWeek={firstDayOfWeek}
+        static={isEditMode}
+        className={classes.calendar}
+        w="100%"
+        h="100%"
+        ref={ref}
+        styles={{
+          calendarHeaderControl: {
+            pointerEvents: isEditMode ? "none" : undefined,
+            borderRadius: "md",
+            height: isSmall ? "1.5rem" : undefined,
+            width: isSmall ? "1.5rem" : undefined,
+          },
+          calendarHeaderLevel: {
+            pointerEvents: "none",
+            fontSize: isSmall ? "0.75rem" : undefined,
+            height: "100%",
+          },
+          levelsGroup: {
+            height: "100%",
+            padding: "md",
+          },
+          calendarHeader: {
+            maxWidth: "unset",
+            marginBottom: 0,
+          },
+          monthCell: {
+            textAlign: "center",
+            position: "relative",
+          },
+          day: {
+            borderRadius: actualItemRadius,
+            width: "100%",
+            height: "100%",
+            position: "absolute",
+            top: 0,
+            left: 0,
+            bottom: 0,
+            right: 0,
+          },
+          month: {
+            height: "100%",
+          },
+          weekday: {
+            padding: 0,
+          },
+          weekdaysRow: {
+            height: 22,
+          },
+        }}
+        renderDay={(tileDate) => {
+          const eventsForDate = normalizedEvents
+            .filter((event) => dayjs(event.startDate).isSame(tileDate, "day"))
+            .filter(
+              (event) => event.metadata?.type !== "radarr" || options.releaseType.includes(event.metadata.releaseType),
+            )
+            .toSorted((eventA, eventB) => eventA.startDate.getTime() - eventB.startDate.getTime());
 
-        return (
-          <CalendarDay
-            date={dayjs(tileDate).toDate()}
-            events={eventsForDate}
-            disabled={isEditMode || eventsForDate.length === 0}
-            rootWidth={width}
-            rootHeight={height}
-          />
-        );
-      }}
-    />
+          return (
+            <CalendarDay
+              date={dayjs(tileDate).toDate()}
+              events={eventsForDate}
+              disabled={isEditMode || eventsForDate.length === 0}
+              rootWidth={width}
+              rootHeight={height}
+            />
+          );
+        }}
+      />
+    </HoverCard.Group>
   );
 };
 

--- a/packages/widgets/src/calendar/component.tsx
+++ b/packages/widgets/src/calendar/component.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useParams } from "next/navigation";
-import { useMantineTheme, HoverCard } from "@mantine/core";
+import { useMantineTheme } from "@mantine/core";
 import { Calendar } from "@mantine/dates";
 import { useElementSize } from "@mantine/hooks";
 import dayjs from "dayjs";
@@ -67,9 +67,8 @@ const CalendarBase = ({ isEditMode, events, month, setMonth, options }: Calendar
   const normalizedEvents = useMemo(() => splitEvents(events), [events]);
 
   return (
-    <HoverCard.Group openDelay={350} closeDelay={200}>
-      <Calendar
-        defaultDate={new Date()}
+    <Calendar
+      defaultDate={new Date()}
         onPreviousMonth={(month) => setMonth(new Date(month))}
         onNextMonth={(month) => setMonth(new Date(month))}
         highlightToday
@@ -145,8 +144,7 @@ const CalendarBase = ({ isEditMode, events, month, setMonth, options }: Calendar
             />
           );
         }}
-      />
-    </HoverCard.Group>
+    />
   );
 };
 

--- a/packages/widgets/src/calendar/component.tsx
+++ b/packages/widgets/src/calendar/component.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import { useMantineTheme } from "@mantine/core";
 import { Calendar } from "@mantine/dates";
@@ -65,11 +65,6 @@ const CalendarBase = ({ isEditMode, events, month, setMonth, options }: Calendar
   const isSmall = width < 256;
 
   const normalizedEvents = useMemo(() => splitEvents(events), [events]);
-  const activeCloseRef = useRef<(() => void) | null>(null);
-  const onDayOpen = useCallback((close: () => void) => {
-    activeCloseRef.current?.();
-    activeCloseRef.current = close;
-  }, []);
 
   return (
     <Calendar
@@ -146,7 +141,6 @@ const CalendarBase = ({ isEditMode, events, month, setMonth, options }: Calendar
             disabled={isEditMode || eventsForDate.length === 0}
             rootWidth={width}
             rootHeight={height}
-            onOpen={onDayOpen}
           />
         );
       }}


### PR DESCRIPTION
Closes #2637

Adds a 350ms hover delay before the calendar day popover opens, preventing it from triggering when users drag the mouse across the calendar grid. The delay is cleared on mouse leave, so quickly passing over a day won't trigger the popover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar day popovers with smoother hover-based opening and closing behavior.
  * Simplified calendar interactions by removing click-to-toggle and inconsistent hover state behavior.
  * Refined trigger styling for a more consistent calendar experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->