### PR TITLE
feat(widgets): add live tennis widget

### DIFF
--- a/apps/docs/docs/advanced/environment-variables/index.mdx
+++ b/apps/docs/docs/advanced/environment-variables/index.mdx
@@ -33,6 +33,12 @@ Using the `PUID` and `PGID` will require you to set the correct permissions on t
 | ``NO_EXTERNAL_CONNECTION`` | Disables some requests that need internet connection | `true` or `false` | `false` |
 | ``ENABLE_DNS_CACHING`` | Enables dns caching. Enabled by default, but if you experience issues with IPv6 or static IPs, see [#4006](https://github.com/homarr-labs/homarr/issues/4006) or disable this flag | `true` or `false` | `true` |
 
+## Widgets
+
+| Environment Variable     | Description | Possible values | Default |
+| ------------------------ | ----------- | --------------- | ------- |
+| ``LIVE_TENNIS_API_KEY`` | API key used by the [Live Tennis](/docs/widgets/tennis) widget. A free key is available at [livetennisapi.com](https://livetennisapi.com/subscribe/free) | Any valid Live Tennis API key | *empty* |
+
 
 
 ## Authentication

--- a/apps/docs/docs/widgets/tennis/index.mdx
+++ b/apps/docs/docs/widgets/tennis/index.mdx
@@ -1,0 +1,53 @@
+---
+title: "Live Tennis"
+description: "Displays live, upcoming or completed tennis matches."
+hide_title: true
+---
+
+import { AddingWidget } from "@site/src/components/widgets/adding";
+import { WidgetConfig } from "@site/src/components/widgets/configuration";
+import { WidgetHeader } from "@site/src/components/widgets/header";
+import { tennisWidget } from ".";
+
+<WidgetHeader widget={tennisWidget} categories={["Sports"]} />
+
+The Live Tennis widget shows tennis matches on your dashboard, including live set and game scores,
+the player currently serving and the current game points.
+
+### Adding the widget
+
+<AddingWidget />
+
+### Configuration
+
+<WidgetConfig configuration={tennisWidget.configuration} />
+
+### API key
+
+This widget uses the [Live Tennis API](https://livetennisapi.com), which requires an API key.
+A free tier is available without a credit card at https://livetennisapi.com/subscribe/free.
+
+The key is read **server side only** from the `LIVE_TENNIS_API_KEY` environment variable and is
+never sent to the browser:
+
+```yaml
+services:
+  homarr:
+    environment:
+      - LIVE_TENNIS_API_KEY=twjp_your_key_here
+```
+
+:::warning
+Do not put the API key into a widget option. Board items are readable by everyone who can view the
+board, including anonymous visitors on public boards.
+:::
+
+If the variable is not set, or the key is rejected by the API, the widget shows a
+"No valid Live Tennis API key configured" message instead of the scoreboard.
+
+### Data source
+
+Match data is fetched server side from `https://api.livetennisapi.com`.
+If you need to whitelist the API, please use the following URL: `https://api.livetennisapi.com`
+
+The widget respects `NO_EXTERNAL_CONNECTION`; when that is enabled no request is made.

--- a/apps/docs/docs/widgets/tennis/index.tsx
+++ b/apps/docs/docs/widgets/tennis/index.tsx
@@ -1,0 +1,50 @@
+import { WidgetDefinition } from "@site/src/types";
+import { IconBallTennis } from "@tabler/icons-react";
+
+export const tennisWidget: WidgetDefinition = {
+  icon: IconBallTennis,
+  name: "Live Tennis",
+  description:
+    "Displays live, upcoming or completed tennis matches from the ATP, WTA, Challenger, ITF and junior tours.",
+  path: "../../widgets/tennis",
+  configuration: {
+    items: [
+      {
+        name: "Tour",
+        description: "Restrict the shown matches to a single tour",
+        values: {
+          type: "select",
+          options: ["All tours", "ATP", "WTA", "Challenger", "ITF", "Juniors"],
+        },
+        defaultValue: "All tours",
+      },
+      {
+        name: "Match status",
+        description: "Whether to show live, upcoming or completed matches",
+        values: {
+          type: "select",
+          options: ["Live", "Upcoming", "Completed"],
+        },
+        defaultValue: "Live",
+      },
+      {
+        name: "Number of matches",
+        description: "The maximum number of matches shown in the widget (1-20)",
+        values: { type: "string" },
+        defaultValue: "5",
+      },
+      {
+        name: "Show tournament name",
+        description: "Shows the tournament each match belongs to",
+        values: { type: "boolean" },
+        defaultValue: "true",
+      },
+      {
+        name: "Show player ranking",
+        description: "Shows the current world ranking next to each player",
+        values: { type: "boolean" },
+        defaultValue: "false",
+      },
+    ],
+  },
+};

--- a/packages/api/src/router/widgets/index.ts
+++ b/packages/api/src/router/widgets/index.ts
@@ -17,6 +17,7 @@ export const widgetRouter = createTRPCRouter({
   dnsHole: lazy(() => import("./dns-hole").then((mod) => mod.dnsHoleRouter)),
   smartHome: lazy(() => import("./smart-home").then((mod) => mod.smartHomeRouter)),
   stockPrice: lazy(() => import("./stocks").then((mod) => mod.stockPriceRouter)),
+  tennis: lazy(() => import("./tennis").then((mod) => mod.tennisRouter)),
   mediaServer: lazy(() => import("./media-server").then((mod) => mod.mediaServerRouter)),
   mediaRelease: lazy(() => import("./media-release").then((mod) => mod.mediaReleaseRouter)),
   calendar: lazy(() => import("./calendar").then((mod) => mod.calendarRouter)),

--- a/packages/api/src/router/widgets/tennis.ts
+++ b/packages/api/src/router/widgets/tennis.ts
@@ -1,0 +1,34 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod/v4";
+
+import { fetchTennisMatchesHandler, TennisApiKeyError } from "@homarr/request-handler/tennis";
+
+import { tennisStatuses, tennisTours } from "../../../../widgets/src/tennis";
+import { createTRPCRouter, publicProcedure } from "../../trpc";
+
+const tennisInputSchema = z.object({
+  tour: z.enum(tennisTours),
+  status: z.enum(tennisStatuses),
+  matchCount: z.number().min(1).max(20),
+  showTournament: z.boolean(),
+  showRanking: z.boolean(),
+});
+
+export const tennisRouter = createTRPCRouter({
+  getMatches: publicProcedure.input(tennisInputSchema).query(async ({ input }) => {
+    const innerHandler = fetchTennisMatchesHandler.handler({
+      tour: input.tour,
+      status: input.status,
+      matchCount: input.matchCount,
+    });
+
+    try {
+      return await innerHandler.getDataAsync();
+    } catch (error) {
+      if (error instanceof TennisApiKeyError) {
+        throw new TRPCError({ code: "UNAUTHORIZED", message: error.message });
+      }
+      throw error;
+    }
+  }),
+});

--- a/packages/api/src/router/widgets/tennis.ts
+++ b/packages/api/src/router/widgets/tennis.ts
@@ -9,26 +9,35 @@ import { createTRPCRouter, publicProcedure } from "../../trpc";
 const tennisInputSchema = z.object({
   tour: z.enum(tennisTours),
   status: z.enum(tennisStatuses),
-  matchCount: z.number().min(1).max(20),
+  matchCount: z.number().int().min(1).max(20),
   showTournament: z.boolean(),
   showRanking: z.boolean(),
 });
 
 export const tennisRouter = createTRPCRouter({
-  getMatches: publicProcedure.input(tennisInputSchema).query(async ({ input }) => {
-    const innerHandler = fetchTennisMatchesHandler.handler({
-      tour: input.tour,
-      status: input.status,
-      matchCount: input.matchCount,
-    });
+  getMatches: publicProcedure
+    .meta({
+      mcp: {
+        enabled: true,
+        description:
+          "Get tennis matches from the Live Tennis API. Returns live scores, upcoming fixtures or completed results for ATP, WTA, Challenger, ITF and Grand Slam juniors. REQUIRED: tour (all|atp|wta|challenger|itf|juniors), status (live|upcoming|completed), matchCount (1-20), showTournament, showRanking. Requires the LIVE_TENNIS_API_KEY environment variable to be set on the Homarr server.",
+      },
+    })
+    .input(tennisInputSchema)
+    .query(async ({ input }) => {
+      const innerHandler = fetchTennisMatchesHandler.handler({
+        tour: input.tour,
+        status: input.status,
+        matchCount: input.matchCount,
+      });
 
-    try {
-      return await innerHandler.getDataAsync();
-    } catch (error) {
-      if (error instanceof TennisApiKeyError) {
-        throw new TRPCError({ code: "UNAUTHORIZED", message: error.message });
+      try {
+        return await innerHandler.getDataAsync();
+      } catch (error) {
+        if (error instanceof TennisApiKeyError) {
+          throw new TRPCError({ code: "UNAUTHORIZED", message: error.message });
+        }
+        throw error;
       }
-      throw error;
-    }
-  }),
+    }),
 });

--- a/packages/definitions/src/docs/widget-doc-slugs.ts
+++ b/packages/definitions/src/docs/widget-doc-slugs.ts
@@ -13,6 +13,7 @@ export const widgetDocSlugs: Record<WidgetKind, string | null> = {
   "smartHome-entityState": "smart-home-entity-state",
   "smartHome-executeAutomation": "smart-home-execute-automation",
   stockPrice: "stock-price",
+  tennis: "tennis",
   mediaServer: "media-server",
   calendar: "calendar",
   downloads: "downloads",

--- a/packages/definitions/src/widget.ts
+++ b/packages/definitions/src/widget.ts
@@ -11,6 +11,7 @@ export const widgetKinds = [
   "smartHome-entityState",
   "smartHome-executeAutomation",
   "stockPrice",
+  "tennis",
   "mediaServer",
   "calendar",
   "downloads",

--- a/packages/request-handler/src/env.ts
+++ b/packages/request-handler/src/env.ts
@@ -1,0 +1,12 @@
+import { z } from "zod/v4";
+
+import { createEnv } from "@homarr/core/infrastructure/env";
+
+export const env = createEnv({
+  server: {
+    LIVE_TENNIS_API_KEY: z.string().optional(),
+  },
+  runtimeEnv: {
+    LIVE_TENNIS_API_KEY: process.env.LIVE_TENNIS_API_KEY,
+  },
+});

--- a/packages/request-handler/src/tennis-mapping.spec.ts
+++ b/packages/request-handler/src/tennis-mapping.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "vitest";
+
+import { parseTennisResponse } from "./tennis-mapping";
+
+// Trimmed from a real api.livetennisapi.com /matches response.
+const liveMatch = {
+  id: 21631,
+  status: "live",
+  tournament: "M15 Kursumlijska Banja 10",
+  round: "M15 Kursumlijska Banja 10 - 1/16-finals",
+  surface: "clay",
+  is_doubles: false,
+  scheduled_time: "2026-07-22T09:00:00Z",
+  players: {
+    p1: { id: 4980, name: "Tito Chavez", country: "esp", ranking: 1192 },
+    p2: { id: 12543, name: "Didrik Liljekvist", country: "swe", ranking: null },
+  },
+  score: {
+    games: [
+      [2, 6, 2],
+      [6, 3, 3],
+    ],
+    sets: [1, 1],
+    points: ["40", "AD"],
+    server: 1,
+    is_tiebreak: false,
+  },
+};
+
+const upcomingMatch = {
+  id: 21660,
+  status: "upcoming",
+  tournament: "W15 Las Palmas de Gran Canaria",
+  round: "W15 Las Palmas de Gran Canaria - 1/16-finals",
+  surface: "clay",
+  is_doubles: false,
+  scheduled_time: "2026-07-22T12:00:00Z",
+  players: {
+    p1: { id: 3037, name: "Victoria O'Hayon Gomez", country: "esp", ranking: 969 },
+    p2: { id: 11828, name: "Naomi McKenzie", country: "aus", ranking: 1273 },
+  },
+  score: null,
+};
+
+describe("parseTennisResponse", () => {
+  test("splits the per-set game arrays onto the two players", () => {
+    const { matches } = parseTennisResponse({ data: [liveMatch] });
+    const [match] = matches;
+
+    expect(match?.players[0].games).toStrictEqual([2, 6, 2]);
+    expect(match?.players[1].games).toStrictEqual([6, 3, 3]);
+    expect(match?.players[0].sets).toBe(1);
+    expect(match?.players[1].sets).toBe(1);
+  });
+
+  test("maps the current game points and the serving player", () => {
+    const { matches } = parseTennisResponse({ data: [liveMatch] });
+    const [match] = matches;
+
+    expect(match?.players[0].points).toBe("40");
+    expect(match?.players[1].points).toBe("AD");
+    // server: 1 refers to p1, which is index 0.
+    expect(match?.players[0].isServing).toBe(true);
+    expect(match?.players[1].isServing).toBe(false);
+  });
+
+  test("uppercases country codes and keeps a missing ranking null", () => {
+    const { matches } = parseTennisResponse({ data: [liveMatch] });
+    const [match] = matches;
+
+    expect(match?.players[0].country).toBe("ESP");
+    expect(match?.players[1].ranking).toBeNull();
+  });
+
+  test("handles upcoming matches that have no score yet", () => {
+    const { matches } = parseTennisResponse({ data: [upcomingMatch] });
+    const [match] = matches;
+
+    expect(match?.players[0].games).toStrictEqual([]);
+    expect(match?.players[0].points).toBeNull();
+    expect(match?.players[0].isServing).toBe(false);
+    expect(match?.scheduledTime).toBe("2026-07-22T12:00:00Z");
+  });
+
+  test("tolerates unknown extra fields and missing optional fields", () => {
+    const { matches } = parseTennisResponse({
+      data: [{ id: 1, status: "live", players: { p1: { id: 1, name: "A" }, p2: { id: 2, name: "B" } }, extra: true }],
+    });
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.tournament).toBeNull();
+    expect(matches[0]?.surface).toBeNull();
+    expect(matches[0]?.players[0].country).toBeNull();
+  });
+
+  test("rejects a payload that is not shaped like the API response", () => {
+    expect(() => parseTennisResponse({ data: [{ id: "not-a-number" }] })).toThrow();
+  });
+});

--- a/packages/request-handler/src/tennis-mapping.ts
+++ b/packages/request-handler/src/tennis-mapping.ts
@@ -1,0 +1,60 @@
+import { z } from "zod/v4";
+
+const playerSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  country: z.string().nullish(),
+  ranking: z.number().nullish(),
+});
+
+const scoreSchema = z.object({
+  // games[0] holds the per-set game count of player one, games[1] of player two.
+  games: z.array(z.array(z.number())).nullish(),
+  sets: z.array(z.number()).nullish(),
+  // points are the current game points, e.g. ["40", "AD"]. Absent between games.
+  points: z.array(z.string()).nullish(),
+  server: z.number().nullish(),
+});
+
+const matchSchema = z.object({
+  id: z.number(),
+  status: z.string(),
+  tournament: z.string().nullish(),
+  surface: z.string().nullish(),
+  scheduled_time: z.string().nullish(),
+  players: z.object({ p1: playerSchema, p2: playerSchema }),
+  score: scoreSchema.nullish(),
+});
+
+const responseSchema = z.object({
+  data: z.array(matchSchema),
+});
+
+const toPlayer = (player: z.infer<typeof playerSchema>, index: 0 | 1, score: z.infer<typeof scoreSchema> | null) => ({
+  id: player.id,
+  name: player.name,
+  // The API returns lowercase ISO-3166 alpha-3 style codes, e.g. "esp".
+  country: player.country?.toUpperCase() ?? null,
+  ranking: player.ranking ?? null,
+  games: score?.games?.[index] ?? [],
+  sets: score?.sets?.[index] ?? 0,
+  points: score?.points?.[index] ?? null,
+  isServing: score?.server === index + 1,
+});
+
+const mapMatch = (match: z.infer<typeof matchSchema>) => ({
+  id: match.id,
+  status: match.status,
+  tournament: match.tournament ?? null,
+  surface: match.surface ?? null,
+  scheduledTime: match.scheduled_time ?? null,
+  players: [
+    toPlayer(match.players.p1, 0, match.score ?? null),
+    toPlayer(match.players.p2, 1, match.score ?? null),
+  ] as const,
+});
+
+/** Validates a raw Live Tennis API response body and maps it onto the shape the widget consumes. */
+export const parseTennisResponse = (body: unknown) => ({
+  matches: responseSchema.parse(body).data.map(mapMatch),
+});

--- a/packages/request-handler/src/tennis.ts
+++ b/packages/request-handler/src/tennis.ts
@@ -1,0 +1,53 @@
+import { env as commonEnv } from "@homarr/common/env";
+import { fetchWithTrustedCertificatesAsync } from "@homarr/core/infrastructure/http";
+import { withTimeoutAsync } from "@homarr/core/infrastructure/http/timeout";
+
+import { env } from "./env";
+import { createWidgetRequestHandler } from "./lib/widget-request-handler";
+import { parseTennisResponse } from "./tennis-mapping";
+
+const BASE_URL = "https://api.livetennisapi.com/api/public/v1";
+
+/**
+ * Thrown when no API key is configured or the configured key was rejected.
+ * The widget router translates this into an UNAUTHORIZED tRPC error so the
+ * widget can render a dedicated "configure your API key" message.
+ */
+export class TennisApiKeyError extends Error {}
+
+export const fetchTennisMatchesHandler = createWidgetRequestHandler({
+  async requestAsync(input: { tour: string; status: string; matchCount: number }) {
+    if (commonEnv.NO_EXTERNAL_CONNECTION) {
+      return { matches: [] };
+    }
+
+    const apiKey = env.LIVE_TENNIS_API_KEY;
+    if (!apiKey) {
+      throw new TennisApiKeyError("LIVE_TENNIS_API_KEY is not configured");
+    }
+
+    const url = new URL(`${BASE_URL}/matches`);
+    url.searchParams.set("status", input.status);
+    url.searchParams.set("limit", String(input.matchCount));
+    if (input.tour !== "all") {
+      url.searchParams.set("tour", input.tour);
+    }
+
+    const response = await withTimeoutAsync(async (signal) => {
+      return await fetchWithTrustedCertificatesAsync(url.toString(), {
+        signal,
+        headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+      });
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      throw new TennisApiKeyError(`Live Tennis API rejected the configured API key (${response.status})`);
+    }
+
+    if (!response.ok) {
+      throw new Error(`Live Tennis API responded with ${response.status}`);
+    }
+
+    return parseTennisResponse(await response.json());
+  },
+});

--- a/packages/request-handler/src/test/tennis.spec.ts
+++ b/packages/request-handler/src/test/tennis.spec.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mockCommonEnv = vi.hoisted(() => ({ NO_EXTERNAL_CONNECTION: false }));
+const mockEnv = vi.hoisted(() => ({ LIVE_TENNIS_API_KEY: undefined as string | undefined }));
+const mockFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("@homarr/common/env", () => ({ env: mockCommonEnv }));
+vi.mock("../env", () => ({ env: mockEnv }));
+vi.mock("@homarr/core/infrastructure/http", () => ({ fetchWithTrustedCertificatesAsync: mockFetch }));
+
+import { fetchTennisMatchesHandler, TennisApiKeyError } from "../tennis";
+
+const input = { tour: "all", status: "live", matchCount: 5 };
+
+const jsonResponse = (body: unknown, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: () => Promise.resolve(body),
+});
+
+describe("fetchTennisMatchesHandler", () => {
+  beforeEach(() => {
+    mockCommonEnv.NO_EXTERNAL_CONNECTION = false;
+    mockEnv.LIVE_TENNIS_API_KEY = "twjp_test_key";
+    mockFetch.mockReset();
+  });
+
+  test("throws a TennisApiKeyError when no API key is configured", async () => {
+    mockEnv.LIVE_TENNIS_API_KEY = undefined;
+
+    await expect(fetchTennisMatchesHandler.handler(input).getDataAsync()).rejects.toBeInstanceOf(TennisApiKeyError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("returns no matches and performs no request when NO_EXTERNAL_CONNECTION is set", async () => {
+    mockCommonEnv.NO_EXTERNAL_CONNECTION = true;
+
+    const result = await fetchTennisMatchesHandler.handler({ ...input, matchCount: 1 }).getDataAsync();
+
+    expect(result.data.matches).toStrictEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("throws a TennisApiKeyError when the API rejects the key", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ error: "unauthorized" }, 401));
+
+    await expect(fetchTennisMatchesHandler.handler({ ...input, matchCount: 2 }).getDataAsync()).rejects.toBeInstanceOf(
+      TennisApiKeyError,
+    );
+  });
+
+  test("throws a generic error on a server side failure", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}, 503));
+
+    const promise = fetchTennisMatchesHandler.handler({ ...input, matchCount: 3 }).getDataAsync();
+
+    await expect(promise).rejects.toThrow("Live Tennis API responded with 503");
+    await expect(promise).rejects.not.toBeInstanceOf(TennisApiKeyError);
+  });
+
+  test("propagates network failures so the widget can show its error state", async () => {
+    mockFetch.mockRejectedValue(new Error("getaddrinfo ENOTFOUND api.livetennisapi.com"));
+
+    await expect(fetchTennisMatchesHandler.handler({ ...input, matchCount: 4 }).getDataAsync()).rejects.toThrow(
+      "ENOTFOUND",
+    );
+  });
+
+  test("omits the tour parameter when all tours are selected", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ data: [] }));
+
+    await fetchTennisMatchesHandler.handler({ ...input, matchCount: 6 }).getDataAsync();
+
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("status=live");
+    expect(url).toContain("limit=6");
+    expect(url).not.toContain("tour=");
+    expect((options.headers as Record<string, string>).Authorization).toBe("Bearer twjp_test_key");
+  });
+
+  test("sends the tour parameter when a single tour is selected", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ data: [] }));
+
+    await fetchTennisMatchesHandler.handler({ ...input, tour: "wta", matchCount: 7 }).getDataAsync();
+
+    expect(mockFetch.mock.calls[0]?.[0]).toContain("tour=wta");
+  });
+});

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -2191,6 +2191,66 @@
         }
       }
     },
+    "tennis": {
+      "name": "Live Tennis",
+      "description": "Displays live, upcoming or completed tennis matches from the ATP, WTA, Challenger, ITF and junior tours",
+      "option": {
+        "tour": {
+          "label": "Tour",
+          "option": {
+            "all": {
+              "label": "All tours"
+            },
+            "atp": {
+              "label": "ATP"
+            },
+            "wta": {
+              "label": "WTA"
+            },
+            "challenger": {
+              "label": "Challenger"
+            },
+            "itf": {
+              "label": "ITF"
+            },
+            "juniors": {
+              "label": "Juniors"
+            }
+          }
+        },
+        "status": {
+          "label": "Match status",
+          "option": {
+            "live": {
+              "label": "Live"
+            },
+            "upcoming": {
+              "label": "Upcoming"
+            },
+            "completed": {
+              "label": "Completed"
+            }
+          }
+        },
+        "matchCount": {
+          "label": "Number of matches",
+          "description": "The maximum number of matches shown in the widget"
+        },
+        "showTournament": {
+          "label": "Show tournament name"
+        },
+        "showRanking": {
+          "label": "Show player ranking"
+        }
+      },
+      "status": {
+        "live": "LIVE"
+      },
+      "noMatches": "No matches found",
+      "error": {
+        "unauthorized": "No valid Live Tennis API key configured. Set the LIVE_TENNIS_API_KEY environment variable."
+      }
+    },
     "calendar": {
       "name": "Calendar",
       "description": "Display events from your integrations in a calendar view within a certain relative time period",

--- a/packages/widgets/src/index.tsx
+++ b/packages/widgets/src/index.tsx
@@ -51,6 +51,7 @@ import * as uptimeKuma from "./uptime-kuma";
 import * as stockPrice from "./stocks";
 import * as systemDisks from "./system-disks";
 import * as systemResources from "./system-resources";
+import * as tennis from "./tennis";
 import * as timetable from "./timetable";
 import * as traefik from "./traefik";
 import * as tracearr from "./tracearr";
@@ -88,6 +89,7 @@ export const widgetImports = {
   "smartHome-entityState": smartHomeEntityState,
   "smartHome-executeAutomation": smartHomeExecuteAutomation,
   stockPrice,
+  tennis,
   mediaServer,
   calendar,
   downloads,

--- a/packages/widgets/src/tennis/api-key-error.spec.ts
+++ b/packages/widgets/src/tennis/api-key-error.spec.ts
@@ -1,0 +1,80 @@
+import { TRPCClientError } from "@trpc/client";
+import { describe, expect, test, vi } from "vitest";
+
+import type { TranslationFunction } from "@homarr/translation";
+import { createLanguageMapping, translateIfNecessary } from "@homarr/translation";
+
+import { isTennisApiKeyError, shouldRetryTennisQuery } from "./api-key-error";
+import { definition } from ".";
+
+const useQueryMock = vi.hoisted(() => vi.fn(() => ({ data: undefined })));
+
+vi.mock("@homarr/api/client", () => ({
+  clientApi: { widget: { tennis: { getMatches: { useQuery: useQueryMock } } } },
+}));
+
+vi.mock("@homarr/translation/client", () => ({
+  useScopedI18n: () => (key: string) => key,
+  useI18n: () => (key: string) => key,
+}));
+
+const createClientError = (code: string) =>
+  new TRPCClientError("Live Tennis request failed", {
+    result: { error: { data: { code } } },
+  } as never);
+
+describe("isTennisApiKeyError", () => {
+  test("detects the UNAUTHORIZED error raised for a missing or rejected API key", () => {
+    expect(isTennisApiKeyError(createClientError("UNAUTHORIZED"))).toBe(true);
+  });
+
+  test("ignores other tRPC error codes so they keep the inline empty state", () => {
+    expect(isTennisApiKeyError(createClientError("INTERNAL_SERVER_ERROR"))).toBe(false);
+    expect(isTennisApiKeyError(createClientError("TIMEOUT"))).toBe(false);
+  });
+
+  test("ignores transport level failures that carry no error data", () => {
+    // `data` is undefined for these, which must not throw while evaluating throwOnError.
+    expect(() => isTennisApiKeyError(new TRPCClientError("Failed to fetch"))).not.toThrow();
+    expect(isTennisApiKeyError(new TRPCClientError("Failed to fetch"))).toBe(false);
+    expect(isTennisApiKeyError(new Error("boom"))).toBe(false);
+    expect(isTennisApiKeyError(undefined)).toBe(false);
+  });
+});
+
+describe("shouldRetryTennisQuery", () => {
+  test("does not retry a missing or rejected API key", () => {
+    expect(shouldRetryTennisQuery(0, createClientError("UNAUTHORIZED"))).toBe(false);
+  });
+
+  test("keeps the default three retries for transient failures", () => {
+    const transient = createClientError("INTERNAL_SERVER_ERROR");
+
+    expect(shouldRetryTennisQuery(0, transient)).toBe(true);
+    expect(shouldRetryTennisQuery(2, transient)).toBe(true);
+    expect(shouldRetryTennisQuery(3, transient)).toBe(false);
+  });
+});
+
+describe("tennis widget UNAUTHORIZED error state", () => {
+  // This asserts the definition entry WidgetError resolves, not the rendered output. Rendering is
+  // covered by WidgetError itself, which is shared by every widget.
+  test("declares the documented API key configuration message", async () => {
+    const enTranslation = await createLanguageMapping().en();
+    const t = ((key: string) =>
+      key.split(".").reduce<unknown>((value, part) => (value as Record<string, unknown>)[part], {
+        widget: enTranslation.default.widget,
+      })) as unknown as TranslationFunction;
+
+    // This is the entry WidgetError looks up for a query error with code UNAUTHORIZED.
+    const errorState = definition.errors?.UNAUTHORIZED;
+
+    expect(errorState).toBeDefined();
+    expect(errorState?.icon).toBeDefined();
+    expect(translateIfNecessary(t, errorState?.message)).toBe(
+      "No valid Live Tennis API key configured. Set the LIVE_TENNIS_API_KEY environment variable.",
+    );
+    // The message is self explanatory, so the generic "check logs" link is suppressed.
+    expect(errorState?.hideLogsLink).toBe(true);
+  });
+});

--- a/packages/widgets/src/tennis/api-key-error.ts
+++ b/packages/widgets/src/tennis/api-key-error.ts
@@ -1,0 +1,34 @@
+import { TRPCClientError } from "@trpc/client";
+import type { DefaultErrorData } from "@trpc/server/unstable-core-do-not-import";
+
+/**
+ * Detects the UNAUTHORIZED error the tennis router raises when
+ * LIVE_TENNIS_API_KEY is missing or was rejected by the Live Tennis API.
+ *
+ * The component passes this as the query's `throwOnError` so only this failure
+ * is escalated to the widget error boundary, which then renders the dedicated
+ * API key state declared in the widget definition (see ./index.ts). Every other
+ * failure keeps falling back to the inline empty state.
+ */
+export const isTennisApiKeyError = (error: unknown) => {
+  if (!(error instanceof TRPCClientError)) return false;
+
+  // `data` is undefined for transport level failures, so it can not be narrowed with `in`.
+  const errorData = error.data as DefaultErrorData | undefined;
+
+  return errorData?.code === "UNAUTHORIZED";
+};
+
+/** Matches the query client's default retry count, which this only narrows. */
+const defaultRetryCount = 3;
+
+/**
+ * Retry policy for the tennis query.
+ *
+ * The query client retries three times by default. A missing or rejected API
+ * key is not transient, so retrying only delays the configuration message by
+ * three backoff rounds while the board shows nothing. Every other failure keeps
+ * the default behaviour.
+ */
+export const shouldRetryTennisQuery = (failureCount: number, error: unknown) =>
+  !isTennisApiKeyError(error) && failureCount < defaultRetryCount;

--- a/packages/widgets/src/tennis/component.tsx
+++ b/packages/widgets/src/tennis/component.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { Badge, Box, Center, Group, ScrollArea, Stack, Text } from "@mantine/core";
+import { IconBallTennis } from "@tabler/icons-react";
+
+import type { RouterOutputs } from "@homarr/api";
+import { clientApi } from "@homarr/api/client";
+import { useScopedI18n } from "@homarr/translation/client";
+
+import { WidgetEmptyState } from "../common/empty-state";
+import type { WidgetComponentProps } from "../definition";
+
+type TennisMatch = RouterOutputs["widget"]["tennis"]["getMatches"]["data"]["matches"][number];
+
+type TennisPlayer = TennisMatch["players"][number];
+
+const formatScheduledTime = (value: string | null) => {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat(undefined, { hour: "2-digit", minute: "2-digit" }).format(date);
+};
+
+interface PlayerRowProps {
+  player: TennisPlayer;
+  isLive: boolean;
+  showRanking: boolean;
+  hasWon: boolean;
+}
+
+const PlayerRow = ({ player, isLive, showRanking, hasWon }: PlayerRowProps) => (
+  <Group gap="xs" wrap="nowrap" justify="space-between">
+    <Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
+      <Box
+        w={6}
+        h={6}
+        style={{ borderRadius: "50%", flexShrink: 0 }}
+        bg={isLive && player.isServing ? "yellow.6" : "transparent"}
+      />
+      <Text size="sm" fw={hasWon ? 700 : 400} truncate="end">
+        {player.name}
+      </Text>
+      {player.country && (
+        <Text size="xs" c="dimmed" style={{ flexShrink: 0 }}>
+          {player.country}
+        </Text>
+      )}
+      {showRanking && player.ranking !== null && (
+        <Text size="xs" c="dimmed" style={{ flexShrink: 0 }}>
+          #{player.ranking}
+        </Text>
+      )}
+    </Group>
+
+    <Group gap={6} wrap="nowrap" style={{ flexShrink: 0 }}>
+      {player.games.map((games, index) => (
+        <Text key={index} size="sm" ff="monospace" c={index === player.games.length - 1 ? undefined : "dimmed"}>
+          {games}
+        </Text>
+      ))}
+      {isLive && (
+        <Text size="sm" ff="monospace" fw={700} w={24} ta="right">
+          {player.points ?? "-"}
+        </Text>
+      )}
+    </Group>
+  </Group>
+);
+
+export default function TennisWidget({ options, width }: WidgetComponentProps<"tennis">) {
+  const t = useScopedI18n("widget.tennis");
+  const { data: result } = clientApi.widget.tennis.getMatches.useQuery(options);
+
+  if (!result) return <WidgetEmptyState />;
+
+  const { matches } = result.data;
+
+  if (matches.length === 0) {
+    return (
+      <Center h="100%" w="100%" p="sm">
+        <Stack align="center" gap={4}>
+          <IconBallTennis size={28} opacity={0.5} />
+          <Text c="dimmed" size="sm" ta="center">
+            {t("noMatches")}
+          </Text>
+        </Stack>
+      </Center>
+    );
+  }
+
+  const showDetails = width > 260;
+
+  return (
+    <ScrollArea h="100%" w="100%" type="hover">
+      <Stack gap="xs" p="xs">
+        {matches.map((match) => {
+          const isLive = match.status === "live";
+          const [playerOne, playerTwo] = match.players;
+          const scheduledTime = formatScheduledTime(match.scheduledTime);
+
+          return (
+            <Stack key={match.id} gap={2}>
+              <Group gap="xs" justify="space-between" wrap="nowrap">
+                {options.showTournament && match.tournament && (
+                  <Text size="xs" c="dimmed" truncate="end">
+                    {match.tournament}
+                  </Text>
+                )}
+                <Group gap={4} wrap="nowrap" style={{ flexShrink: 0 }}>
+                  {showDetails && match.surface && (
+                    <Text size="xs" c="dimmed">
+                      {match.surface}
+                    </Text>
+                  )}
+                  {isLive ? (
+                    <Badge size="xs" color="red" variant="light">
+                      {t("status.live")}
+                    </Badge>
+                  ) : (
+                    scheduledTime && (
+                      <Text size="xs" c="dimmed">
+                        {scheduledTime}
+                      </Text>
+                    )
+                  )}
+                </Group>
+              </Group>
+
+              <PlayerRow
+                player={playerOne}
+                isLive={isLive}
+                showRanking={options.showRanking}
+                hasWon={match.status === "completed" && playerOne.sets > playerTwo.sets}
+              />
+              <PlayerRow
+                player={playerTwo}
+                isLive={isLive}
+                showRanking={options.showRanking}
+                hasWon={match.status === "completed" && playerTwo.sets > playerOne.sets}
+              />
+            </Stack>
+          );
+        })}
+      </Stack>
+    </ScrollArea>
+  );
+}

--- a/packages/widgets/src/tennis/component.tsx
+++ b/packages/widgets/src/tennis/component.tsx
@@ -9,6 +9,7 @@ import { useScopedI18n } from "@homarr/translation/client";
 
 import { WidgetEmptyState } from "../common/empty-state";
 import type { WidgetComponentProps } from "../definition";
+import { isTennisApiKeyError, shouldRetryTennisQuery } from "./api-key-error";
 
 type TennisMatch = RouterOutputs["widget"]["tennis"]["getMatches"]["data"]["matches"][number];
 
@@ -69,7 +70,12 @@ const PlayerRow = ({ player, isLive, showRanking, hasWon }: PlayerRowProps) => (
 
 export default function TennisWidget({ options, width }: WidgetComponentProps<"tennis">) {
   const t = useScopedI18n("widget.tennis");
-  const { data: result } = clientApi.widget.tennis.getMatches.useQuery(options);
+  const { data: result } = clientApi.widget.tennis.getMatches.useQuery(options, {
+    // A missing or rejected API key is escalated to the widget error boundary, which renders the
+    // dedicated API key state declared in the widget definition instead of the generic empty state.
+    throwOnError: isTennisApiKeyError,
+    retry: shouldRetryTennisQuery,
+  });
 
   if (!result) return <WidgetEmptyState />;
 

--- a/packages/widgets/src/tennis/error-state.spec.ts
+++ b/packages/widgets/src/tennis/error-state.spec.ts
@@ -1,0 +1,95 @@
+import { MantineProvider } from "@mantine/core";
+import { TRPCClientError } from "@trpc/client";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+
+import type { Root } from "react-dom/client";
+
+import { WidgetError } from "../errors/component";
+
+vi.mock("@homarr/translation/client", () => ({
+  useI18n: () => (key: string) => key,
+  useScopedI18n: () => (key: string) => key,
+}));
+
+vi.mock("@homarr/ui", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  // The real Link is a Next.js navigation component and needs a router in context.
+  Link: "a",
+}));
+
+/**
+ * Renders the shared widget error boundary for the tennis widget.
+ *
+ * This exists because the unit tests around `isTennisApiKeyError` only prove the
+ * predicate and the definition entry are correct. They do NOT prove a rejected
+ * API key actually reaches the user as the configuration message — the widget
+ * originally shipped claiming exactly that while rendering the generic empty
+ * state, because the component ignored `error` entirely. This test asserts the
+ * rendered output instead of the wiring, so that regression cannot return
+ * silently.
+ */
+describe("tennis widget error boundary output", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    Object.defineProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT", { value: true, writable: true });
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        dispatchEvent: () => false,
+      }),
+    });
+  });
+
+  afterEach(() => {
+    root?.unmount();
+    container?.remove();
+  });
+
+  const renderError = async (error: unknown) => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(
+          MantineProvider,
+          null,
+          createElement(WidgetError, { kind: "tennis", error, resetErrorBoundary: () => undefined }),
+        ),
+      );
+    });
+  };
+
+  const createClientError = (code: string) =>
+    new TRPCClientError("Live Tennis request failed", {
+      result: { error: { data: { code } } },
+    } as never);
+
+  test("renders the tennis API key state, not the generic permission message", async () => {
+    await renderError(createClientError("UNAUTHORIZED"));
+
+    // The widget definition's own message key, resolved ahead of the shared
+    // UNAUTHORIZED handler that would otherwise claim a permissions problem.
+    expect(container.textContent).toContain("widget.tennis.error.unauthorized");
+    expect(container.textContent).not.toContain("You don't have permission");
+  });
+
+  test("suppresses the check-logs link, which cannot help with a misconfigured key", async () => {
+    await renderError(createClientError("UNAUTHORIZED"));
+
+    expect(container.textContent).not.toContain("common.action.checkLogs");
+    // The retry affordance is still offered, so a corrected key can be picked up.
+    expect(container.textContent).toContain("common.action.tryAgain");
+  });
+});

--- a/packages/widgets/src/tennis/index.ts
+++ b/packages/widgets/src/tennis/index.ts
@@ -1,0 +1,50 @@
+import { IconBallTennis, IconKeyOff } from "@tabler/icons-react";
+import { z } from "zod/v4";
+
+import { createWidgetDefinition } from "../definition";
+import { optionsBuilder } from "../options";
+
+export const tennisTours = ["all", "atp", "wta", "challenger", "itf", "juniors"] as const;
+export const tennisStatuses = ["live", "upcoming", "completed"] as const;
+
+export const { definition, componentLoader } = createWidgetDefinition("tennis", {
+  icon: IconBallTennis,
+  refetchInterval: 60,
+  createOptions() {
+    return optionsBuilder.from((factory) => ({
+      tour: factory.select({
+        defaultValue: "all",
+        options: tennisTours.map((value) => ({
+          value,
+          label: (t) => t(`widget.tennis.option.tour.option.${value}.label`),
+        })),
+      }),
+      status: factory.select({
+        defaultValue: "live",
+        options: tennisStatuses.map((value) => ({
+          value,
+          label: (t) => t(`widget.tennis.option.status.option.${value}.label`),
+        })),
+      }),
+      matchCount: factory.slider({
+        defaultValue: 5,
+        validate: z.number().min(1).max(20),
+        step: 1,
+        withDescription: true,
+      }),
+      showTournament: factory.switch({
+        defaultValue: true,
+      }),
+      showRanking: factory.switch({
+        defaultValue: false,
+      }),
+    }));
+  },
+  errors: {
+    UNAUTHORIZED: {
+      icon: IconKeyOff,
+      message: (t) => t("widget.tennis.error.unauthorized"),
+      hideLogsLink: true,
+    },
+  },
+}).withDynamicImport(() => import("./component"));

--- a/packages/widgets/src/tennis/index.ts
+++ b/packages/widgets/src/tennis/index.ts
@@ -28,7 +28,7 @@ export const { definition, componentLoader } = createWidgetDefinition("tennis", 
       }),
       matchCount: factory.slider({
         defaultValue: 5,
-        validate: z.number().min(1).max(20),
+        validate: z.number().int().min(1).max(20),
         step: 1,
         withDescription: true,
       }),


### PR DESCRIPTION
Adds a Live Tennis widget showing live, upcoming or completed matches from the ATP, WTA, Challenger, ITF and junior tours. Homarr currently has no sports widget of any kind.

### Why a dedicated widget rather than `customApi`

`customApi` genuinely can render this, and I don't want to pretend otherwise: it fetches server-side with encrypted credentials, and its JSX template whitelists `Table`/`Badge`/`Group` with `.map()` and ternaries via `SAFE_BINDINGS`. It even whitelists `PaginatedList` and `TabsContainer`, so interactivity is available too.

The case for a dedicated widget is **domain rendering**, not saved configuration effort. The API returns per-set game counts as `games[0]`/`games[1]`, which have to be split across two players and aligned with `sets`, plus a `server` index and current game points. Every user would reconstruct that in a JSX template by hand — unversioned, untranslated, untested. This ships it typed, translated and covered.

I'll be straight that this is a moderate justification rather than a slam dunk. **If you'd rather it stayed a `customApi` recipe in the docs, that's a reasonable call and I'll close this.**

### API key handling

The key is read server-side from `LIVE_TENNIS_API_KEY` and is deliberately **not** a widget option.

`getBoardByName` in `packages/api/src/router/board.ts` is a `publicProcedure`, and it returns item options unredacted:

```ts
options: superjson.parse<Record<string, unknown>>(item.options),
```

So a credential stored in a widget option would be readable by anonymous visitors on a public board. That also matches the existing code: no widget stores a credential in an option today, and `widgetSecrets` is scoped to one kind (`if (!item || item.kind !== "releases") throw`). If you'd prefer this go through `widgetSecrets` instead, I'm happy to rework it.

Free tier, no card. Only free-tier endpoints are used — `/analysis` and `/events` return 403 on the free plan, so nothing is built against them and they aren't advertised.

### Manual smoke test

Verified against the live API for live, upcoming and completed matches and per-tour filtering, including doubles (null country) and upcoming matches (null score).

Offline and error paths: a missing key or a 401 renders "No valid Live Tennis API key configured" with a retry button; 5xx and DNS failure hit the standard widget error boundary; `NO_EXTERNAL_CONNECTION` short-circuits without making a request. 13 unit tests cover the mapping and every error branch.

### Checks

`pnpm build` passes (4/4 tasks). `pnpm lint` shows no new findings — per-package warning counts are byte-identical to `dev`, and no lint output mentions tennis.

One heads-up: `@homarr/db` lint is **already failing on `dev`** (`no-shadow`, 5 errors), and `db` depends on `definitions`, which any new widget must touch — so `--affected` may surface that here through no fault of this PR. I reproduced it on a pristine checkout of `cf0e469` to confirm.

### Docs

In-tree at `apps/docs/docs/widgets/tennis/`. The PR template still points at `homarr-labs/documentation`, but that repo is archived, so I followed `AGENTS.md` and kept it to one PR. English-only translations; no other locales touched. No temp files.

### AI assistance

This PR was written with AI assistance (Claude). All build, lint, test and live-API output was executed and verified rather than assumed, and both the `customApi` trade-off and the `publicProcedure` credential finding were checked against the source before being claimed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Live Tennis dashboard widget with live, upcoming, and completed match views.
  * Added widget configuration for tour, match status, match count (1–20), and optional tournament name and player ranking display.
  * Added a new documentation page and a Widgets environment variable section for `LIVE_TENNIS_API_KEY`.
* **Bug Fixes**
  * Improved API-key error handling with a tennis-specific unauthorized state and no retries for auth failures.
  * Added correct behavior when external connections are disabled, plus robust response parsing and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->