### PR TITLE
feat(sabnzbd): add archived history options to the Downloads widget

### DIFF
--- a/apps/docs/docs/widgets/downloads/index.ts
+++ b/apps/docs/docs/widgets/downloads/index.ts
@@ -99,10 +99,9 @@ export const downloadsWidget: WidgetDefinition = {
       },
       {
         name: "Archived history window",
-        description:
-          "Show archived jobs completed within the selected period. Increase the item limit to show older results.",
-        values: "10 days, 20 days, or 30 days",
-        defaultValue: "10 days",
+        description: "Number of days of archived jobs to include. Increase the item limit to show more results.",
+        values: "Any positive whole number of days",
+        defaultValue: "7 days",
       },
       {
         name: "Limit items per integration",

--- a/apps/docs/docs/widgets/downloads/index.ts
+++ b/apps/docs/docs/widgets/downloads/index.ts
@@ -91,6 +91,20 @@ export const downloadsWidget: WidgetDefinition = {
         defaultValue: "yes",
       },
       {
+        name: "Include archived SABnzbd history",
+        description:
+          "Include completed SABnzbd jobs that have been moved to Archive. This option is only available when SABnzbd is used.",
+        values: { type: "boolean" },
+        defaultValue: "no",
+      },
+      {
+        name: "Archived history window",
+        description:
+          "Show archived jobs completed within the selected period. Increase the item limit to show older results.",
+        values: "10 days, 20 days, or 30 days",
+        defaultValue: "10 days",
+      },
+      {
         name: "Limit items per integration",
         description: "This will limit the number of items shown per integration, not globally.",
         values: "Any number above 1",

--- a/apps/docs/docs/widgets/whats-up-docker/index.ts
+++ b/apps/docs/docs/widgets/whats-up-docker/index.ts
@@ -10,7 +10,7 @@ export const wudWidget: WidgetDefinition = {
     items: [
       {
         name: "Show title",
-        description: 'Displays the icon and "What\'s Up Docker" label above the stats',
+        description: "Displays the icon and \"What's Up Docker\" label above the stats",
         values: { type: "boolean" },
         defaultValue: "yes",
       },
@@ -28,8 +28,7 @@ export const wudWidget: WidgetDefinition = {
       },
       {
         name: "Show container update list",
-        description:
-          "Lists each monitored container that has an image update available, linking to its release notes when known",
+        description: "Lists each monitored container that has an image update available, linking to its release notes when known",
         values: { type: "boolean" },
         defaultValue: "no",
       },

--- a/apps/docs/docs/widgets/whats-up-docker/index.ts
+++ b/apps/docs/docs/widgets/whats-up-docker/index.ts
@@ -10,7 +10,7 @@ export const wudWidget: WidgetDefinition = {
     items: [
       {
         name: "Show title",
-        description: "Displays the icon and \"What's Up Docker\" label above the stats",
+        description: 'Displays the icon and "What\'s Up Docker" label above the stats',
         values: { type: "boolean" },
         defaultValue: "yes",
       },
@@ -28,7 +28,8 @@ export const wudWidget: WidgetDefinition = {
       },
       {
         name: "Show container update list",
-        description: "Lists each monitored container that has an image update available, linking to its release notes when known",
+        description:
+          "Lists each monitored container that has an image update available, linking to its release notes when known",
         values: { type: "boolean" },
         defaultValue: "no",
       },

--- a/packages/api/src/router/widgets/downloads.ts
+++ b/packages/api/src/router/widgets/downloads.ts
@@ -18,7 +18,7 @@ export const downloadsRouter = createTRPCRouter({
       mcp: {
         enabled: true,
         description:
-          "Get active download jobs and queue status from connected download clients (qBittorrent, SABnzbd, Transmission, Deluge, NZBGet). REQUIRED: integrationIds (array of download client integration IDs from integration_all). OPTIONAL: limitPerIntegration (number, default 50). For SABnzbd, includeArchivedHistory includes archived jobs when true and defaults to false; historyWindowDays accepts 10, 20, or 30 days and defaults to 10 days.",
+          "Get active download jobs and queue status from connected download clients (qBittorrent, SABnzbd, Transmission, Deluge, NZBGet). REQUIRED: integrationIds (array of download client integration IDs from integration_all). OPTIONAL: limitPerIntegration (number, default 50). For SABnzbd, includeArchivedHistory includes archived jobs when true and defaults to false; historyWindowDays is a positive whole number of days and defaults to 7.",
       },
     })
     .concat(createDownloadClientIntegrationMiddleware("query"))
@@ -26,7 +26,7 @@ export const downloadsRouter = createTRPCRouter({
       z.object({
         limitPerIntegration: z.number().default(50),
         includeArchivedHistory: z.boolean().default(false),
-        historyWindowDays: z.enum(["10", "20", "30"]).default("10"),
+        historyWindowDays: z.number().int().min(1).default(7),
       }),
     )
     .query(async ({ ctx, input }) => {

--- a/packages/api/src/router/widgets/downloads.ts
+++ b/packages/api/src/router/widgets/downloads.ts
@@ -18,7 +18,7 @@ export const downloadsRouter = createTRPCRouter({
       mcp: {
         enabled: true,
         description:
-          "Get active download jobs and queue status from connected download clients (qBittorrent, SABnzbd, Transmission, Deluge, NZBGet). REQUIRED: integrationIds (array of download client integration IDs from integration_all). OPTIONAL: limitPerIntegration (number, default 50)",
+          "Get active download jobs and queue status from connected download clients (qBittorrent, SABnzbd, Transmission, Deluge, NZBGet). REQUIRED: integrationIds (array of download client integration IDs from integration_all). OPTIONAL: limitPerIntegration (number, default 50). For SABnzbd, includeArchivedHistory includes archived jobs when true and defaults to false; historyWindowDays accepts 10, 20, or 30 days and defaults to 10 days.",
       },
     })
     .concat(createDownloadClientIntegrationMiddleware("query"))

--- a/packages/api/src/router/widgets/downloads.ts
+++ b/packages/api/src/router/widgets/downloads.ts
@@ -22,10 +22,20 @@ export const downloadsRouter = createTRPCRouter({
       },
     })
     .concat(createDownloadClientIntegrationMiddleware("query"))
-    .input(z.object({ limitPerIntegration: z.number().default(50) }))
+    .input(
+      z.object({
+        limitPerIntegration: z.number().default(50),
+        includeArchivedHistory: z.boolean().default(false),
+        historyWindowDays: z.enum(["10", "20", "30"]).default("10"),
+      }),
+    )
     .query(async ({ ctx, input }) => {
       return await settleIntegrationQueries(ctx.integrations, async (integration) => {
-        const innerHandler = downloadClientRequestHandler.handler(integration, { limit: input.limitPerIntegration });
+        const innerHandler = downloadClientRequestHandler.handler(integration, {
+          limit: input.limitPerIntegration,
+          includeArchivedHistory: input.includeArchivedHistory,
+          historyWindowDays: input.historyWindowDays,
+        });
         const { data, timestamp } = await innerHandler.getDataAsync();
         return {
           integration: { id: integration.id, name: integration.name, kind: integration.kind, updatedAt: timestamp },

--- a/packages/integrations/src/download-client/sabnzbd/sabnzbd-history.spec.ts
+++ b/packages/integrations/src/download-client/sabnzbd/sabnzbd-history.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { SabnzbdHistorySlot } from "./sabnzbd-schema";
+import { getSabnzbdHistorySlotsAsync } from "./sabnzbd-history";
+
+const NOW = Date.UTC(2026, 7, 10);
+
+function createSlot(id: string, daysAgo: number): SabnzbdHistorySlot {
+  return {
+    category: "test",
+    download_time: 60,
+    status: "Completed",
+    completed: Math.floor(NOW / 1000) - daysAgo * 24 * 60 * 60,
+    nzo_id: id,
+    postproc_time: 30,
+    name: id,
+    bytes: 1000,
+  };
+}
+
+describe("getSabnzbdHistorySlotsAsync", () => {
+  test("merges active and archived history, filters by window, sorts newest first, and deduplicates", async () => {
+    const result = await getSabnzbdHistorySlotsAsync({
+      activeSlots: [createSlot("active", 1), createSlot("duplicate", 3)],
+      historyWindowDays: 10,
+      now: NOW,
+      fetchPageAsync: vi.fn().mockResolvedValue([
+        createSlot("archived", 2),
+        createSlot("duplicate", 3),
+        createSlot("expired", 11),
+      ]),
+    });
+
+    expect(result.map((slot) => slot.nzo_id)).toEqual(["active", "archived", "duplicate"]);
+  });
+
+  test.each([10, 20, 30])("includes the exact %i-day cutoff", async (historyWindowDays) => {
+    const result = await getSabnzbdHistorySlotsAsync({
+      activeSlots: [],
+      historyWindowDays,
+      now: NOW,
+      fetchPageAsync: vi.fn().mockResolvedValue([
+        createSlot("inside", historyWindowDays),
+        createSlot("outside", historyWindowDays + 1),
+      ]),
+    });
+
+    expect(result.map((slot) => slot.nzo_id)).toEqual(["inside"]);
+  });
+
+  test("requests another page when the archive page is full", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => createSlot(`page-1-${index}`, 1));
+    const fetchPageAsync = vi
+      .fn()
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce([createSlot("page-2", 2)]);
+
+    await getSabnzbdHistorySlotsAsync({
+      activeSlots: [],
+      historyWindowDays: 10,
+      now: NOW,
+      fetchPageAsync,
+    });
+
+    expect(fetchPageAsync).toHaveBeenNthCalledWith(1, { start: 0, limit: 100 });
+    expect(fetchPageAsync).toHaveBeenNthCalledWith(2, { start: 100, limit: 100 });
+    expect(fetchPageAsync).toHaveBeenCalledTimes(2);
+  });
+
+  test("stops after a full page that is entirely outside the selected window", async () => {
+    const expiredPage = Array.from({ length: 100 }, (_, index) => createSlot(`expired-${index}`, 11));
+    const fetchPageAsync = vi.fn().mockResolvedValue(expiredPage);
+
+    await getSabnzbdHistorySlotsAsync({
+      activeSlots: [],
+      historyWindowDays: 10,
+      now: NOW,
+      fetchPageAsync,
+    });
+
+    expect(fetchPageAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("stops after a partial archive page", async () => {
+    const fetchPageAsync = vi.fn().mockResolvedValue([createSlot("archived", 1)]);
+
+    await getSabnzbdHistorySlotsAsync({
+      activeSlots: [],
+      historyWindowDays: 10,
+      now: NOW,
+      fetchPageAsync,
+    });
+
+    expect(fetchPageAsync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/integrations/src/download-client/sabnzbd/sabnzbd-history.spec.ts
+++ b/packages/integrations/src/download-client/sabnzbd/sabnzbd-history.spec.ts
@@ -32,7 +32,7 @@ describe("getSabnzbdHistorySlotsAsync", () => {
     expect(result.map((slot) => slot.nzo_id)).toEqual(["active", "archived", "duplicate"]);
   });
 
-  test.each([10, 20, 30])("includes the exact %i-day cutoff", async (historyWindowDays) => {
+  test.each([2, 7, 14, 28])("includes the exact %i-day cutoff", async (historyWindowDays) => {
     const result = await getSabnzbdHistorySlotsAsync({
       activeSlots: [],
       historyWindowDays,

--- a/packages/integrations/src/download-client/sabnzbd/sabnzbd-history.spec.ts
+++ b/packages/integrations/src/download-client/sabnzbd/sabnzbd-history.spec.ts
@@ -24,11 +24,9 @@ describe("getSabnzbdHistorySlotsAsync", () => {
       activeSlots: [createSlot("active", 1), createSlot("duplicate", 3)],
       historyWindowDays: 10,
       now: NOW,
-      fetchPageAsync: vi.fn().mockResolvedValue([
-        createSlot("archived", 2),
-        createSlot("duplicate", 3),
-        createSlot("expired", 11),
-      ]),
+      fetchPageAsync: vi
+        .fn()
+        .mockResolvedValue([createSlot("archived", 2), createSlot("duplicate", 3), createSlot("expired", 11)]),
     });
 
     expect(result.map((slot) => slot.nzo_id)).toEqual(["active", "archived", "duplicate"]);
@@ -39,10 +37,9 @@ describe("getSabnzbdHistorySlotsAsync", () => {
       activeSlots: [],
       historyWindowDays,
       now: NOW,
-      fetchPageAsync: vi.fn().mockResolvedValue([
-        createSlot("inside", historyWindowDays),
-        createSlot("outside", historyWindowDays + 1),
-      ]),
+      fetchPageAsync: vi
+        .fn()
+        .mockResolvedValue([createSlot("inside", historyWindowDays), createSlot("outside", historyWindowDays + 1)]),
     });
 
     expect(result.map((slot) => slot.nzo_id)).toEqual(["inside"]);

--- a/packages/integrations/src/download-client/sabnzbd/sabnzbd-history.ts
+++ b/packages/integrations/src/download-client/sabnzbd/sabnzbd-history.ts
@@ -28,10 +28,7 @@ export async function getSabnzbdHistorySlotsAsync({
 
     archivedSlots.push(...slots);
 
-    if (
-      slots.length < ARCHIVED_HISTORY_PAGE_SIZE ||
-      slots.every((slot) => slot.completed < cutoff)
-    ) {
+    if (slots.length < ARCHIVED_HISTORY_PAGE_SIZE || slots.every((slot) => slot.completed < cutoff)) {
       break;
     }
   }

--- a/packages/integrations/src/download-client/sabnzbd/sabnzbd-history.ts
+++ b/packages/integrations/src/download-client/sabnzbd/sabnzbd-history.ts
@@ -1,0 +1,49 @@
+import type { SabnzbdHistorySlot } from "./sabnzbd-schema";
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+const ARCHIVED_HISTORY_PAGE_SIZE = 100;
+const MAX_ARCHIVED_HISTORY_PAGES = 100;
+
+interface GetSabnzbdHistorySlotsInput {
+  activeSlots: SabnzbdHistorySlot[];
+  historyWindowDays: number;
+  fetchPageAsync: (input: { start: number; limit: number }) => Promise<SabnzbdHistorySlot[]>;
+  now?: number;
+}
+
+export async function getSabnzbdHistorySlotsAsync({
+  activeSlots,
+  historyWindowDays,
+  fetchPageAsync,
+  now = Date.now(),
+}: GetSabnzbdHistorySlotsInput): Promise<SabnzbdHistorySlot[]> {
+  const cutoff = Math.floor(now / 1000) - historyWindowDays * SECONDS_PER_DAY;
+  const archivedSlots: SabnzbdHistorySlot[] = [];
+
+  for (let page = 0; page < MAX_ARCHIVED_HISTORY_PAGES; page += 1) {
+    const slots = await fetchPageAsync({
+      start: page * ARCHIVED_HISTORY_PAGE_SIZE,
+      limit: ARCHIVED_HISTORY_PAGE_SIZE,
+    });
+
+    archivedSlots.push(...slots);
+
+    if (
+      slots.length < ARCHIVED_HISTORY_PAGE_SIZE ||
+      slots.every((slot) => slot.completed < cutoff)
+    ) {
+      break;
+    }
+  }
+
+  const seenIds = new Set<string>();
+
+  return [...activeSlots, ...archivedSlots]
+    .filter((slot) => slot.completed >= cutoff)
+    .toSorted((first, second) => second.completed - first.completed)
+    .filter((slot) => {
+      if (seenIds.has(slot.nzo_id)) return false;
+      seenIds.add(slot.nzo_id);
+      return true;
+    });
+}

--- a/packages/integrations/src/download-client/sabnzbd/sabnzbd-integration.ts
+++ b/packages/integrations/src/download-client/sabnzbd/sabnzbd-integration.ts
@@ -62,7 +62,7 @@ export class SabnzbdIntegration extends Integration implements IDownloadClientIn
     const items = queue.slots
       .map((slot): DownloadClientItem => {
         const state = SabnzbdIntegration.getUsenetQueueState(slot.status);
-        const times = slot.timeleft.split(":").reverse();
+        const times = slot.timeleft.split(":").toReversed();
         const time = dayjs
           .duration({
             seconds: Number(times[0] ?? 0),

--- a/packages/integrations/src/download-client/sabnzbd/sabnzbd-integration.ts
+++ b/packages/integrations/src/download-client/sabnzbd/sabnzbd-integration.ts
@@ -12,6 +12,7 @@ import type { DownloadClientJobsAndStatus } from "../../interfaces/downloads/dow
 import type { IDownloadClientIntegration } from "../../interfaces/downloads/download-client-integration";
 import type { DownloadClientItem } from "../../interfaces/downloads/download-client-items";
 import type { DownloadClientStatus } from "../../interfaces/downloads/download-client-status";
+import { getSabnzbdHistorySlotsAsync } from "./sabnzbd-history";
 import { historySchema, queueSchema } from "./sabnzbd-schema";
 
 dayjs.extend(duration);
@@ -23,7 +24,11 @@ export class SabnzbdIntegration extends Integration implements IDownloadClientIn
     return { success: true };
   }
 
-  public async getClientJobsAndStatusAsync(input: { limit: number }): Promise<DownloadClientJobsAndStatus> {
+  public async getClientJobsAndStatusAsync(input: {
+    limit: number;
+    includeArchivedHistory?: boolean;
+    historyWindowDays?: "10" | "20" | "30";
+  }): Promise<DownloadClientJobsAndStatus> {
     const type = "usenet";
     const { queue } = await queueSchema.parseAsync(
       await this.sabNzbApiCallAsync("queue", { limit: input.limit.toString() }),
@@ -31,6 +36,24 @@ export class SabnzbdIntegration extends Integration implements IDownloadClientIn
     const { history } = await historySchema.parseAsync(
       await this.sabNzbApiCallAsync("history", { limit: input.limit.toString() }),
     );
+    const historySlots = input.includeArchivedHistory
+      ? await getSabnzbdHistorySlotsAsync({
+          activeSlots: history.slots,
+          historyWindowDays: Number(input.historyWindowDays ?? "10"),
+          fetchPageAsync: async ({ start, limit }) => {
+            const { history: archivedHistory } = await historySchema.parseAsync(
+              await this.sabNzbApiCallAsync("history", {
+                archive: "1",
+                start: start.toString(),
+                limit: limit.toString(),
+              }),
+            );
+
+            return archivedHistory.slots;
+          },
+        })
+      : history.slots;
+
     const status: DownloadClientStatus = {
       paused: queue.paused,
       rates: { down: Math.floor(Number(queue.kbpersec) * 1024) }, //Actually rounded kiBps ()
@@ -63,7 +86,7 @@ export class SabnzbdIntegration extends Integration implements IDownloadClientIn
         };
       })
       .concat(
-        history.slots.map((slot, index): DownloadClientItem => {
+        historySlots.map((slot, index): DownloadClientItem => {
           const state = SabnzbdIntegration.getUsenetHistoryState(slot.status);
           return {
             type,

--- a/packages/integrations/src/download-client/sabnzbd/sabnzbd-integration.ts
+++ b/packages/integrations/src/download-client/sabnzbd/sabnzbd-integration.ts
@@ -27,7 +27,7 @@ export class SabnzbdIntegration extends Integration implements IDownloadClientIn
   public async getClientJobsAndStatusAsync(input: {
     limit: number;
     includeArchivedHistory?: boolean;
-    historyWindowDays?: "10" | "20" | "30";
+    historyWindowDays?: number;
   }): Promise<DownloadClientJobsAndStatus> {
     const type = "usenet";
     const { queue } = await queueSchema.parseAsync(
@@ -36,23 +36,25 @@ export class SabnzbdIntegration extends Integration implements IDownloadClientIn
     const { history } = await historySchema.parseAsync(
       await this.sabNzbApiCallAsync("history", { limit: input.limit.toString() }),
     );
-    const historySlots = input.includeArchivedHistory
-      ? await getSabnzbdHistorySlotsAsync({
-          activeSlots: history.slots,
-          historyWindowDays: Number(input.historyWindowDays ?? "10"),
-          fetchPageAsync: async ({ start, limit }) => {
-            const { history: archivedHistory } = await historySchema.parseAsync(
-              await this.sabNzbApiCallAsync("history", {
-                archive: "1",
-                start: start.toString(),
-                limit: limit.toString(),
-              }),
-            );
+    let historySlots = history.slots;
 
-            return archivedHistory.slots;
-          },
-        })
-      : history.slots;
+    if (input.includeArchivedHistory) {
+      historySlots = await getSabnzbdHistorySlotsAsync({
+        activeSlots: history.slots,
+        historyWindowDays: input.historyWindowDays ?? 7,
+        fetchPageAsync: async ({ start, limit }) => {
+          const { history: archivedHistory } = await historySchema.parseAsync(
+            await this.sabNzbApiCallAsync("history", {
+              archive: "1",
+              start: start.toString(),
+              limit: limit.toString(),
+            }),
+          );
+
+          return archivedHistory.slots;
+        },
+      });
+    }
 
     const status: DownloadClientStatus = {
       paused: queue.paused,

--- a/packages/integrations/src/download-client/sabnzbd/sabnzbd-schema.ts
+++ b/packages/integrations/src/download-client/sabnzbd/sabnzbd-schema.ts
@@ -35,3 +35,5 @@ export const historySchema = z.object({
     ),
   }),
 });
+
+export type SabnzbdHistorySlot = z.infer<typeof historySchema>["history"]["slots"][number];

--- a/packages/old-import/src/widgets/options.ts
+++ b/packages/old-import/src/widgets/options.ts
@@ -85,6 +85,8 @@ const optionMapping: OptionMapping = {
     showCompletedUsenet: () => true,
     showCompletedHttp: () => true,
     limitPerIntegration: () => undefined,
+    includeArchivedHistory: () => undefined,
+    historyWindowDays: () => undefined,
     columnOrder: () => undefined,
     columnWidths: () => undefined,
   },

--- a/packages/request-handler/src/downloads.ts
+++ b/packages/request-handler/src/downloads.ts
@@ -7,7 +7,11 @@ import { createIntegrationRequestHandler } from "./lib/integration-request-handl
 export const downloadClientRequestHandler = createIntegrationRequestHandler<
   DownloadClientJobsAndStatus,
   IntegrationKindByCategory<"downloadClient">,
-  { limit: number }
+  {
+    limit: number;
+    includeArchivedHistory: boolean;
+    historyWindowDays: "10" | "20" | "30";
+  }
 >({
   async requestAsync(integration, input) {
     const integrationInstance = await createIntegrationAsync(integration);

--- a/packages/request-handler/src/downloads.ts
+++ b/packages/request-handler/src/downloads.ts
@@ -10,7 +10,7 @@ export const downloadClientRequestHandler = createIntegrationRequestHandler<
   {
     limit: number;
     includeArchivedHistory: boolean;
-    historyWindowDays: "10" | "20" | "30";
+    historyWindowDays: number;
   }
 >({
   async requestAsync(integration, input) {

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -3126,6 +3126,19 @@
         "showCompletedHttp": {
           "label": "Show Miscellaneous entries marked as completed"
         },
+        "includeArchivedHistory": {
+          "label": "Include archived SABnzbd history",
+          "description": "Include completed SABnzbd jobs that have been moved to Archive"
+        },
+        "historyWindowDays": {
+          "label": "Archived history window",
+          "description": "Show archived jobs completed within this period. Increase the item limit to show older results.",
+          "values": {
+            "10Days": "10 days",
+            "20Days": "20 days",
+            "30Days": "30 days"
+          }
+        },
         "activeTorrentThreshold": {
           "label": "Hide completed torrent under this threshold (in kiB/s)"
         },

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -3132,12 +3132,8 @@
         },
         "historyWindowDays": {
           "label": "Archived history window",
-          "description": "Show archived jobs completed within this period. Increase the item limit to show older results.",
-          "values": {
-            "10Days": "10 days",
-            "20Days": "20 days",
-            "30Days": "30 days"
-          }
+          "description": "Show archived jobs completed within this period. Increase the item limit to show older results."
+
         },
         "activeTorrentThreshold": {
           "label": "Hide completed torrent under this threshold (in kiB/s)"

--- a/packages/widgets/src/downloads/component.tsx
+++ b/packages/widgets/src/downloads/component.tsx
@@ -315,6 +315,8 @@ export default function DownloadClientsWidget({
   } = clientApi.widget.downloads.getJobsAndStatuses.useQuery({
     integrationIds,
     limitPerIntegration: options.limitPerIntegration,
+    includeArchivedHistory: options.includeArchivedHistory,
+    historyWindowDays: options.historyWindowDays,
   });
 
   const t = useScopedI18n("widget.downloads");

--- a/packages/widgets/src/downloads/index.ts
+++ b/packages/widgets/src/downloads/index.ts
@@ -73,6 +73,28 @@ export const { definition, componentLoader } = createWidgetDefinition("downloads
         showCompletedHttp: factory.switch({
           defaultValue: true,
         }),
+        includeArchivedHistory: factory.switch({
+          defaultValue: false,
+          withDescription: true,
+        }),
+        historyWindowDays: factory.select({
+          defaultValue: "10",
+          options: [
+            {
+              value: "10",
+              label: (t) => t("widget.downloads.option.historyWindowDays.values.10Days"),
+            },
+            {
+              value: "20",
+              label: (t) => t("widget.downloads.option.historyWindowDays.values.20Days"),
+            },
+            {
+              value: "30",
+              label: (t) => t("widget.downloads.option.historyWindowDays.values.30Days"),
+            },
+          ],
+          withDescription: true,
+        }),
         activeTorrentThreshold: factory.number({
           validate: z.number().min(0),
           defaultValue: 0,
@@ -99,6 +121,13 @@ export const { definition, componentLoader } = createWidgetDefinition("downloads
       {
         columnOrder: { shouldHide: () => true },
         columnWidths: { shouldHide: () => true },
+        includeArchivedHistory: {
+          shouldHide: (_, integrationKinds) => !integrationKinds.includes("sabNzbd"),
+        },
+        historyWindowDays: {
+          shouldHide: ({ includeArchivedHistory }, integrationKinds) =>
+            !integrationKinds.includes("sabNzbd") || !includeArchivedHistory,
+        },
         showCompletedUsenet: {
           shouldHide: (_, integrationKinds) =>
             !getIntegrationKindsByCategory("usenet").some((kinds) => integrationKinds.includes(kinds)),

--- a/packages/widgets/src/downloads/index.ts
+++ b/packages/widgets/src/downloads/index.ts
@@ -77,22 +77,10 @@ export const { definition, componentLoader } = createWidgetDefinition("downloads
           defaultValue: false,
           withDescription: true,
         }),
-        historyWindowDays: factory.select({
-          defaultValue: "10",
-          options: [
-            {
-              value: "10",
-              label: (t) => t("widget.downloads.option.historyWindowDays.values.10Days"),
-            },
-            {
-              value: "20",
-              label: (t) => t("widget.downloads.option.historyWindowDays.values.20Days"),
-            },
-            {
-              value: "30",
-              label: (t) => t("widget.downloads.option.historyWindowDays.values.30Days"),
-            },
-          ],
+        historyWindowDays: factory.number({
+          defaultValue: 7,
+          validate: z.number().int().min(1),
+          step: 1,
           withDescription: true,
         }),
         activeTorrentThreshold: factory.number({


### PR DESCRIPTION
## Summary

Add optional SABnzbd archived-history support to Homarr's existing Downloads widget using the widget options architecture.

This change is implemented entirely in Homarr. It does not modify SABnzbd, its queue, Archive behavior, or API.

## User-facing behavior

- Adds **Include archived SABnzbd history** to the Downloads widget when SABnzbd is selected
- Adds an **Archived history window** as a numeric widget option
- Uses positive whole-day values with 1-day increments
- Defaults the history window to **7 days**
- Archived history is **disabled by default**
- The history-window option appears only when archived history is enabled
- Existing **Limit items per integration** still controls how many rows are displayed
- Uses Homarr's existing widget option and translation systems

## Implementation

- Threads the widget options through the existing Downloads request path
- Fetches SABnzbd archived history using `archive`, `start`, and `limit`
- Uses bounded pagination with 100-item pages and a hard 100-page safety cap
- Stops on partial pages or once a full page is entirely older than the selected window
- Merges normal and archived history
- Filters to the selected date window
- Sorts newest-first
- Deduplicates by `nzo_id`

No integration-options persistence layer, database schema changes, migrations, onboarding changes, or integration management-form changes are added.

## Validation

The earlier widget-options candidate passed its focused archived-history tests, affected-workspace typechecks, lint, production Docker build, and live SABnzbd validation.

The current review-response head changes the history-window control from fixed string presets to Homarr's existing numeric option, defaults it to 7 days, and simplifies the archived-history conditional. The guarded compare against the reviewed parent shows only the intended Downloads/SABnzbd code, tests, API/request typing, and documentation files.

Hosted GitHub Actions for the current fork-based head still require maintainer approval before they can run, so fresh CI for this review-response commit is pending.

## Notes

This redesign follows maintainer feedback to keep the feature in the Downloads widget and reuse Homarr's existing option, translation, request-handler, and integration patterns.