### PR TITLE
ci: drop --delete-branch from reconcile auto-merge call

### DIFF
--- a/.github/workflows/bot-auto-merge-reconcile.yml
+++ b/.github/workflows/bot-auto-merge-reconcile.yml
@@ -36,5 +36,5 @@ jobs:
             --jq '.[] | select(.author.login as $login | ["app/homarr-renovate", "app/homarr-crowdin", "app/homarr-update-contributors", "app/homarr-releases"] | index($login)) | select(.reviewDecision == "APPROVED") | select(.mergeStateStatus == "CLEAN") | select(.autoMergeRequest == null) | .number' \
           | while read -r pr; do
               echo "Re-enabling auto-merge on PR #$pr"
-              gh pr merge "$pr" --auto --squash --delete-branch
+              gh pr merge "$pr" --auto --squash
             done


### PR DESCRIPTION
The [Bots] Reconcile Auto-merge job failed on its first real run: `gh pr merge --auto --squash --delete-branch` requires a git checkout (`failed to run git: fatal: not a git repository`), so auto-merge was never enabled. Auto-merge itself is a pure API operation; branch cleanup is already owned by the PR-creating workflows (`peter-evans/create-pull-request` `delete-branch: true`, renovate, crowdin).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pull request branches are now preserved when auto-merge is re-enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->