### PR TITLE
ci: checkout repo in bot auto-merge workflows

### DIFF
--- a/.github/workflows/bot-auto-merge-reconcile.yml
+++ b/.github/workflows/bot-auto-merge-reconcile.yml
@@ -36,5 +36,5 @@ jobs:
             --jq '.[] | select(.author.login as $login | ["app/homarr-renovate", "app/homarr-crowdin", "app/homarr-update-contributors", "app/homarr-releases"] | index($login)) | select(.reviewDecision == "APPROVED") | select(.mergeStateStatus == "CLEAN") | select(.autoMergeRequest == null) | .number' \
           | while read -r pr; do
               echo "Re-enabling auto-merge on PR #$pr"
-              gh pr merge "$pr" --auto --squash --delete-branch
+              gh pr merge "$pr" --auto --squash
             done

--- a/.github/workflows/bot-auto-merge-reconcile.yml
+++ b/.github/workflows/bot-auto-merge-reconcile.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
       - name: Obtain token
         id: obtainToken
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/bot-pr-automerge.yml
+++ b/.github/workflows/bot-pr-automerge.yml
@@ -20,6 +20,9 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.base.ref == 'dev'
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
       - name: Obtain token
         id: obtainToken
         uses: actions/create-github-app-token@v3


### PR DESCRIPTION
Both bot auto-merge workflows call `gh pr merge`, which fails with `failed to run git: fatal: not a git repository` when the runner has no checkout. The previous `automatic-approval.yml` had an `actions/checkout` step that mine dropped; restore it so auto-merge can be enabled (observed twice in the reconcile job).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated pull request workflows to check out repository code before processing.
  * Preserved squash-based auto-merging while retaining merged pull request branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->