### PR TITLE
fix(media-server): guard against undefined playback from stale cached data

### DIFF
--- a/packages/widgets/src/media-server/component.tsx
+++ b/packages/widgets/src/media-server/component.tsx
@@ -66,10 +66,12 @@ export default function MediaServerWidget({ options, integrationIds }: WidgetCom
           const currentlyPlaying = row.original.currentlyPlaying;
           if (!currentlyPlaying) return null;
 
-          const isPaused = currentlyPlaying.playback.state === "paused";
+          const playback = currentlyPlaying.playback;
+          const isPaused = playback?.state === "paused";
           const Icon = isPaused ? IconPlayerPause : mediaTypeIconMap[currentlyPlaying.type];
 
-          const { positionMs, durationMs } = currentlyPlaying.playback;
+          const positionMs = playback?.positionMs ?? null;
+          const durationMs = playback?.durationMs ?? null;
           const progressPercent =
             positionMs !== null && durationMs !== null && durationMs > 0
               ? Math.min(100, Math.round((positionMs / durationMs) * 100))


### PR DESCRIPTION
## Summary

Fixes `TypeError: can't access property "state", i.playback is undefined` on the media server (Current Playing) widget.

## Root Cause

PR #6315 introduced `playback` and `location` fields to `StreamSession.currentlyPlaying`. When TanStack Query returns cached session data from before the schema change, or when an integration has not yet been updated, the `playback` field is `undefined` at runtime even though the TypeScript type says it's always present.

## Fix

Added optional chaining and nullish coalescing on `playback` accesses in the Currently Playing column cell renderer:

- `playback?.state` instead of direct property access
- `playback?.positionMs ?? null` and `playback?.durationMs ?? null` instead of destructuring

## Verification

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Media Server widget’s handling of items without playback information.
  * Prevented playback status and progress displays from failing when media details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->