### PR TITLE
fix(startup): only chown runtime paths for custom PUID/PGID

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -7,14 +7,31 @@ export PGID=${PGID:-0}
 echo "Starting with UID='$PUID', GID='$PGID'"
 
 if [ "${PUID}" != "0" ] || [ "${PGID}" != "0" ]; then
-    # The below command will change the owner of all files in the /app directory (except node_modules) to the new UID and GID
-    echo "Changing owner to $PUID:$PGID, this will take about 10 seconds..."
-    find . -name 'node_modules' -prune -o -mindepth 1 -maxdepth 1 -exec chown -R $PUID:$PGID {} +
-    chown -R $PUID:$PGID /var/cache/nginx
-    chown -R $PUID:$PGID /var/log/nginx
-    chown -R $PUID:$PGID /var/lib/nginx
-    chown -R $PUID:$PGID /run/nginx/nginx.pid
-    chown -R $PUID:$PGID /etc/nginx
+    # Only chown the paths the non-root user must actually write to at runtime.
+    # Recursively chowning the whole /app tree is extremely slow on network- or
+    # HDD-backed storage (e.g. TrueNAS Apps), because the Next.js standalone
+    # bundle and its node_modules contain tens of thousands of tiny files. This
+    # turned a ~10s step into 15+ minutes for some users (#2190). Application
+    # code, migrations and native modules are only read/executed, so they stay
+    # owned by root and do not need chowning.
+    echo "Changing owner to $PUID:$PGID..."
+    # Application data volume (db, redis dumps, trusted certificates).
+    # Ensure the known subdirectories exist and migrate ownership of any
+    # existing content, so a persistent volume with stale or root-owned
+    # entries stays writable after a PUID/PGID change. These trees are small
+    # (a single sqlite db, a redis dump, a few certs), unlike the /app tree.
+    mkdir -p /appdata/db /appdata/redis /appdata/trusted-certificates
+    chown "${PUID}:${PGID}" /appdata
+    chown -R "${PUID}:${PGID}" /appdata/db /appdata/redis /appdata/trusted-certificates
+    # Next.js runtime cache (image optimization, fetch cache, ...)
+    mkdir -p /app/apps/nextjs/.next/cache
+    chown -R "${PUID}:${PGID}" /app/apps/nextjs/.next/cache
+    # nginx runtime directories and the rendered configuration
+    chown -R "${PUID}:${PGID}" /var/cache/nginx
+    chown -R "${PUID}:${PGID}" /var/log/nginx
+    chown -R "${PUID}:${PGID}" /var/lib/nginx
+    chown -R "${PUID}:${PGID}" /run/nginx/nginx.pid
+    chown -R "${PUID}:${PGID}" /etc/nginx
     echo "Changing owner to $PUID:$PGID, done."
 fi
 


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

Closes #2190

## Problem

When a custom `PUID`/`PGID` is set (the default for TrueNAS Apps), the entrypoint recursively chowns the **entire** `/app` tree:

```sh
find . -name 'node_modules' -prune -o -mindepth 1 -maxdepth 1 -exec chown -R $PUID:$PGID {} +
```

Although top-level `node_modules` is pruned, the `chown -R` on each top-level entry still recurses into the nested `node_modules` and `.next/server` inside the Next.js standalone bundle — tens of thousands of tiny files. On network- or HDD-backed storage this turns the advertised ~10s step into **15+ minutes** of downtime on every update.

## Fix

Only chown the paths the non-root user actually needs to **write** to at runtime:

- `/appdata` – the data volume (db, redis dumps, trusted certificates)
- `apps/nextjs/.next/cache` – Next.js runtime cache
- the nginx runtime directories

Application code, DB migrations and native modules are only read/executed, so they stay owned by `root` and no longer need chowning. This reduces the ownership step from a full-tree recursion to a handful of operations.

This supersedes #3435, adapted to the current Docker/standalone layout (`.next/cache` is created on demand, the read-only executables are dropped from the chown list).

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [ ] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup permissions by limiting ownership changes to required runtime data and cache directories.
  * Prevented unnecessary permission changes to application files, migrations, and native modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->