### PR TITLE
test: cover public custom widgets for guests

### DIFF
--- a/apps/docs/docs/widgets/custom-api/index.mdx
+++ b/apps/docs/docs/widgets/custom-api/index.mdx
@@ -38,6 +38,9 @@ Enable the definition before you use it. The definition must also be available t
 
 Each named request declares its minimum board permission. This permission does not depend on the HTTP method.
 
+Anonymous visitors can load queries from a Custom API widget on a public board. Definitions placed only on private
+boards remain unavailable to them.
+
 Queries and actions can use GET, POST, PUT, or PATCH. DELETE is valid only for actions so it can never run
 automatically while a board loads. The `kind` value controls the remaining runtime behavior.
 

--- a/packages/api/src/router/test/widgets/custom-api-v2.spec.ts
+++ b/packages/api/src/router/test/widgets/custom-api-v2.spec.ts
@@ -113,17 +113,22 @@ async function setup(
 describe("Custom JSX v2 board router", () => {
   beforeEach(() => mocks.executeRequest.mockClear());
 
-  test("allows public queries only through the definition placed on an accessible board", async () => {
+  test("loads placed widgets and public queries for anonymous visitors on public boards", async () => {
     const { db, itemId } = await setup();
     const caller = customApiRouter.createCaller({ db, deviceType: undefined, session: null });
 
+    await expect(caller.getData({ itemId })).resolves.toMatchObject({
+      template: definition.template,
+      data: { "load-status": { value: 42 } },
+      status: { "load-status": { ok: true } },
+    });
     await expect(caller.queryRequest({ itemId, requestId: "status", params: { name: "homarr" } })).resolves.toEqual(
       expect.objectContaining({ ok: true, data: { value: 42 } }),
     );
     await expect(caller.queryRequest({ itemId, requestId: "missing", params: {} })).rejects.toMatchObject({
       code: "NOT_FOUND",
     });
-    expect(mocks.executeRequest).toHaveBeenCalledOnce();
+    expect(mocks.executeRequest).toHaveBeenCalledTimes(2);
   });
 
   test("uses current defaults when an updated option no longer accepts the stored value", async () => {
@@ -150,6 +155,7 @@ describe("Custom JSX v2 board router", () => {
     await expect(
       anonymous.queryRequest({ itemId: privateSetup.itemId, requestId: "status", params: { name: "homarr" } }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    await expect(anonymous.getData({ itemId: privateSetup.itemId })).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     const enabledSetup = await setup();
     await enabledSetup.db


### PR DESCRIPTION
Closes #6557

The v2 implementation already uses a public, item-scoped `getData` endpoint with board-view authorization. This PR locks that behavior down for the current implementation:

- proves an anonymous visitor can load the placed widget and its load queries on a public board
- proves the same endpoint hides widgets placed on private boards
- documents public-board query access and the existing action restriction

This intentionally targets `v2`; it does not include the obsolete definition-based dev backport.