### PR TITLE
fix: restore auto-refresh for docker and notifications widgets

### DIFF
--- a/packages/definitions/src/docs/homarr-docs-sitemap.ts
+++ b/packages/definitions/src/docs/homarr-docs-sitemap.ts
@@ -119,6 +119,7 @@ export type HomarrDocumentationPath =
   | "/docs/tags/variables"
   | "/docs/tags/widgets"
   | "/docs/advanced/command-line"
+  | "/docs/advanced/command-line/development"
   | "/docs/advanced/command-line/fix-usernames"
   | "/docs/advanced/command-line/integrations"
   | "/docs/advanced/command-line/password-recovery"

--- a/packages/widgets/src/docker/index.ts
+++ b/packages/widgets/src/docker/index.ts
@@ -26,6 +26,7 @@ const columnTranslationKeyMap = {
 export const { definition, componentLoader } = createWidgetDefinition("dockerContainers", {
   icon: IconBrandDocker,
   queryKey: [["docker", "getContainers"]],
+  refetchInterval: 30,
   createOptions() {
     return optionsBuilder.from(
       (factory) => ({

--- a/packages/widgets/src/notifications/index.ts
+++ b/packages/widgets/src/notifications/index.ts
@@ -7,7 +7,6 @@ import { optionsBuilder } from "../options";
 
 export const { componentLoader, definition } = createWidgetDefinition("notifications", {
   icon: IconMessage,
-  refetchInterval: null,
   createOptions() {
     return optionsBuilder.from((factory) => ({
       hideLogos: factory.switch({ defaultValue: false }),


### PR DESCRIPTION
## Problem

Fixes #6456

Users reported that the **docker** and **notifications** widgets stopped auto-refreshing.

### Root cause

The refetch interval logic in `trpc.tsx` iterates over widget definitions and calls `setQueryDefaults` for each widget's query key. Two issues:

1. **dockerContainers** — uses a non-default query key (`[["docker", "getContainers"]]`) that doesn't match the default `[["widget"]]` prefix (which carries the 30s interval). Since the widget had no explicit `refetchInterval` set, the loop skipped it entirely (`if (def.refetchInterval === undefined) continue;`), giving it **zero auto-refresh**.

2. **notifications** — had `refetchInterval: null`, which the code converts to `refetchInterval: false` — **never refresh**. This was likely intentional for a subscription-based widget, but since the widget isn't refreshing via subscriptions either, enabling the default polling restores expected behavior.

## Changes

- **`packages/widgets/src/docker/index.ts`** — Added `refetchInterval: 30` so the docker container list polls every 30 seconds
- **`packages/widgets/src/notifications/index.ts`** — Removed `refetchInterval: null` so it falls through to the default 30-second interval

## Validation

- Typecheck passes (`pnpm turbo typecheck --filter=@homarr/widgets`)
- All 634 widget tests pass across 15 test files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Docker container status now refreshes automatically every 30 seconds.
  * Notifications continue using their standard data-refresh behavior without a disabled refresh setting.

* **Documentation**
  * Added the command-line development documentation page to the documentation site navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->