### PR TITLE
fix(boards): disable mobile sidebars

### DIFF
--- a/apps/docs/docs/management/boards/index.mdx
+++ b/apps/docs/docs/management/boards/index.mdx
@@ -107,7 +107,7 @@ The complete canvas always fits the available width and never adds horizontal bo
 - **Mobile** starts at `0px` and uses three columns on new boards.
 - **Base** is the widest layout and starts at `768px` on new boards.
 
-Mobile and Base can be renamed and their column counts and rails can be changed, but they cannot be removed. You can add removable custom layouts between their breakpoints.
+Mobile and Base can be renamed and their column counts can be changed, but they cannot be removed. Mobile has no fixed rails; rail configuration is available only on Base and custom layouts. You can add removable custom layouts between their breakpoints.
 
 Each layout stores independent positions and sizes. Moving or resizing a widget while editing Mobile does not move it in Base or any custom layout. New custom layouts are generated from Base and scaled to their selected column count.
 
@@ -128,7 +128,7 @@ The total number of columns in the layout. Changing it projects the saved positi
 
 #### Fixed rails
 
-Each responsive layout can enable a fixed left rail, a fixed right rail, or both.
+Base and custom responsive layouts can enable a fixed left rail, a fixed right rail, or both. Mobile has no fixed rails.
 Set a rail width to zero to disable it for that layout.
 Choose a width from one to three columns with the three-step slider.
 The preview shows how much space remains for the main canvas.

--- a/apps/nextjs/src/app/[locale]/boards/[name]/settings/_layout.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/[name]/settings/_layout.tsx
@@ -222,15 +222,17 @@ export const LayoutSettingsContent = ({ board, form, isSaving, saveSettingsAsync
                     />
                   )}
                 </Grid.Col>
-                <Grid.Col span={{ base: 12, lg: 4 }}>
-                  <GutterSettings
-                    left={layout.leftGutterColumnCount}
-                    right={layout.rightGutterColumnCount}
-                    columnCount={layout.columnCount}
-                    onLeftChange={(value) => form.setFieldValue(`layouts.${index}.leftGutterColumnCount`, value)}
-                    onRightChange={(value) => form.setFieldValue(`layouts.${index}.rightGutterColumnCount`, value)}
-                  />
-                </Grid.Col>
+                {layout.role !== "mobile" && (
+                  <Grid.Col span={{ base: 12, lg: 4 }}>
+                    <GutterSettings
+                      left={layout.leftGutterColumnCount}
+                      right={layout.rightGutterColumnCount}
+                      columnCount={layout.columnCount}
+                      onLeftChange={(value) => form.setFieldValue(`layouts.${index}.leftGutterColumnCount`, value)}
+                      onRightChange={(value) => form.setFieldValue(`layouts.${index}.rightGutterColumnCount`, value)}
+                    />
+                  </Grid.Col>
+                )}
               </Grid>
 
               <Group justify="space-between" mt="lg" gap="sm" wrap="wrap">

--- a/apps/nextjs/src/app/[locale]/boards/[name]/settings/_settings-form.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/[name]/settings/_settings-form.tsx
@@ -36,6 +36,11 @@ const boardSettingsFormSchema = boardSavePartialSettingsSchema
 
 export type FormValues = z.infer<typeof boardSettingsFormSchema>;
 
+const normalizeMobileLayoutGutters = (layouts: readonly FormValues["layouts"][number][]) =>
+  layouts.map((layout) =>
+    layout.role === "mobile" ? { ...layout, leftGutterColumnCount: 0, rightGutterColumnCount: 0 } : layout,
+  );
+
 const PARTIAL_FORM_KEYS = [
   "pageTitle",
   "metaTitle",
@@ -70,7 +75,7 @@ const buildInitialValues = (board: Board): FormValues => ({
   itemRadius: board.itemRadius,
   customCss: board.customCss ?? "",
   disableStatus: board.disableStatus,
-  layouts: board.layouts,
+  layouts: normalizeMobileLayoutGutters(board.layouts),
 });
 
 interface BoardSettingsFormProps {
@@ -127,7 +132,8 @@ export const BoardSettingsForm = ({ board, permissions, hasFullAccess, hideVisib
     const changed = <TKey extends keyof FormValues>(...fields: TKey[]) =>
       fields.some((field) => values[field] !== defaults[field]);
 
-    const { layouts, ...partialSettings } = values;
+    const { layouts: submittedLayouts, ...partialSettings } = values;
+    const layouts = normalizeMobileLayoutGutters(submittedLayouts);
     const partialSettingsChanged = changed(...PARTIAL_FORM_KEYS);
     const layoutsChanged = changed("layouts");
     if (!partialSettingsChanged && !layoutsChanged) return values;

--- a/apps/nextjs/src/components/board/layout/test/board-lanes.spec.ts
+++ b/apps/nextjs/src/components/board/layout/test/board-lanes.spec.ts
@@ -40,6 +40,22 @@ describe("board lanes", () => {
     expect(getBoardLaneColumnCount(layout, "right")).toBe(0);
   });
 
+  test("disables gutters for mobile layouts", () => {
+    const layout = {
+      id: "mobile",
+      name: "Mobile",
+      columnCount: 12,
+      leftGutterColumnCount: 2,
+      rightGutterColumnCount: 3,
+      breakpoint: 0,
+      role: "mobile",
+    } satisfies Board["layouts"][number];
+
+    expect(getBoardLaneColumnCount(layout, "left")).toBe(0);
+    expect(getBoardLaneColumnCount(layout, "main")).toBe(12);
+    expect(getBoardLaneColumnCount(layout, "right")).toBe(0);
+  });
+
   test("rejects ambiguous duplicate roots", () => {
     const board = new BoardMockBuilder()
       .addSection(new EmptySectionMockBuilder({ id: "main-a" }).build())

--- a/packages/definitions/src/section.ts
+++ b/packages/definitions/src/section.ts
@@ -1,3 +1,5 @@
+import type { LayoutRole } from "./board";
+
 export const sectionKinds = ["empty", "container"] as const;
 export type SectionKind = (typeof sectionKinds)[number];
 
@@ -21,12 +23,17 @@ export const getBoardLaneColumnCount = (
     columnCount: number;
     leftGutterColumnCount?: number | null;
     rightGutterColumnCount?: number | null;
+    role?: LayoutRole;
   },
   lane: BoardLane,
 ) => {
   const total = Math.max(1, Math.floor(layout.columnCount));
-  const left = Math.min(Math.max(0, Math.floor(layout.leftGutterColumnCount ?? 0)), total - 1);
-  const right = Math.min(Math.max(0, Math.floor(layout.rightGutterColumnCount ?? 0)), total - left - 1);
+  const left =
+    layout.role === "mobile" ? 0 : Math.min(Math.max(0, Math.floor(layout.leftGutterColumnCount ?? 0)), total - 1);
+  const right =
+    layout.role === "mobile"
+      ? 0
+      : Math.min(Math.max(0, Math.floor(layout.rightGutterColumnCount ?? 0)), total - left - 1);
   if (lane === "left") return left;
   if (lane === "right") return right;
   return total - left - right;

--- a/packages/validation/src/board-layout.spec.ts
+++ b/packages/validation/src/board-layout.spec.ts
@@ -42,4 +42,17 @@ describe("board layout gutters", () => {
       }).success,
     ).toBe(false);
   });
+
+  test("rejects sidebars on mobile layouts", () => {
+    expect(
+      boardLayoutSchema.safeParse({
+        id: "mobile",
+        name: "Mobile",
+        columnCount: 6,
+        leftGutterColumnCount: 1,
+        breakpoint: 0,
+        role: "mobile",
+      }).success,
+    ).toBe(false);
+  });
 });

--- a/packages/validation/src/board.spec.ts
+++ b/packages/validation/src/board.spec.ts
@@ -41,6 +41,10 @@ describe("responsiveBoardLayoutsSchema", () => {
       name: "duplicate layout ID",
       layouts: [mobile, { ...base, id: mobile.id }],
     },
+    {
+      name: "mobile sidebar",
+      layouts: [{ ...mobile, leftGutterColumnCount: 1 }, base],
+    },
   ])("rejects $name", ({ layouts }) => {
     expect(responsiveBoardLayoutsSchema.safeParse(layouts).success).toBe(false);
   });

--- a/packages/validation/src/board.ts
+++ b/packages/validation/src/board.ts
@@ -85,7 +85,14 @@ export const boardLayoutSchema = z
   .refine((layout) => layout.leftGutterColumnCount + layout.rightGutterColumnCount < layout.columnCount, {
     message: "Gutters must leave at least one dashboard column",
     path: ["columnCount"],
-  });
+  })
+  .refine(
+    (layout) => layout.role !== "mobile" || (layout.leftGutterColumnCount === 0 && layout.rightGutterColumnCount === 0),
+    {
+      message: "Mobile layouts cannot have sidebars",
+      path: ["leftGutterColumnCount"],
+    },
+  );
 
 export const responsiveBoardLayoutsSchema = z
   .array(boardLayoutSchema)


### PR DESCRIPTION
## Summary

- disable fixed sidebars for the protected Mobile layout
- remove Mobile sidebar configuration from board settings
- normalize and reject stale mobile gutter values
- align board/DnD geometry, tests, and documentation

## Root cause

Mobile layouts were still flowing through the generic gutter configuration and geometry paths, so sidebar configuration remained available even though Mobile does not support sidebars.

## Validation

- 27 focused Vitest tests passed
- definitions and validation TypeScript checks passed
- no TypeScript diagnostics mention the changed files
- oxfmt check and git diff --check passed
- full Next.js typecheck is blocked by unrelated workspace issues: missing generated custom-widgets/workshop modules and an existing `useTypeScriptCli` config mismatch

Stacked on #6450; targets `feat/auto-mobile-boards`.