### PR TITLE
feat: add assistant widget to demo dashboard

### DIFF
--- a/packages/db/migrations/seed.ts
+++ b/packages/db/migrations/seed.ts
@@ -512,6 +512,8 @@ const buildDemoWidgets = (appIds: string[]): DemoWidget[] => [
   { kind: "notebook", width: 4, height: 4, needsIntegration: false },
   { kind: "dockerContainers", width: 6, height: 2, needsIntegration: false },
   { kind: "weather", width: 2, height: 1, needsIntegration: false },
+  // Row 12: assistant
+  { kind: "assistant", width: 8, height: 4, needsIntegration: false },
 ];
 
 const seedDemoUserAsync = async (db: Database) => {


### PR DESCRIPTION
## Summary

Adds the Homarr Assistant widget to the demo dashboard so visitors can try the assistant directly from the demo/mock board.

### Change

- **`packages/db/migrations/seed.ts`** — added an `assistant` widget (8×4) to `buildDemoWidgets`, which seeds the demo user's board in `DEMO_MODE`.

The widget uses its default options (`conversationMode: "current"`). Because demo mode reports the assistant as available (`getAvailability` → `enabled: true`), the widget renders in its enabled, interactive state.

### Notes

- Only affects fresh demo-mode seeds (the demo board is created once in `seedDemoUserAsync`).
- No docs/translations needed — the widget already ships with its own labels.
