### PR TITLE
feat(boards): allow addItem to target a specific section

### DIFF
--- a/packages/api/src/router/board.ts
+++ b/packages/api/src/router/board.ts
@@ -35,6 +35,7 @@ import {
   everyoneGroup,
   getPermissionsWithChildren,
   getPermissionsWithParents,
+  sectionKinds,
   widgetDefaultSizes,
   widgetKinds,
 } from "@homarr/definitions";
@@ -1427,13 +1428,58 @@ export const boardRouter = createTRPCRouter({
       const oldmarr = oldmarrConfigSchema.parse(JSON.parse(content));
       await importOldmarrAsync(ctx.db, oldmarr, input.configuration);
     }),
+  getSections: protectedProcedure
+    .meta({
+      openapi: { method: "GET", path: "/api/boards/{boardId}/sections", tags: ["boards"], protect: true },
+      mcp: {
+        enabled: true,
+        description:
+          "List the sections of a board. Returns id, kind (empty, category or dynamic), name (only category sections are named) and position for each section. Use the id as sectionId in board_addItem to place an item in a specific section",
+      },
+    })
+    .input(z.object({ boardId: z.string() }))
+    .output(
+      z.array(
+        z.object({
+          id: z.string(),
+          kind: z.enum(sectionKinds),
+          name: z.string().nullable(),
+          xOffset: z.number().nullable(),
+          yOffset: z.number().nullable(),
+        }),
+      ),
+    )
+    .query(async ({ ctx, input }) => {
+      await throwIfActionForbiddenAsync(ctx, eq(boards.id, input.boardId), "view");
+
+      const board = await ctx.db.query.boards.findFirst({
+        where: eq(boards.id, input.boardId),
+        with: {
+          sections: true,
+        },
+      });
+
+      if (!board) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Board not found" });
+      }
+
+      return board.sections
+        .toSorted((sectionA, sectionB) => (sectionA.yOffset ?? 0) - (sectionB.yOffset ?? 0))
+        .map((section) => ({
+          id: section.id,
+          kind: section.kind,
+          name: section.name,
+          xOffset: section.xOffset,
+          yOffset: section.yOffset,
+        }));
+    }),
   addItem: protectedProcedure
     .meta({
       openapi: { method: "POST", path: "/api/boards/items", tags: ["boards"], protect: true },
       mcp: {
         enabled: true,
         description:
-          "Add a widget/app item to a board. Automatically places it in the first empty section at the next free grid position. Provide boardId (from board_getAllBoards), kind (widget type like 'app', 'weather', etc.), optional options map, and optional integrationIds array. Returns { itemId }",
+          "Add a widget/app item to a board at the next free grid position. Provide boardId (from board_getAllBoards), kind (widget type like 'app', 'weather', etc.), optional options map, optional integrationIds array and an optional sectionId (from board_getSections) to place the item in a specific empty or category section. Without sectionId the item is placed in the first empty section. Returns { itemId }",
       },
     })
     .input(addItemToBoardSchema)
@@ -1466,12 +1512,26 @@ export const boardRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Board not found" });
       }
 
-      const emptySection = board.sections
-        .filter((s) => s.kind === "empty")
-        .toSorted((a, b) => (a.yOffset ?? 0) - (b.yOffset ?? 0))[0];
+      const targetSection = input.sectionId
+        ? board.sections.find((section) => section.id === input.sectionId)
+        : board.sections
+            .filter((section) => section.kind === "empty")
+            .toSorted((sectionA, sectionB) => (sectionA.yOffset ?? 0) - (sectionB.yOffset ?? 0))
+            .at(0);
 
-      if (!emptySection) {
-        throw new TRPCError({ code: "BAD_REQUEST", message: "Board has no empty section to place items in" });
+      if (!targetSection) {
+        throw new TRPCError(
+          input.sectionId
+            ? { code: "NOT_FOUND", message: "Section not found on this board" }
+            : { code: "BAD_REQUEST", message: "Board has no empty section to place items in" },
+        );
+      }
+
+      if (targetSection.kind === "dynamic") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Items can only be added to empty or category sections",
+        });
       }
 
       const itemId = createId();
@@ -1489,7 +1549,7 @@ export const boardRouter = createTRPCRouter({
       for (const layout of board.layouts) {
         const existingInSection = board.items
           .flatMap((item) => item.layouts)
-          .filter((il) => il.sectionId === emptySection.id && il.layoutId === layout.id);
+          .filter((il) => il.sectionId === targetSection.id && il.layoutId === layout.id);
 
         const occupied: boolean[][] = [];
         for (const il of existingInSection) {
@@ -1524,7 +1584,7 @@ export const boardRouter = createTRPCRouter({
             if (fitsAt(x, y)) {
               layoutRows.push({
                 itemId,
-                sectionId: emptySection.id,
+                sectionId: targetSection.id,
                 layoutId: layout.id,
                 xOffset: x,
                 yOffset: y,

--- a/packages/api/src/router/board.ts
+++ b/packages/api/src/router/board.ts
@@ -29,13 +29,12 @@ import {
   sections,
   users,
 } from "@homarr/db/schema";
-import type { WidgetKind } from "@homarr/definitions";
+import type { SectionKind, WidgetKind } from "@homarr/definitions";
 import {
   emptySuperJSON,
   everyoneGroup,
   getPermissionsWithChildren,
   getPermissionsWithParents,
-  sectionKinds,
   widgetDefaultSizes,
   widgetKinds,
 } from "@homarr/definitions";
@@ -128,7 +127,7 @@ export const boardRouter = createTRPCRouter({
       mcp: {
         enabled: true,
         description:
-          "List all boards the current user can access. Returns id, name, logoImageUrl, isPublic, creator, isHome and isMobileHome flags",
+          "List all boards the current user can access. Returns id, name, logoImageUrl, isPublic, creator, isHome and isMobileHome flags and the sections of each board (id, kind, name and position). Use a section id as sectionId in board_addItem to place an item in a specific empty or category section",
       },
     })
     .query(async ({ ctx }) => {
@@ -175,6 +174,15 @@ export const boardRouter = createTRPCRouter({
               email: true,
             },
           },
+          sections: {
+            columns: {
+              id: true,
+              kind: true,
+              name: true,
+              xOffset: true,
+              yOffset: true,
+            },
+          },
           userPermissions: {
             where: eq(boardUserPermissions.userId, ctx.session?.user.id ?? ""),
           },
@@ -199,6 +207,7 @@ export const boardRouter = createTRPCRouter({
       });
       return dbBoards.map((board) => ({
         ...board,
+        sections: board.sections.toSorted((sectionA, sectionB) => (sectionA.yOffset ?? 0) - (sectionB.yOffset ?? 0)),
         isHome: currentUserWhenPresent?.homeBoardId === board.id,
         isMobileHome: currentUserWhenPresent?.mobileHomeBoardId === board.id,
       }));
@@ -1428,52 +1437,13 @@ export const boardRouter = createTRPCRouter({
       const oldmarr = oldmarrConfigSchema.parse(JSON.parse(content));
       await importOldmarrAsync(ctx.db, oldmarr, input.configuration);
     }),
-  getSections: protectedProcedure
-    .meta({
-      openapi: { method: "GET", path: "/api/boards/{boardId}/sections", tags: ["boards"], protect: true },
-      mcp: {
-        enabled: true,
-        description:
-          "List the sections of a board. Requires view access to the board. Provide boardId (from board_getAllBoards). Returns id, kind (empty, category or dynamic), name (only category sections are named) and position for each section. Use the id as sectionId in board_addItem to place an item in a specific section",
-      },
-    })
-    .input(z.object({ boardId: z.string() }))
-    .output(
-      z.array(
-        z.object({
-          id: z.string(),
-          kind: z.enum(sectionKinds),
-          name: z.string().nullable(),
-          xOffset: z.number().nullable(),
-          yOffset: z.number().nullable(),
-        }),
-      ),
-    )
-    .query(async ({ ctx, input }) => {
-      // Throws NOT_FOUND when the board does not exist
-      await throwIfActionForbiddenAsync(ctx, eq(boards.id, input.boardId), "view");
-
-      const boardSections = await ctx.db.query.sections.findMany({
-        where: eq(sections.boardId, input.boardId),
-      });
-
-      return boardSections
-        .toSorted((sectionA, sectionB) => (sectionA.yOffset ?? 0) - (sectionB.yOffset ?? 0))
-        .map((section) => ({
-          id: section.id,
-          kind: section.kind,
-          name: section.name,
-          xOffset: section.xOffset,
-          yOffset: section.yOffset,
-        }));
-    }),
   addItem: protectedProcedure
     .meta({
       openapi: { method: "POST", path: "/api/boards/items", tags: ["boards"], protect: true },
       mcp: {
         enabled: true,
         description:
-          "Add a widget/app item to a board at the next free grid position. Requires modify access to the board. Provide boardId (from board_getAllBoards), kind (widget type like 'app', 'weather', etc.), optional options map, optional integrationIds array (from integration_all or integration_search) and an optional sectionId (from board_getSections) to place the item in a specific empty or category section. Without sectionId the item is placed in the first empty section. Returns { itemId }",
+          "Add a widget/app item to a board at the next free grid position. Requires modify access to the board. Provide boardId (from board_getAllBoards), kind (widget type like 'app', 'weather', etc.), optional options map, optional integrationIds array (from integration_all or integration_search) and an optional sectionId (from the sections array of board_getAllBoards) to place the item in a specific empty or category section. Without sectionId the item is placed in the first empty section. Returns { itemId }",
       },
     })
     .input(addItemToBoardSchema)
@@ -1506,28 +1476,7 @@ export const boardRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Board not found" });
       }
 
-      const targetSection =
-        input.sectionId !== undefined
-          ? board.sections.find((section) => section.id === input.sectionId)
-          : board.sections
-              .filter((section) => section.kind === "empty")
-              .toSorted((sectionA, sectionB) => (sectionA.yOffset ?? 0) - (sectionB.yOffset ?? 0))
-              .at(0);
-
-      if (!targetSection) {
-        throw new TRPCError(
-          input.sectionId !== undefined
-            ? { code: "NOT_FOUND", message: "Section not found on this board" }
-            : { code: "BAD_REQUEST", message: "Board has no empty section to place items in" },
-        );
-      }
-
-      if (targetSection.kind === "dynamic") {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Items can only be added to empty or category sections",
-        });
-      }
+      const targetSection = findTargetSectionOrThrow(board.sections, input.sectionId);
 
       const itemId = createId();
 
@@ -1626,6 +1575,44 @@ export const boardRouter = createTRPCRouter({
  * 8. serverSettings.homeBoardId
  * 9. show NOT_FOUND error
  */
+/**
+ * Determines the section a new item should be placed in.
+ * When a sectionId is provided the matching empty or category section is returned,
+ * otherwise the topmost empty section of the board is used.
+ * @param boardSections sections of the board the item is added to
+ * @param sectionId optional id of the section the item should be placed in
+ * @returns the section the item should be placed in
+ */
+const findTargetSectionOrThrow = <TSection extends { id: string; kind: SectionKind; yOffset: number | null }>(
+  boardSections: TSection[],
+  sectionId: string | undefined,
+): TSection => {
+  if (sectionId === undefined) {
+    const firstEmptySection = boardSections
+      .filter((section) => section.kind === "empty")
+      .toSorted((sectionA, sectionB) => (sectionA.yOffset ?? 0) - (sectionB.yOffset ?? 0))
+      .at(0);
+
+    if (!firstEmptySection) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: "Board has no empty section to place items in" });
+    }
+
+    return firstEmptySection;
+  }
+
+  const requestedSection = boardSections.find((section) => section.id === sectionId);
+
+  if (!requestedSection) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Section not found on this board" });
+  }
+
+  if (requestedSection.kind === "dynamic") {
+    throw new TRPCError({ code: "BAD_REQUEST", message: "Items can only be added to empty or category sections" });
+  }
+
+  return requestedSection;
+};
+
 const getHomeIdBoardAsync = async (
   db: Database,
   user: InferSelectModel<typeof users> | null,

--- a/packages/api/src/router/board.ts
+++ b/packages/api/src/router/board.ts
@@ -1434,7 +1434,7 @@ export const boardRouter = createTRPCRouter({
       mcp: {
         enabled: true,
         description:
-          "List the sections of a board. Returns id, kind (empty, category or dynamic), name (only category sections are named) and position for each section. Use the id as sectionId in board_addItem to place an item in a specific section",
+          "List the sections of a board. Requires view access to the board. Provide boardId (from board_getAllBoards). Returns id, kind (empty, category or dynamic), name (only category sections are named) and position for each section. Use the id as sectionId in board_addItem to place an item in a specific section",
       },
     })
     .input(z.object({ boardId: z.string() }))
@@ -1450,20 +1450,14 @@ export const boardRouter = createTRPCRouter({
       ),
     )
     .query(async ({ ctx, input }) => {
+      // Throws NOT_FOUND when the board does not exist
       await throwIfActionForbiddenAsync(ctx, eq(boards.id, input.boardId), "view");
 
-      const board = await ctx.db.query.boards.findFirst({
-        where: eq(boards.id, input.boardId),
-        with: {
-          sections: true,
-        },
+      const boardSections = await ctx.db.query.sections.findMany({
+        where: eq(sections.boardId, input.boardId),
       });
 
-      if (!board) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Board not found" });
-      }
-
-      return board.sections
+      return boardSections
         .toSorted((sectionA, sectionB) => (sectionA.yOffset ?? 0) - (sectionB.yOffset ?? 0))
         .map((section) => ({
           id: section.id,
@@ -1479,7 +1473,7 @@ export const boardRouter = createTRPCRouter({
       mcp: {
         enabled: true,
         description:
-          "Add a widget/app item to a board at the next free grid position. Provide boardId (from board_getAllBoards), kind (widget type like 'app', 'weather', etc.), optional options map, optional integrationIds array and an optional sectionId (from board_getSections) to place the item in a specific empty or category section. Without sectionId the item is placed in the first empty section. Returns { itemId }",
+          "Add a widget/app item to a board at the next free grid position. Requires modify access to the board. Provide boardId (from board_getAllBoards), kind (widget type like 'app', 'weather', etc.), optional options map, optional integrationIds array (from integration_all or integration_search) and an optional sectionId (from board_getSections) to place the item in a specific empty or category section. Without sectionId the item is placed in the first empty section. Returns { itemId }",
       },
     })
     .input(addItemToBoardSchema)
@@ -1512,16 +1506,17 @@ export const boardRouter = createTRPCRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Board not found" });
       }
 
-      const targetSection = input.sectionId
-        ? board.sections.find((section) => section.id === input.sectionId)
-        : board.sections
-            .filter((section) => section.kind === "empty")
-            .toSorted((sectionA, sectionB) => (sectionA.yOffset ?? 0) - (sectionB.yOffset ?? 0))
-            .at(0);
+      const targetSection =
+        input.sectionId !== undefined
+          ? board.sections.find((section) => section.id === input.sectionId)
+          : board.sections
+              .filter((section) => section.kind === "empty")
+              .toSorted((sectionA, sectionB) => (sectionA.yOffset ?? 0) - (sectionB.yOffset ?? 0))
+              .at(0);
 
       if (!targetSection) {
         throw new TRPCError(
-          input.sectionId
+          input.sectionId !== undefined
             ? { code: "NOT_FOUND", message: "Section not found on this board" }
             : { code: "BAD_REQUEST", message: "Board has no empty section to place items in" },
         );

--- a/packages/api/src/router/test/board.spec.ts
+++ b/packages/api/src/router/test/board.spec.ts
@@ -1483,6 +1483,134 @@ describe("saveLayouts should save layout changes", () => {
   });
 });
 
+describe("getSections should return sections of a board", () => {
+  test("should return sections sorted by yOffset", async () => {
+    // Arrange
+    const db = createDb();
+    const caller = boardRouter.createCaller({ db, deviceType: undefined, session: defaultSession });
+    const { boardId, sectionId } = await createFullBoardAsync(db, "board-with-sections");
+    const categorySectionId = createId();
+    await db.insert(sections).values({
+      id: categorySectionId,
+      kind: "category",
+      name: "First category",
+      xOffset: 0,
+      yOffset: 1,
+      boardId,
+    });
+
+    // Act
+    const result = await caller.getSections({ boardId });
+
+    // Assert
+    expect(result.length).toBe(2);
+    const firstSection = expectToBeDefined(result[0]);
+    expect(firstSection.id).toBe(sectionId);
+    expect(firstSection.kind).toBe("empty");
+    const secondSection = expectToBeDefined(result[1]);
+    expect(secondSection.id).toBe(categorySectionId);
+    expect(secondSection.kind).toBe("category");
+    expect(secondSection.name).toBe("First category");
+  });
+
+  test("should throw error when board not found", async () => {
+    // Arrange
+    const db = createDb();
+    const caller = boardRouter.createCaller({ db, deviceType: undefined, session: defaultSession });
+
+    // Act
+    const actAsync = async () => await caller.getSections({ boardId: "nonExistentBoardId" });
+
+    // Assert
+    await expect(actAsync()).rejects.toThrowError("Board not found");
+  });
+});
+
+describe("addItem should add item to board", () => {
+  test("should place item in first empty section when no sectionId is provided", async () => {
+    // Arrange
+    const db = createDb();
+    const caller = boardRouter.createCaller({ db, deviceType: undefined, session: defaultSession });
+    const { boardId, sectionId } = await createFullBoardAsync(db, "board-for-add-item");
+
+    // Act
+    const { itemId } = await caller.addItem({ boardId, kind: "clock" });
+
+    // Assert
+    const itemLayout = await db.query.itemLayouts.findFirst({
+      where: eq(itemLayouts.itemId, itemId),
+    });
+    const definedItemLayout = expectToBeDefined(itemLayout);
+    expect(definedItemLayout.sectionId).toBe(sectionId);
+    // The existing item of createFullBoardAsync occupies (0, 0), so the next free position is (1, 0)
+    expect(definedItemLayout.xOffset).toBe(1);
+    expect(definedItemLayout.yOffset).toBe(0);
+  });
+
+  test("should place item in the section provided through sectionId", async () => {
+    // Arrange
+    const db = createDb();
+    const caller = boardRouter.createCaller({ db, deviceType: undefined, session: defaultSession });
+    const { boardId } = await createFullBoardAsync(db, "board-for-add-item-section");
+    const categorySectionId = createId();
+    await db.insert(sections).values({
+      id: categorySectionId,
+      kind: "category",
+      name: "First category",
+      xOffset: 0,
+      yOffset: 1,
+      boardId,
+    });
+
+    // Act
+    const { itemId } = await caller.addItem({ boardId, kind: "clock", sectionId: categorySectionId });
+
+    // Assert
+    const itemLayout = await db.query.itemLayouts.findFirst({
+      where: eq(itemLayouts.itemId, itemId),
+    });
+    const definedItemLayout = expectToBeDefined(itemLayout);
+    expect(definedItemLayout.sectionId).toBe(categorySectionId);
+    expect(definedItemLayout.xOffset).toBe(0);
+    expect(definedItemLayout.yOffset).toBe(0);
+  });
+
+  test("should throw error when section does not exist on the board", async () => {
+    // Arrange
+    const db = createDb();
+    const caller = boardRouter.createCaller({ db, deviceType: undefined, session: defaultSession });
+    const { boardId } = await createFullBoardAsync(db, "board-for-add-item-invalid-section");
+
+    // Act
+    const actAsync = async () => await caller.addItem({ boardId, kind: "clock", sectionId: "nonExistentSectionId" });
+
+    // Assert
+    await expect(actAsync()).rejects.toThrowError("Section not found on this board");
+  });
+
+  test("should throw error when section is a dynamic section", async () => {
+    // Arrange
+    const db = createDb();
+    const caller = boardRouter.createCaller({ db, deviceType: undefined, session: defaultSession });
+    const { boardId, sectionId, layoutId } = await createFullBoardAsync(db, "board-for-add-item-dynamic-section");
+    const dynamicSectionId = await addDynamicSectionAsync(db, {
+      parentSectionId: sectionId,
+      boardId,
+      layoutId,
+      xOffset: 1,
+      yOffset: 0,
+      width: 2,
+      height: 2,
+    });
+
+    // Act
+    const actAsync = async () => await caller.addItem({ boardId, kind: "clock", sectionId: dynamicSectionId });
+
+    // Assert
+    await expect(actAsync()).rejects.toThrowError("Items can only be added to empty or category sections");
+  });
+});
+
 const expectInputToBeFullBoardWithName = (
   input: RouterOutputs["board"]["getHomeBoard"],
   props: { name: string } & Awaited<ReturnType<typeof createFullBoardAsync>>,

--- a/packages/api/src/router/test/board.spec.ts
+++ b/packages/api/src/router/test/board.spec.ts
@@ -1588,6 +1588,24 @@ describe("addItem should add item to board", () => {
     await expect(actAsync()).rejects.toThrowError("Section not found on this board");
   });
 
+  test("should throw error when section id is an empty string", async () => {
+    // Arrange
+    const db = createDb();
+    const caller = boardRouter.createCaller({ db, deviceType: undefined, session: defaultSession });
+    const { boardId } = await createFullBoardAsync(db, "board-for-add-item-empty-section-id");
+
+    // Act
+    const actAsync = async () => await caller.addItem({ boardId, kind: "clock", sectionId: "" });
+
+    // Assert
+    await expect(actAsync()).rejects.toThrowError();
+    const boardItems = await db.query.items.findMany({
+      where: eq(items.boardId, boardId),
+    });
+    // Only the item created by createFullBoardAsync should exist
+    expect(boardItems.length).toBe(1);
+  });
+
   test("should throw error when section is a dynamic section", async () => {
     // Arrange
     const db = createDb();

--- a/packages/api/src/router/test/board.spec.ts
+++ b/packages/api/src/router/test/board.spec.ts
@@ -1483,7 +1483,7 @@ describe("saveLayouts should save layout changes", () => {
   });
 });
 
-describe("getSections should return sections of a board", () => {
+describe("getAllBoards should include sections of the boards", () => {
   test("should return sections sorted by yOffset", async () => {
     // Arrange
     const db = createDb();
@@ -1500,29 +1500,18 @@ describe("getSections should return sections of a board", () => {
     });
 
     // Act
-    const result = await caller.getSections({ boardId });
+    const result = await caller.getAllBoards();
 
     // Assert
-    expect(result.length).toBe(2);
-    const firstSection = expectToBeDefined(result[0]);
+    const board = expectToBeDefined(result.find((currentBoard) => currentBoard.id === boardId));
+    expect(board.sections.length).toBe(2);
+    const firstSection = expectToBeDefined(board.sections[0]);
     expect(firstSection.id).toBe(sectionId);
     expect(firstSection.kind).toBe("empty");
-    const secondSection = expectToBeDefined(result[1]);
+    const secondSection = expectToBeDefined(board.sections[1]);
     expect(secondSection.id).toBe(categorySectionId);
     expect(secondSection.kind).toBe("category");
     expect(secondSection.name).toBe("First category");
-  });
-
-  test("should throw error when board not found", async () => {
-    // Arrange
-    const db = createDb();
-    const caller = boardRouter.createCaller({ db, deviceType: undefined, session: defaultSession });
-
-    // Act
-    const actAsync = async () => await caller.getSections({ boardId: "nonExistentBoardId" });
-
-    // Assert
-    await expect(actAsync()).rejects.toThrowError("Board not found");
   });
 });
 

--- a/packages/validation/src/board.ts
+++ b/packages/validation/src/board.ts
@@ -124,5 +124,5 @@ export const addItemToBoardSchema = z.object({
   kind: zodEnumFromArray(widgetKinds),
   options: z.record(z.string(), z.unknown()).default({}),
   integrationIds: z.array(z.string()).default([]),
-  sectionId: z.string().optional(),
+  sectionId: z.string().min(1).optional(),
 });

--- a/packages/validation/src/board.ts
+++ b/packages/validation/src/board.ts
@@ -5,6 +5,7 @@ import {
   backgroundImageRepeats,
   backgroundImageSizes,
   boardPermissions,
+  sectionKinds,
   widgetKinds,
 } from "@homarr/definitions";
 
@@ -100,6 +101,14 @@ const boardPermissionEntrySchema = z.object({
   permission: z.enum(boardPermissions),
 });
 
+export const boardSectionSummarySchema = z.object({
+  id: z.string(),
+  kind: z.enum(sectionKinds),
+  name: z.string().nullable(),
+  xOffset: z.number().nullable(),
+  yOffset: z.number().nullable(),
+});
+
 export const boardSummarySchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -113,6 +122,7 @@ export const boardSummarySchema = z.object({
       email: z.string().nullable(),
     })
     .nullable(),
+  sections: z.array(boardSectionSummarySchema),
   isHome: z.boolean(),
   isMobileHome: z.boolean(),
   userPermissions: z.array(boardPermissionEntrySchema),

--- a/packages/validation/src/board.ts
+++ b/packages/validation/src/board.ts
@@ -124,4 +124,5 @@ export const addItemToBoardSchema = z.object({
   kind: zodEnumFromArray(widgetKinds),
   options: z.record(z.string(), z.unknown()).default({}),
   integrationIds: z.array(z.string()).default([]),
+  sectionId: z.string().optional(),
 });


### PR DESCRIPTION
## Description

The `board.addItem` endpoint (OpenAPI `POST /api/boards/items` and MCP tool `board_addItem`) always places new items in the first **empty** section of a board. For boards organised into named **category** sections there is no API-reachable way to add an item to a specific category: `addItem` can't target one, and `saveBoard` (which can reposition items) is not exposed via OpenAPI or MCP. The only workaround is editing the database directly.

This PR adds:

- an optional `sectionId` to `addItemToBoardSchema`. When provided, the item is placed at the next free grid position of that section (the existing placement algorithm, unchanged — just pointed at the given section). Only `empty` and `category` sections are allowed; a `dynamic` section id is rejected with `BAD_REQUEST`, and an unknown id with `NOT_FOUND`. When omitted, behaviour is exactly as before (first empty section), so existing OpenAPI/MCP clients are unaffected.
- the sections of each board (`id`, `kind`, `name`, position) in the `getAllBoards` response, so API/MCP clients can discover the `sectionId` to pass without an additional tool (per review feedback, instead of a separate `getSections` procedure).
- tests (default placement, section-targeted placement, unknown section, dynamic section, empty section id, section listing in `getAllBoards`).

Motivation: automation and agent clients (e.g. via the built-in MCP server) managing a categorised dashboard — "add an app tile for service X in the *Local Apps* category".

Verified locally: `pnpm typecheck` (all 37 packages) and the board router test suite (51 tests, including 6 new) pass; changed files formatted with `oxfmt`.

## Checklist

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [ ] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).
- [x] When using AI; No temp files are checked in, the code style follows the rest of the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)
