### PR TITLE
chore: gate Renovate updates behind dashboard approval

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:recommended"],
+  extends: ["config:recommended", ":dependencyDashboardApproval"],
   packageRules: [
     {
       matchPackageNames: ["^@homarr/"],
@@ -47,7 +47,7 @@
   rangeStrategy: "bump",
   automerge: false,
   baseBranchPatterns: ["dev"],
-  dependencyDashboard: false,
+  dependencyDashboard: true,
   // prevent special characters in branch names (otherwise git errors occur on windows)
   branchNameStrict: true,
 }


### PR DESCRIPTION
Require explicit Dependency Dashboard approval before Renovate can create branches or pull requests. Dependabot security alerts and grouped security updates remain enabled; Dependabot version updates remain paused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled the dependency dashboard for improved visibility and approval of dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->