### PR TITLE
fix(docker): Expose TCP port in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,5 +95,6 @@ ENV AUTH_PROVIDERS='credentials'
 ENV REDIS_IS_EXTERNAL='false'
 ENV NODE_ENV='production'
 
+EXPOSE 7575/tcp
 ENTRYPOINT [ "/app/entrypoint.sh" ]
 CMD ["sh", "run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,6 @@ ENV AUTH_PROVIDERS='credentials'
 ENV REDIS_IS_EXTERNAL='false'
 ENV NODE_ENV='production'
 
-EXPOSE 7575/tcp
+EXPOSE 7575
 ENTRYPOINT [ "/app/entrypoint.sh" ]
 CMD ["sh", "run.sh"]

--- a/apps/docs/docs/advanced/proxy/index.mdx
+++ b/apps/docs/docs/advanced/proxy/index.mdx
@@ -47,7 +47,6 @@ services:
       traefik.http.routers.homarr.rule: Host(`your.internal.dns.address.here.com`)
       traefik.http.routers.homarr.entrypoints: websecure
       traefik.http.routers.homarr-secure.app: homarr
-      traefik.http.apps.homarr.loadbalancer.server.port: 7575
 
 networks:
   proxy:


### PR DESCRIPTION
The tcp port should be exposed in Dockerfile, see [1]. Because the port is now exposed in the docker image, it doesn't need to be specified in the traefik configuration [2].

---
1: https://docs.docker.com/reference/dockerfile/#expose 
2: https://doc.traefik.io/traefik/reference/routing-configuration/other-providers/docker/

<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).
- [ ] When using AI; No temp files are checked in, the code style follows the rest of the project

**When contributing a new integration or widget:**

- [ ] I confirmed manually that the integration or widget is working with a real system and performed basic smoke
  tests (e.g. what happens if it is offline)
- [ ] Optional but recommended: I confirm that I am willing to be added to the `CODEOWNERS` of this feature and will
  provide support and maintain the integration (e.g. in case of breaking or failure)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated the container configuration to expose the application on TCP port 7575.
  * Simplified the proxy setup by removing the redundant explicit port label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->