### PR TITLE
fix(synology): support vol_info in storage_v2 responses

### DIFF
--- a/packages/integrations/src/synology/synology-client.ts
+++ b/packages/integrations/src/synology/synology-client.ts
@@ -85,6 +85,11 @@ export class SynologyClient {
       if (volumesFromV2.length > 0) {
         return volumesFromV2;
       }
+
+      const legacyVolumesFromV2 = this.mapLegacyVolumes(storageV2.vol_info);
+      if (legacyVolumesFromV2.length > 0) {
+        return legacyVolumesFromV2;
+      }
     } catch (error) {
       logger.debug("storage_v2 unavailable, falling back to legacy storage info", {
         integrationId: this.integrationId,

--- a/packages/integrations/src/synology/synology-types.ts
+++ b/packages/integrations/src/synology/synology-types.ts
@@ -78,6 +78,7 @@ export const synologyStorageV2VolumeSchema = z
 
 export const synologyStorageV2DataSchema = z.object({
   volumes: z.array(synologyStorageV2VolumeSchema).optional(),
+  vol_info: z.array(synologyVolumeInfoSchema).optional(),
 });
 
 export const synologyUtilizationCpuSchema = z.object({

--- a/packages/integrations/src/synology/test/synology-integration.spec.ts
+++ b/packages/integrations/src/synology/test/synology-integration.spec.ts
@@ -426,6 +426,60 @@ describe("SynologyIntegration.getSystemInfoAsync", () => {
     expect(result.fileSystem[0]?.deviceName).toBe("volume_1");
   });
 
+  test("uses vol_info from storage_v2 without falling back to legacy storage", async () => {
+    mockSuccessfulFlow({
+      storageV2: {
+        success: true,
+        data: {
+          vol_info: [
+            {
+              name: "volume_1",
+              used_size: "4000000000",
+              total_size: "10000000000",
+              status: "normal",
+            },
+            {
+              name: "volume_2",
+              used_size: "5000000000",
+              total_size: "20000000000",
+              status: "attention",
+            },
+          ],
+        },
+      },
+    });
+
+    const integration = createIntegration();
+    const result = await integration.getSystemInfoAsync();
+
+    expect(result.fileSystem).toEqual([
+      {
+        deviceName: "volume_1",
+        used: "4000000000",
+        available: "6000000000",
+        percentage: 40,
+      },
+      {
+        deviceName: "volume_2",
+        used: "5000000000",
+        available: "15000000000",
+        percentage: 25,
+      },
+    ]);
+
+    const legacyStorageRequests = mockFetch.mock.calls.filter(([url]) => {
+      const urlString = toUrlString(url);
+
+      return (
+        getApiFromUrl(urlString) === "SYNO.Core.System" &&
+        getMethodFromUrl(urlString) === "info" &&
+        getTypeFromUrl(urlString) === "storage"
+      );
+    });
+
+    expect(legacyStorageRequests).toHaveLength(0);
+  });
+
   test("continues when optional tier-2 calls fail", async () => {
     mockSuccessfulFlow({ skipOptional: true });
     const integration = createIntegration();


### PR DESCRIPTION
## Summary

This PR adds support for Synology DSM responses where `storage_v2` returns volume information in `data.vol_info` instead of `data.volumes`.

I ran into this while setting up the Synology integration on a DS1621+ with DSM 7.3.2. The integration itself worked, but the System Health Monitoring widget kept timing out.

After testing the DSM API calls individually, the problem turned out to be the storage request.

## What was happening

On my system, this request:

```text
SYNO.Core.System
method=info
type=storage_v2
```

works correctly and returns in about **0.64 seconds**.

However, DSM returns the volume information like this:

```json
{
  "data": {
    "hdd_info": [...],
    "vol_info": [
      {
        "name": "volume_1",
        "status": "attention",
        "total_size": "...",
        "used_size": "..."
      },
      {
        "name": "volume_2",
        "status": "normal",
        "total_size": "...",
        "used_size": "..."
      }
    ]
  },
  "success": true
}
```

Homarr currently expects the volumes in `data.volumes`.

Because no volumes are found there, Homarr falls back to the older request:

```text
SYNO.Core.System
method=info
type=storage
```

That request also works on my NAS, but it takes around **12.58 seconds**.

Since Synology requests in Homarr have a 5 second timeout, the fallback request times out and the complete System Health Monitoring widget fails.

## Changes

This PR:

- adds `vol_info` support to the `storage_v2` response schema
- uses the existing legacy volume mapping for `storage_v2.vol_info`
- keeps the existing `storage_v2.volumes` handling unchanged
- still falls back to the legacy `type=storage` request when neither format contains usable volume information

This means systems returning `vol_info` can use the much faster `storage_v2` response instead of unnecessarily falling back to the legacy request.

## Measurements from the affected system

For reference, these were the response times I measured:

```text
SYNO.Core.System.Utilization           ~2.11 s
SYNO.Core.System info                  ~0.22 s
SYNO.Core.System info type=storage_v2  ~0.64 s
SYNO.Core.System info type=storage     ~12.58 s
```

## Tests

I also added a regression test for the `storage_v2.vol_info` response format.

The test verifies that:

- volumes from `vol_info` are mapped correctly
- filesystem usage is calculated correctly
- the legacy `type=storage` fallback is not called when `vol_info` contains valid volumes

The Synology integration tests pass:

```text
Test Files  1 passed (1)
Tests       11 passed (11)
Duration    6.92s
```

I also ran formatting, linting, typecheck and `git diff --check` successfully.

## Tested with

- Synology DS1621+
- DX517 expansion unit
- DSM 7.3.2-86009 Update 4
- Homarr running in Docker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Synology storage detection for installations returning volume details through the `storage_v2` response.
  * Storage capacity, available space, and usage percentages are now reported correctly for these volumes.
  * Prevented unnecessary fallback requests to the legacy storage endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->