### PR TITLE
test(navidrome): complete cleanup review

### DIFF
--- a/apps/docs/docs/widgets/audio-stats/index.mdx
+++ b/apps/docs/docs/widgets/audio-stats/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Audio Stats"
-description: "Displays library statistics from Navidrome or Audiobookshelf, adapting its display based on the linked integration."
+description: "Displays media and listening statistics from Navidrome or Audiobookshelf, adapting its display based on the linked integration."
 hide_title: true
 ---
 

--- a/packages/integrations/src/navidrome/test/navidrome-integration.spec.ts
+++ b/packages/integrations/src/navidrome/test/navidrome-integration.spec.ts
@@ -1,5 +1,11 @@
+// @vitest-environment node
 import { Response } from "undici";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.SKIP_ENV_VALIDATION = "true";
+  process.env.SECRET_ENCRYPTION_KEY = "0".repeat(64);
+});
 
 import { fetchWithTrustedCertificatesAsync } from "@homarr/core/infrastructure/http";
 
@@ -84,7 +90,7 @@ describe("NavidromeIntegration.getDashboardDataAsync", () => {
         >;
       }
 
-      return Promise.resolve(new Response(subsonicOk({}), { status: 200 })) as unknown as ReturnType<
+      return Promise.reject(new Error(`Unexpected dashboard request: ${urlStr}`)) as unknown as ReturnType<
         typeof fetchWithTrustedCertificatesAsync
       >;
     });
@@ -113,7 +119,7 @@ describe("NavidromeIntegration.getDashboardDataAsync", () => {
         ) as unknown as ReturnType<typeof fetchWithTrustedCertificatesAsync>;
       }
 
-      return Promise.resolve(new Response(subsonicOk({}), { status: 200 })) as unknown as ReturnType<
+      return Promise.reject(new Error(`Unexpected dashboard request: ${urlStr}`)) as unknown as ReturnType<
         typeof fetchWithTrustedCertificatesAsync
       >;
     });

--- a/packages/integrations/src/navidrome/test/navidrome-integration.spec.ts
+++ b/packages/integrations/src/navidrome/test/navidrome-integration.spec.ts
@@ -39,19 +39,19 @@ const subsonicFailed = (message: string, code = 70) =>
     "subsonic-response": { status: "failed", error: { code, message } },
   });
 
+const makeAlbums = (count: number, songCount: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `album-${index}`,
+    name: `Album ${index}`,
+    songCount,
+  }));
+
 beforeEach(() => {
   mockFetch.mockReset();
 });
 
 describe("NavidromeIntegration.getDashboardDataAsync", () => {
   test("paginates album list and counts songs", async () => {
-    const makeAlbums = (count: number, songCount: number) =>
-      Array.from({ length: count }, (_, i) => ({
-        id: `album-${i}`,
-        name: `Album ${i}`,
-        songCount,
-      }));
-
     mockFetch.mockImplementation((url) => {
       const urlStr = toUrlString(url);
 


### PR DESCRIPTION
## Summary

- Replay the complete Navidrome cleanup diff from #6493 so CodeRabbit can review it after that PR was merged too early.
- Hoist the album fixture helper to resolve the remaining Oxlint warning.

## Merge impact

The cleanup changes are already present on `dev` from #6493. The only new resulting code change is the test-helper hoist; the older branch base intentionally keeps the complete cleanup visible in this PR review diff.

## Validation

- Navidrome and Audio Stats tests: 17 passed
- @homarr/integrations typecheck
- Focused Oxlint and Oxfmt
- git diff --check

This PR must not be merged until CodeRabbit has completed a review of the latest head and every actionable thread is addressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Audio Stats widget description to refer to media and listening statistics.

* **Tests**
  * Improved Navidrome integration test setup and authentication error coverage.
  * Strengthened dashboard request mocks to catch unexpected requests.
  * Simplified dashboard test scenarios by removing outdated now-playing assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->