### PR TITLE
fix: allow [homarr_base] template variables in app href validation

### DIFF
--- a/packages/definitions/src/docs/homarr-docs-sitemap.ts
+++ b/packages/definitions/src/docs/homarr-docs-sitemap.ts
@@ -119,6 +119,7 @@ export type HomarrDocumentationPath =
   | "/docs/tags/variables"
   | "/docs/tags/widgets"
   | "/docs/advanced/command-line"
+  | "/docs/advanced/command-line/development"
   | "/docs/advanced/command-line/fix-usernames"
   | "/docs/advanced/command-line/integrations"
   | "/docs/advanced/command-line/password-recovery"

--- a/packages/validation/src/app.ts
+++ b/packages/validation/src/app.ts
@@ -5,6 +5,10 @@ export const appHrefSchema = z
   .trim()
   .url()
   .regex(/^(?!javascript)[a-zA-Z]*:\/\//i) // javascript: is not allowed, i for case insensitive (so Javascript: is also not allowed)
+  .or(z.string().trim().includes("[homarr_base]"))
+  .or(z.string().trim().includes("[homarr_hostname]"))
+  .or(z.string().trim().includes("[homarr_domain]"))
+  .or(z.string().trim().includes("[homarr_protocol]"))
   .or(z.literal(""))
   .transform((value) => (value.length === 0 ? null : value))
   .nullable();


### PR DESCRIPTION
Simply relaxes the Zod schema so `[homarr_base]`, `[homarr_hostname]`, `[homarr_domain]`, and `[homarr_protocol]` template variables are accepted by the API. The client-side resolution already works in the UI — this just unblocks the REST/tRPC API path.

Closes #6488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App URLs now support Homarr placeholders for the base URL, hostname, domain, and protocol.
  * Added the command-line development guide to recognized documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->