### PR TITLE
fix: handle missing message in assistant generation telemetry

### DIFF
--- a/apps/nextjs/src/components/assistant/assistant-panel.tsx
+++ b/apps/nextjs/src/components/assistant/assistant-panel.tsx
@@ -930,7 +930,7 @@ const RequestTelemetry = () => {
   const generationQuery = clientApi.assistant.getGenerationTelemetry.useQuery(
     { threadId: threadId ?? "", messageId },
     {
-      enabled: opened && persistedTelemetry?.provider === "openrouter" && Boolean(threadId),
+      enabled: opened && persistedTelemetry?.provider === "openrouter" && Boolean(threadId) && Boolean(messageId),
       refetchInterval: (query) =>
         query.state.data?.complete === false && query.state.dataUpdateCount < 6 ? 1500 : false,
       retry: 2,

--- a/packages/api/src/router/assistant.ts
+++ b/packages/api/src/router/assistant.ts
@@ -738,7 +738,7 @@ export const assistantRouter = createTRPCRouter({
         }),
         getConfigurationAsync(ctx.db),
       ]);
-      if (!message) throw new TRPCError({ code: "NOT_FOUND", message: "Message not found." });
+      if (!message) return { complete: true, generations: [] };
       if (configuration?.provider !== "openrouter" || !configuration.encryptedApiKey) {
         return { complete: true, generations: [] };
       }


### PR DESCRIPTION
## Summary

Fixes the `assistant.getGenerationTelemetry` tRPC query error (`[[ << query #337 ]] assistant.getGenerationTelemetry`) that appeared in the console.

### Root cause

`RequestTelemetry` fires `getGenerationTelemetry` with the current message id from the assistant store. In some cases the store's message id doesn't match a persisted message yet (the assistant message is still streaming/being written) or the message was just removed. The procedure threw `NOT_FOUND` ("Message not found"), which surfaced as a failed query error via the tRPC logger link.

### Changes

- **`packages/api/src/router/assistant.ts`** — `getGenerationTelemetry` now returns `{ complete: true, generations: [] }` when the message isn't found, instead of throwing `NOT_FOUND`. This matches the existing graceful handling for providers without OpenRouter telemetry (the next branch in the same function).
- **`apps/nextjs/src/components/assistant/assistant-panel.tsx`** — the query is only enabled once both `threadId` and `messageId` are available, so it never fires with an empty id during the initial render/streaming window.

### Validation

- `tsc --noEmit` passes for `@homarr/api` and `@homarr/nextjs`.
