### PR TITLE
fix(media-requests): cache statistics responses

### DIFF
--- a/packages/request-handler/src/media-request-stats.ts
+++ b/packages/request-handler/src/media-request-stats.ts
@@ -16,4 +16,6 @@ export const mediaRequestStatsRequestHandler = createIntegrationRequestHandler<
       users: await integrationInstance.getUsersAsync(),
     };
   },
+  cacheTtlMs: 60_000,
+  fallbackToStaleOnError: true,
 });


### PR DESCRIPTION
## Summary

- apply the media-request cache policy from #6347 to the statistics handler
- cache successful statistics responses for 60 seconds
- return stale statistics data when a transient Seerr request fails

## Root cause

PR #6347 added the longer cache TTL and stale-on-error fallback to the media request list handler, but the statistics handler remained on the 10-second default without fallback. A transient failure from either `getStatsAsync` or `getUsersAsync` therefore still propagated to the average Seerr statistics widget.

## Impact

The statistics widget keeps displaying its last successful snapshot during intermittent Seerr API failures, matching the resilience already used by the request-list widget.

## Validation

- `pnpm exec oxfmt --check packages/request-handler/src/media-request-stats.ts`
- `pnpm exec turbo typecheck --filter=@homarr/request-handler`
- `git diff --check`

Fixes #6329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media request statistics reliability by caching results for up to one minute.
  * Added fallback to recently cached data when fetching new statistics fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->