### PR TITLE
fix(integrations): resolve intermittent Seerr/Overseerr crashes

### DIFF
--- a/packages/definitions/src/docs/homarr-docs-sitemap.ts
+++ b/packages/definitions/src/docs/homarr-docs-sitemap.ts
@@ -119,6 +119,7 @@ export type HomarrDocumentationPath =
   | "/docs/tags/variables"
   | "/docs/tags/widgets"
   | "/docs/advanced/command-line"
+  | "/docs/advanced/command-line/development"
   | "/docs/advanced/command-line/fix-usernames"
   | "/docs/advanced/command-line/integrations"
   | "/docs/advanced/command-line/password-recovery"

--- a/packages/integrations/src/overseerr/overseerr-integration.ts
+++ b/packages/integrations/src/overseerr/overseerr-integration.ts
@@ -185,9 +185,15 @@ export class OverseerrIntegration
       }),
     );
 
-    return settled
+    const fulfilled = settled
       .filter((result): result is PromiseFulfilledResult<MediaRequest> => result.status === "fulfilled")
       .map((result) => result.value);
+
+    if (fulfilled.length === 0) {
+      throw new Error("Failed to resolve any media request information");
+    }
+
+    return fulfilled;
   }
 
   protected mapRequestStatus(status: UpstreamMediaRequestStatus): MediaRequestStatus {


### PR DESCRIPTION
## Description

Fixes #6329

The Seerr integration (which extends OverseerrIntegration) crashes intermittently because:

1. **`Promise.all` in `getRequestsAsync`** — if any single media item's TMDB info fetch fails (e.g., upstream 404, timeout), the entire `Promise.all` rejects, killing the whole request list. Replaced with `Promise.allSettled` + filter to gracefully skip individual failures.

2. **No `response.ok` check in `getItemInformationAsync`** — HTTP error responses are parsed as if they were successful JSON, producing garbage data that propagates downstream.

3. **Cache deletes stale entries before refetching** — if the upstream is temporarily unavailable, the widget has no data to fall back to. Added `fallbackToStaleOnError` to serve stale cache entries when the fetch fails.

4. **No cache TTL on media-request-list handler** — defaults to 10s, causing excessive upstream calls. Set to 60s.

## Changes

| File | Change |
|------|--------|
| `packages/integrations/src/overseerr/overseerr-integration.ts` | `Promise.all` → `Promise.allSettled` + add `response.ok` guard |
| `packages/request-handler/src/lib/request-handler.ts` | Add `fallbackToStaleOnError` option |
| `packages/request-handler/src/lib/integration-request-handler.ts` | Pass through `cacheTtlMs` and `fallbackToStaleOnError` |
| `packages/request-handler/src/media-request-list.ts` | Set `cacheTtlMs: 60_000` and `fallbackToStaleOnError: true` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request loading reliability by retaining successful results when individual details cannot be retrieved.
  * Added clearer errors when media information is unavailable.
  * Handled empty request lists without unnecessary processing.

* **Documentation**
  * Added the command-line development guide to the documentation sitemap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->