### PR TITLE
fix: make Home Assistant widget actions responsive

### DIFF
--- a/apps/docs/docs/widgets/smart-home-entity-state/index.mdx
+++ b/apps/docs/docs/widgets/smart-home-entity-state/index.mdx
@@ -43,6 +43,7 @@ import temperature from './img/temperature.png';
 ### Interactions
 
 - Toggle entity state by clicking on the entity (only when clickable enabled).
+- After a successful toggle, the displayed state refreshes immediately.
 
 ### Adding the widget
 

--- a/apps/docs/docs/widgets/smart-home-execute-automation/index.mdx
+++ b/apps/docs/docs/widgets/smart-home-execute-automation/index.mdx
@@ -47,4 +47,7 @@ import withDisplayname from './img/with-displayname.png';
 <AddingWidget />
 
 ### Configuration
+
+Use the Home Assistant entity ID (for example, `automation.turn_on_lights`) in the **Automation ID** field, not the automation's internal ID.
+
 <WidgetConfig configuration={smartHomeExecuteAutomationWidget.configuration} />

--- a/packages/api/src/router/widgets/smart-home.ts
+++ b/packages/api/src/router/widgets/smart-home.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from "@trpc/server";
 import { z } from "zod/v4";
 
 import { getIntegrationKindsByCategory } from "@homarr/definitions";
@@ -41,7 +42,12 @@ export const smartHomeRouter = createTRPCRouter({
       const client = await createIntegrationAsync(integration);
       const success = await client.triggerToggleAsync(input.entityId);
 
-      return success;
+      if (!success) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Home Assistant failed to toggle the entity",
+        });
+      }
     }),
   executeAutomation: protectedProcedure
     .meta({
@@ -55,6 +61,13 @@ export const smartHomeRouter = createTRPCRouter({
     .input(z.object({ automationId: z.string() }))
     .mutation(async ({ ctx: { integration }, input }) => {
       const client = await createIntegrationAsync(integration);
-      await client.triggerAutomationAsync(input.automationId);
+      const success = await client.triggerAutomationAsync(input.automationId);
+
+      if (!success) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Home Assistant failed to trigger the automation",
+        });
+      }
     }),
 });

--- a/packages/api/src/router/widgets/smart-home.ts
+++ b/packages/api/src/router/widgets/smart-home.ts
@@ -48,6 +48,8 @@ export const smartHomeRouter = createTRPCRouter({
           message: "Home Assistant failed to toggle the entity",
         });
       }
+
+      return success;
     }),
   executeAutomation: protectedProcedure
     .meta({

--- a/packages/integrations/src/homeassistant/homeassistant-integration.ts
+++ b/packages/integrations/src/homeassistant/homeassistant-integration.ts
@@ -134,7 +134,10 @@ export class HomeAssistantIntegration extends Integration implements ISmartHomeI
    */
   private async postAsync(path: `/api/${string}`, body: Record<string, string>) {
     return await fetchWithTrustedCertificatesAsync(this.url(path), {
-      headers: this.getAuthHeaders(),
+      headers: {
+        ...this.getAuthHeaders(),
+        "Content-Type": "application/json",
+      },
       body: JSON.stringify(body),
       method: "POST",
     });

--- a/packages/integrations/test/home-assistant-unit.spec.ts
+++ b/packages/integrations/test/home-assistant-unit.spec.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { fetchWithTrustedCertificatesAsync } from "@homarr/core/infrastructure/http";
+
+import { HomeAssistantIntegration } from "../src";
+
+vi.mock("@homarr/core/infrastructure/http", () => ({
+  fetchWithTrustedCertificatesAsync: vi.fn(),
+}));
+
+const mockFetch = vi.mocked(fetchWithTrustedCertificatesAsync);
+const integration = new HomeAssistantIntegration({
+  id: "home-assistant",
+  name: "Home Assistant",
+  url: "http://home-assistant.local:8123",
+  externalUrl: null,
+  decryptedSecrets: [{ kind: "apiKey", value: "secret" }],
+});
+
+describe("HomeAssistantIntegration actions", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({ ok: true } as never);
+  });
+
+  test.each([
+    ["toggle", () => integration.triggerToggleAsync("light.desk"), "/api/services/homeassistant/toggle", "light.desk"],
+    [
+      "automation",
+      () => integration.triggerAutomationAsync("automation.turn_on_lights"),
+      "/api/services/automation/trigger",
+      "automation.turn_on_lights",
+    ],
+  ])("sends the %s service call as JSON", async (_action, trigger, path, entityId) => {
+    await expect(trigger()).resolves.toBe(true);
+
+    expect(mockFetch).toHaveBeenCalledWith(new URL(`http://home-assistant.local:8123${path}`), {
+      headers: {
+        Authorization: "Bearer secret",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ entity_id: entityId }),
+      method: "POST",
+    });
+  });
+});

--- a/packages/request-handler/src/smart-home-entity-state.ts
+++ b/packages/request-handler/src/smart-home-entity-state.ts
@@ -18,4 +18,6 @@ export const smartHomeEntityStateRequestHandler = createIntegrationRequestHandle
 
     return result.data.state;
   },
+  // The widget already polls every 30 seconds and refetches after toggles.
+  cacheTtlMs: 0,
 });


### PR DESCRIPTION
Fixes #6570.

## What changed

- stop caching Home Assistant entity-state payloads between the widget's own refreshes
- send service calls as JSON with the required content type
- return mutation errors when Home Assistant rejects toggle or automation actions
- clarify that automation widgets require an entity ID such as `automation.turn_on_lights`

## Why

The entity-state query was invalidated after a toggle but immediately received the server's cached pre-toggle value, leaving the UI stale until the 30-second widget poll. Automation failures were also discarded, so Homarr returned success even when Home Assistant rejected the action.

## Validation

- 12 focused Vitest tests passed
- typecheck passed for API, integrations, request-handler, and docs
- lint passed with no errors (existing unrelated warnings remain)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Smart-home entity states now refresh immediately after successful toggles.
  - Toggle and automation failures now report errors instead of appearing successful.
  - Home Assistant actions send requests with the correct JSON format.
  - Automation execution now uses the Home Assistant entity ID as documented.

- **Documentation**
  - Clarified which identifier to enter when configuring automation actions.
  - Documented the immediate state refresh after toggling an entity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->