### PR TITLE
fix(old-import): map new clock weather options

### DIFF
--- a/packages/old-import/src/widgets/options.ts
+++ b/packages/old-import/src/widgets/options.ts
@@ -65,6 +65,9 @@ const optionMapping: OptionMapping = {
     useCustomTimezone: () => true,
     customTimeFormat: () => undefined,
     customDateFormat: () => undefined,
+    showWeather: () => undefined,
+    weatherLocation: () => undefined,
+    isWeatherFormatFahrenheit: () => undefined,
   },
   downloads: {
     activeTorrentThreshold: (oldOptions) =>


### PR DESCRIPTION
Adds the three clock weather options introduced by #6372 to the exhaustive Oldmarr option mapping. Returning undefined preserves legacy clock behavior by allowing the widget defaults to be applied.\n\nValidation: formatter, old-import/widgets typecheck, lint, and git diff check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of clock widget weather-related options during configuration migration.
  * Added support for recognizing weather display, location, and Fahrenheit-format settings, ensuring these options are handled consistently when older configurations are converted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->