### PR TITLE
revert: revert regressions from #6508, #6509, #6512

### DIFF
--- a/apps/nextjs/src/app/[locale]/manage/integrations/edit/[id]/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/integrations/edit/[id]/page.tsx
@@ -1,7 +1,5 @@
-import { notFound } from "next/navigation";
 import { Container, Fieldset, Group, Stack, Title } from "@mantine/core";
 
-import { auth } from "@homarr/auth/next";
 import { api } from "@homarr/api/server";
 import { getIntegrationName } from "@homarr/definitions";
 import { getI18n, getScopedI18n } from "@homarr/translation/server";
@@ -18,11 +16,6 @@ interface EditIntegrationPageProps {
 
 export default async function EditIntegrationPage(props: EditIntegrationPageProps) {
   const params = await props.params;
-  const session = await auth();
-
-  if (!session?.user.permissions.includes("integration-full-all")) {
-    notFound();
-  }
   const editT = await getScopedI18n("integration.page.edit");
   const t = await getI18n();
   const integration = await api.integration.byId({ id: params.id }).catch(catchTrpcNotFound);

--- a/apps/nextjs/src/app/[locale]/manage/integrations/new/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/integrations/new/page.tsx
@@ -23,10 +23,7 @@ interface NewIntegrationPageProps {
 export default async function IntegrationsNewPage(props: NewIntegrationPageProps) {
   const searchParams = await props.searchParams;
   const session = await auth();
-  if (
-    !session?.user.permissions.includes("integration-full-all") ||
-    !session?.user.permissions.includes("integration-create")
-  ) {
+  if (!session?.user.permissions.includes("integration-create")) {
     notFound();
   }
 

--- a/apps/nextjs/src/app/[locale]/manage/integrations/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/integrations/page.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from "react";
-import { notFound, redirect } from "next/navigation";
+import { redirect } from "next/navigation";
 import {
   AccordionControl,
   AccordionItem,
@@ -49,9 +49,6 @@ export default async function IntegrationsPage(props: IntegrationsPageProps) {
 
   if (!session) {
     redirect("/auth/login");
-  }
-  if (!session.user.permissions.includes("integration-full-all")) {
-    notFound();
   }
 
   const integrations = await api.integration.all();

--- a/apps/nextjs/src/app/[locale]/manage/layout.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/layout.tsx
@@ -71,7 +71,7 @@ export default async function ManageLayout({ children }: PropsWithChildren) {
       icon: IconAffiliateFilled,
       href: "/manage/integrations",
       label: t("items.integrations"),
-      hidden: !session?.user.permissions.includes("integration-full-all"),
+      hidden: !session?.user.permissions.includes("integration-create"),
       "data-onboarding-tour-id": "manage-integrations",
     },
     {

--- a/packages/api/src/router/home.ts
+++ b/packages/api/src/router/home.ts
@@ -92,7 +92,7 @@ export const homeRouter = createTRPCRouter({
       });
     }
 
-    if (ctx.session?.user.permissions.includes("integration-full-all")) {
+    if (ctx.session?.user.permissions.includes("integration-create")) {
       statistics.push({
         titleKey: "integration",
         subtitleKey: "resources",

--- a/packages/api/src/router/integration/integration-router.ts
+++ b/packages/api/src/router/integration/integration-router.ts
@@ -62,13 +62,12 @@ export const integrationRouter = createTRPCRouter({
         requiredSecrets: def.secretKinds,
       }));
     }),
-  all: permissionRequiredProcedure
-    .requiresPermission("integration-full-all")
+  all: protectedProcedure
     .meta({
       mcp: {
         enabled: true,
         description:
-          "List all configured integrations (connections to services like Sonarr, Radarr, Plex, etc.). Requires integration-full-all permission. Returns each integration's id, name, kind, url, and permissions. Use the 'id' field as 'integrationId' in other tools. Check permissions.hasUseAccess before reading data and permissions.hasInteractAccess before performing actions — false means the API key owner lacks that permission level for this integration, not an error",
+          "List all configured integrations (connections to services like Sonarr, Radarr, Plex, etc.). Returns each integration's id, name, kind, url, and permissions. Use the 'id' field as 'integrationId' in other tools. Check permissions.hasUseAccess before reading data and permissions.hasInteractAccess before performing actions — false means the API key owner lacks that permission level for this integration, not an error",
       },
     })
     .query(async ({ ctx }) => {
@@ -297,7 +296,6 @@ export const integrationRouter = createTRPCRouter({
       };
     }),
   create: permissionRequiredProcedure
-    .requiresPermission("integration-full-all")
     .requiresPermission("integration-create")
     .meta({
       mcp: {

--- a/packages/api/src/router/widgets/releases.ts
+++ b/packages/api/src/router/widgets/releases.ts
@@ -104,7 +104,6 @@ export const releasesRouter = createTRPCRouter({
               id: repositoryId,
               provider: repository.provider,
               timestamp: response.timestamp,
-              success: true as const,
               ...response.data,
             };
           } catch (error) {

--- a/packages/definitions/src/docs/homarr-docs-sitemap.ts
+++ b/packages/definitions/src/docs/homarr-docs-sitemap.ts
@@ -119,7 +119,6 @@ export type HomarrDocumentationPath =
   | "/docs/tags/variables"
   | "/docs/tags/widgets"
   | "/docs/advanced/command-line"
-  | "/docs/advanced/command-line/development"
   | "/docs/advanced/command-line/fix-usernames"
   | "/docs/advanced/command-line/integrations"
   | "/docs/advanced/command-line/password-recovery"

--- a/packages/spotlight/src/modes/command/global-group.tsx
+++ b/packages/spotlight/src/modes/command/global-group.tsx
@@ -95,9 +95,7 @@ export const globalCommandGroup = createGroup<Command>({
         icon: IconPlug,
         name: tOption("newIntegration.label"),
         useInteraction: interaction.children(newIntegrationChildrenOptions),
-        hidden:
-          !session?.user.permissions.includes("integration-full-all") ||
-          !session?.user.permissions.includes("integration-create"),
+        hidden: !session?.user.permissions.includes("integration-create"),
       },
       {
         commandKey: "newUser",

--- a/packages/spotlight/src/modes/page/pages-search-group.tsx
+++ b/packages/spotlight/src/modes/page/pages-search-group.tsx
@@ -82,7 +82,7 @@ export const pagesSearchGroup = createGroup<{
         icon: IconPlug,
         path: "/manage/integrations",
         name: t("manageIntegration.label"),
-        hidden: !session?.user.permissions.includes("integration-full-all"),
+        hidden: !session,
       },
       {
         icon: IconSearch,

--- a/packages/validation/src/app.ts
+++ b/packages/validation/src/app.ts
@@ -5,10 +5,6 @@ export const appHrefSchema = z
   .trim()
   .url()
   .regex(/^(?!javascript)[a-zA-Z]*:\/\//i) // javascript: is not allowed, i for case insensitive (so Javascript: is also not allowed)
-  .or(z.string().trim().includes("[homarr_base]"))
-  .or(z.string().trim().includes("[homarr_hostname]"))
-  .or(z.string().trim().includes("[homarr_domain]"))
-  .or(z.string().trim().includes("[homarr_protocol]"))
   .or(z.literal(""))
   .transform((value) => (value.length === 0 ? null : value))
   .nullable();


### PR DESCRIPTION
## Summary

Clean reverts of three recent PRs on `dev` that introduced regressions. These are `git revert` commits (one per PR) applied on top of `origin/dev`.

## Reverts

1. **Revert #6508** — "fix: allow [homarr_base] template variables in app href validation"
   - `packages/validation/src/app.ts`: reverted the four `.or(...includes(...))` branches. They let any string containing a token bypass all URL/scheme validation (including `javascript:...`), a security regression.
   - `packages/definitions/src/docs/homarr-docs-sitemap.ts`: reverted the added sitemap entry.

2. **Revert #6509** — "feat: restrict integrations management to integration-full-all permission"
   - `packages/api/src/router/integration/integration-router.ts`: restored `integration.all` to `protectedProcedure` and removed the `integration-full-all` requirement on `create`. Gating `integration.all` broke the board widget integration picker for users without `integration-full-all` (item-menu, item-select-modal, widget-context-menu, sections/content).
   - Reverted page/layout/spotlight/home permission changes to their previous `integration-create` gating.

3. **Revert #6512** — "fix(releases): add success flag to successful response for correct error detection"
   - `packages/api/src/router/widgets/releases.ts`: removed the `success: true as const` line. It was a no-op (overwritten by the subsequent `...response.data` spread, which already carries `success` from the `ReleaseResponse` union).

## Validation

- `pnpm typecheck` passes for `@homarr/api`, `@homarr/validation`, `@homarr/spotlight`.
- `vitest run packages/api/src/router/test/integration packages/api/src/router/test/app.spec.ts packages/api/src/router/test/widgets/app.spec.ts packages/validation` — **67/67 passing** (original test files, unmodified).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Access & Permissions**
  - Simplified integration management access, allowing users with creation privileges to view, create, and edit integrations.
  - Updated navigation, dashboard statistics, and command search visibility to reflect the streamlined access rules.
  - Unauthenticated visitors continue to be redirected to login.

- **Bug Fixes**
  - Removed unnecessary success metadata from release responses.
  - Tightened validation for application URLs by rejecting unsupported placeholder formats.

- **Documentation**
  - Removed an outdated development path from the documentation sitemap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->