### PR TITLE
feat: restrict integrations management to integration-full-all permission

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/integrations/edit/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/integrations/edit/[id]/page.tsx
@@ -1,5 +1,7 @@
+import { notFound } from "next/navigation";
 import { Container, Fieldset, Group, Stack, Title } from "@mantine/core";
 
+import { auth } from "@homarr/auth/next";
 import { api } from "@homarr/api/server";
 import { getIntegrationName } from "@homarr/definitions";
 import { getI18n, getScopedI18n } from "@homarr/translation/server";
@@ -16,6 +18,11 @@ interface EditIntegrationPageProps {
 
 export default async function EditIntegrationPage(props: EditIntegrationPageProps) {
   const params = await props.params;
+  const session = await auth();
+
+  if (!session?.user.permissions.includes("integration-full-all")) {
+    notFound();
+  }
   const editT = await getScopedI18n("integration.page.edit");
   const t = await getI18n();
   const integration = await api.integration.byId({ id: params.id }).catch(catchTrpcNotFound);

--- a/apps/nextjs/src/app/[locale]/manage/integrations/new/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/integrations/new/page.tsx
@@ -23,7 +23,10 @@ interface NewIntegrationPageProps {
 export default async function IntegrationsNewPage(props: NewIntegrationPageProps) {
   const searchParams = await props.searchParams;
   const session = await auth();
-  if (!session?.user.permissions.includes("integration-full-all")) {
+  if (
+    !session?.user.permissions.includes("integration-full-all") ||
+    !session?.user.permissions.includes("integration-create")
+  ) {
     notFound();
   }
 

--- a/apps/nextjs/src/app/[locale]/manage/integrations/new/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/integrations/new/page.tsx
@@ -23,7 +23,7 @@ interface NewIntegrationPageProps {
 export default async function IntegrationsNewPage(props: NewIntegrationPageProps) {
   const searchParams = await props.searchParams;
   const session = await auth();
-  if (!session?.user.permissions.includes("integration-full-all") || !session?.user.permissions.includes("integration-create")) {
+  if (!session?.user.permissions.includes("integration-full-all")) {
     notFound();
   }
 

--- a/apps/nextjs/src/app/[locale]/manage/integrations/new/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/integrations/new/page.tsx
@@ -23,7 +23,7 @@ interface NewIntegrationPageProps {
 export default async function IntegrationsNewPage(props: NewIntegrationPageProps) {
   const searchParams = await props.searchParams;
   const session = await auth();
-  if (!session?.user.permissions.includes("integration-create")) {
+  if (!session?.user.permissions.includes("integration-full-all") || !session?.user.permissions.includes("integration-create")) {
     notFound();
   }
 

--- a/apps/nextjs/src/app/[locale]/manage/integrations/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/integrations/page.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from "react";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import {
   AccordionControl,
   AccordionItem,
@@ -49,6 +49,9 @@ export default async function IntegrationsPage(props: IntegrationsPageProps) {
 
   if (!session) {
     redirect("/auth/login");
+  }
+  if (!session.user.permissions.includes("integration-full-all")) {
+    notFound();
   }
 
   const integrations = await api.integration.all();

--- a/apps/nextjs/src/app/[locale]/manage/layout.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/layout.tsx
@@ -71,7 +71,7 @@ export default async function ManageLayout({ children }: PropsWithChildren) {
       icon: IconAffiliateFilled,
       href: "/manage/integrations",
       label: t("items.integrations"),
-      hidden: !session?.user.permissions.includes("integration-create"),
+      hidden: !session?.user.permissions.includes("integration-full-all"),
       "data-onboarding-tour-id": "manage-integrations",
     },
     {

--- a/packages/api/src/router/home.ts
+++ b/packages/api/src/router/home.ts
@@ -92,7 +92,7 @@ export const homeRouter = createTRPCRouter({
       });
     }
 
-    if (ctx.session?.user.permissions.includes("integration-create")) {
+    if (ctx.session?.user.permissions.includes("integration-full-all")) {
       statistics.push({
         titleKey: "integration",
         subtitleKey: "resources",

--- a/packages/api/src/router/integration/integration-router.ts
+++ b/packages/api/src/router/integration/integration-router.ts
@@ -62,7 +62,8 @@ export const integrationRouter = createTRPCRouter({
         requiredSecrets: def.secretKinds,
       }));
     }),
-  all: protectedProcedure
+  all: permissionRequiredProcedure
+    .requiresPermission("integration-full-all")
     .meta({
       mcp: {
         enabled: true,

--- a/packages/api/src/router/integration/integration-router.ts
+++ b/packages/api/src/router/integration/integration-router.ts
@@ -68,7 +68,7 @@ export const integrationRouter = createTRPCRouter({
       mcp: {
         enabled: true,
         description:
-          "List all configured integrations (connections to services like Sonarr, Radarr, Plex, etc.). Returns each integration's id, name, kind, url, and permissions. Use the 'id' field as 'integrationId' in other tools. Check permissions.hasUseAccess before reading data and permissions.hasInteractAccess before performing actions — false means the API key owner lacks that permission level for this integration, not an error",
+          "List all configured integrations (connections to services like Sonarr, Radarr, Plex, etc.). Requires integration-full-all permission. Returns each integration's id, name, kind, url, and permissions. Use the 'id' field as 'integrationId' in other tools. Check permissions.hasUseAccess before reading data and permissions.hasInteractAccess before performing actions — false means the API key owner lacks that permission level for this integration, not an error",
       },
     })
     .query(async ({ ctx }) => {
@@ -297,6 +297,7 @@ export const integrationRouter = createTRPCRouter({
       };
     }),
   create: permissionRequiredProcedure
+    .requiresPermission("integration-full-all")
     .requiresPermission("integration-create")
     .meta({
       mcp: {

--- a/packages/definitions/src/docs/homarr-docs-sitemap.ts
+++ b/packages/definitions/src/docs/homarr-docs-sitemap.ts
@@ -119,6 +119,7 @@ export type HomarrDocumentationPath =
   | "/docs/tags/variables"
   | "/docs/tags/widgets"
   | "/docs/advanced/command-line"
+  | "/docs/advanced/command-line/development"
   | "/docs/advanced/command-line/fix-usernames"
   | "/docs/advanced/command-line/integrations"
   | "/docs/advanced/command-line/password-recovery"

--- a/packages/spotlight/src/modes/command/global-group.tsx
+++ b/packages/spotlight/src/modes/command/global-group.tsx
@@ -95,7 +95,8 @@ export const globalCommandGroup = createGroup<Command>({
         icon: IconPlug,
         name: tOption("newIntegration.label"),
         useInteraction: interaction.children(newIntegrationChildrenOptions),
-        hidden: !session?.user.permissions.includes("integration-create"),
+        hidden:
+          !session?.user.permissions.includes("integration-full-all") || !session?.user.permissions.includes("integration-create"),
       },
       {
         commandKey: "newUser",

--- a/packages/spotlight/src/modes/command/global-group.tsx
+++ b/packages/spotlight/src/modes/command/global-group.tsx
@@ -95,7 +95,9 @@ export const globalCommandGroup = createGroup<Command>({
         icon: IconPlug,
         name: tOption("newIntegration.label"),
         useInteraction: interaction.children(newIntegrationChildrenOptions),
-        hidden: !session?.user.permissions.includes("integration-full-all"),
+        hidden:
+          !session?.user.permissions.includes("integration-full-all") ||
+          !session?.user.permissions.includes("integration-create"),
       },
       {
         commandKey: "newUser",

--- a/packages/spotlight/src/modes/command/global-group.tsx
+++ b/packages/spotlight/src/modes/command/global-group.tsx
@@ -95,8 +95,7 @@ export const globalCommandGroup = createGroup<Command>({
         icon: IconPlug,
         name: tOption("newIntegration.label"),
         useInteraction: interaction.children(newIntegrationChildrenOptions),
-        hidden:
-          !session?.user.permissions.includes("integration-full-all") || !session?.user.permissions.includes("integration-create"),
+        hidden: !session?.user.permissions.includes("integration-full-all"),
       },
       {
         commandKey: "newUser",

--- a/packages/spotlight/src/modes/page/pages-search-group.tsx
+++ b/packages/spotlight/src/modes/page/pages-search-group.tsx
@@ -82,7 +82,7 @@ export const pagesSearchGroup = createGroup<{
         icon: IconPlug,
         path: "/manage/integrations",
         name: t("manageIntegration.label"),
-        hidden: !session,
+        hidden: !session?.user.permissions.includes("integration-full-all"),
       },
       {
         icon: IconSearch,


### PR DESCRIPTION
## Summary

Following the same pattern as PR #6425 (which restricted apps management to `board-modify-all`), this PR restricts integrations management access to users with `integration-full-all` permission.

Users without `integration-full-all` could previously access the integrations management page via direct URL (`/manage/integrations`) even though the navigation item was hidden. This fix ensures the page, API, and all entry points are properly gated.

Closes #6507

## Changes

| Layer | File | Change |
|-------|------|--------|
| **API** | `packages/api/src/router/integration/integration-router.ts` | `all` procedure now requires `integration-full-all` |
| **Navigation** | `apps/nextjs/src/app/[locale]/manage/layout.tsx` | Nav item hidden without `integration-full-all` (was `integration-create`) |
| **Page** | `apps/nextjs/src/app/[locale]/manage/integrations/page.tsx` | Shows `notFound()` without `integration-full-all` |
| **New page** | `apps/nextjs/src/app/[locale]/manage/integrations/new/page.tsx` | Requires both `integration-full-all` and `integration-create` |
| **Edit page** | `apps/nextjs/src/app/[locale]/manage/integrations/edit/[id]/page.tsx` | Shows `notFound()` without `integration-full-all` |
| **Home stats** | `packages/api/src/router/home.ts` | Stats card hidden without `integration-full-all` (was `integration-create`) |
| **Spotlight pages** | `packages/spotlight/src/modes/page/pages-search-group.tsx` | \"Manage Integrations\" entry hidden without `integration-full-all` (was `!session`) |
| **Spotlight commands** | `packages/spotlight/src/modes/command/global-group.tsx` | \"New Integration\" command requires `integration-full-all` in addition to `integration-create` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Access Control**
  * Restricted integration management pages and actions to users with full integration permissions.
  * Updated integration navigation, statistics, search visibility, and quick actions to follow the same permission requirement.
  * Unauthorized users can no longer access integration management areas and receive an unavailable-page response.

* **Documentation**
  * Added the command-line development documentation route to the documentation sitemap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->