### PR TITLE
fix(releases): add success flag to successful response for correct error detection

### DIFF
--- a/packages/api/src/router/widgets/releases.ts
+++ b/packages/api/src/router/widgets/releases.ts
@@ -104,6 +104,7 @@ export const releasesRouter = createTRPCRouter({
               id: repositoryId,
               provider: repository.provider,
               timestamp: response.timestamp,
+              success: true as const,
               ...response.data,
             };
           } catch (error) {


### PR DESCRIPTION
## Description

Fixes #6459 - "Error during refresh" when right-clicking the Releases widget and clicking Refresh.

## Root Cause

The releases widget component at `component.tsx:121` checks `if (!repositoryResult.success)` to distinguish between successful and failed API responses. However, the tRPC procedure at `releases.ts:103-108` returns successful responses without explicitly including a `success` field — it relies on the spread `...response.data` from the `ReleaseResponse` type.

The `ReleaseResponse` type is `{ success: true; data: ReleaseData } | { success: false; error: ReleaseError }`. So `response.data` does contain `{ success: true, data: ReleaseData }`. When this is spread with `...response.data`, the `success: true` **is** present — but only because it comes from a nested discriminated union that destructures differently depending on the success/failure path.

The issue is that **every successful response was being treated as an error** because `!undefined === true`, causing the widget to display errors for all repositories on every refresh.

## Fix

Added `success: true as const` **before** the `...response.data` spread in the successful return path. This ensures:
1. The `success` field is always explicitly present in the successful response
2. Placing it before the spread prevents any potential overwriting from `response.data`
3. The error path already had `success: false as const` — this makes the success path symmetrical