### PR TITLE
fix(board): render widget options above grid resize handles

### DIFF
--- a/apps/nextjs/src/components/board/items/item-content.tsx
+++ b/apps/nextjs/src/components/board/items/item-content.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, CSSProperties, MutableRefObject } from "react";
-import { memo, Suspense, use, useCallback, useEffect, useRef, useState } from "react";
+import { memo, Suspense, use, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import dynamic from "next/dynamic";
 import type { CardProps } from "@mantine/core";
@@ -159,6 +159,11 @@ const LoadedBoardItemContent = ({
   const board = useRequiredBoard();
   const t = useI18n();
   const [isEditMode] = useEditMode();
+  const settings = useSettings();
+  const menuItem = useMemo(
+    () => ({ ...item, options: reduceWidgetOptionsWithDefinition(definition, settings, item.options) }),
+    [definition, item, settings],
+  );
   const [manualSurface, setManualSurface] = useState<HTMLDivElement | null>(null);
   const [surfacePortalTarget, setSurfacePortalTarget] = useState<HTMLDivElement | null>(null);
   const { active, viewportSize, open, close, dismiss, hover, leave } = useAdvancedFocus();
@@ -305,20 +310,15 @@ const LoadedBoardItemContent = ({
     >
       <Box ref={contentRef} w="100%" h="100%" mih={0}>
         <ErrorBoundary
-          resetKeys={[item.kind]}
+          resetKeys={[item]}
           fallbackRender={({ resetErrorBoundary, error }) => (
-            <>
-              {isEditMode && (
-                <BoardItemMenu item={item} definition={definition} resetErrorBoundary={resetErrorBoundary} />
-              )}
-              <div
-                className={itemContentClasses.editModeInertContent}
-                data-board-grid-inert-content={isEditMode ? "true" : undefined}
-                inert={isEditMode}
-              >
-                <WidgetError definition={definition} error={error} resetErrorBoundary={resetErrorBoundary} />
-              </div>
-            </>
+            <div
+              className={itemContentClasses.editModeInertContent}
+              data-board-grid-inert-content={isEditMode ? "true" : undefined}
+              inert={isEditMode}
+            >
+              <WidgetError definition={definition} error={error} resetErrorBoundary={resetErrorBoundary} />
+            </div>
           )}
         >
           <InnerContent
@@ -338,6 +338,7 @@ const LoadedBoardItemContent = ({
 
   return (
     <>
+      {isEditMode && <BoardItemMenu item={menuItem} definition={definition} />}
       <WidgetContextMenu
         item={item}
         definition={definition}
@@ -445,7 +446,6 @@ const InnerContent = memo(function InnerContent({ item, definition, Component, .
   const board = useRequiredBoard();
   const [isEditMode] = useEditMode();
   const options = reduceWidgetOptionsWithDefinition(definition, settings, item.options);
-  const newItem = { ...item, options };
   const { removeItem, updateItemOptions } = useItemActions();
   const updateOptions = ({ newOptions }: { newOptions: Record<string, unknown> }) =>
     updateItemOptions({ itemId: item.id, newOptions });
@@ -462,19 +462,15 @@ const InnerContent = memo(function InnerContent({ item, definition, Component, .
             removeWidgetDataQueries(queryClient, widgetQueryKeys);
             reset();
           }}
+          resetKeys={[item]}
           fallbackRender={({ resetErrorBoundary, error }) => (
-            <>
-              {isEditMode && (
-                <BoardItemMenu item={newItem} definition={definition} resetErrorBoundary={resetErrorBoundary} />
-              )}
-              <div
-                className={itemContentClasses.editModeInertContent}
-                data-board-grid-inert-content={isEditMode ? "true" : undefined}
-                inert={isEditMode}
-              >
-                <WidgetError definition={definition} error={error} resetErrorBoundary={resetErrorBoundary} />
-              </div>
-            </>
+            <div
+              className={itemContentClasses.editModeInertContent}
+              data-board-grid-inert-content={isEditMode ? "true" : undefined}
+              inert={isEditMode}
+            >
+              <WidgetError definition={definition} error={error} resetErrorBoundary={resetErrorBoundary} />
+            </div>
           )}
         >
           <Throw
@@ -485,7 +481,6 @@ const InnerContent = memo(function InnerContent({ item, definition, Component, .
               (!("integrationsRequired" in definition) || definition.integrationsRequired !== false)
             }
           />
-          {isEditMode && <BoardItemMenu item={newItem} definition={definition} />}
           <div
             className={itemContentClasses.editModeInertContent}
             data-board-grid-inert-content={isEditMode ? "true" : undefined}

--- a/apps/nextjs/src/components/board/items/item-menu.tsx
+++ b/apps/nextjs/src/components/board/items/item-menu.tsx
@@ -105,7 +105,7 @@ const BoardItemMenuInner = ({ item, definition, resetErrorBoundary }: BoardItemM
           pos="absolute"
           top={12}
           right={8}
-          style={{ zIndex: 10 }}
+          style={{ zIndex: 30 }}
           data-board-widget-settings
           aria-label={tItem("menu.label.settingsFor", { name: label })}
         >


### PR DESCRIPTION
## Summary

Fixes an overlap where the new dnd-kit resize bars (especially the `ne` corner handle) rendered on top of the widget options "..." button in the top-right corner of every widget in edit mode, blocking clicks on it.

### Root cause

The options `ActionIcon` (`data-board-widget-settings`, `zIndex: 10`) rendered **inside** the widget `Card`, which sets `containerType: "size"` (`contain: layout style size`) and therefore creates a stacking context. The button's z-index was trapped inside the card at effective `z-auto`, while the resize handles are direct children of `.board-grid-entry` with `z-index: 20` (edges) / `9` (corners) — so the `ne` corner handle painted above the button and swallowed its clicks.

### Fix

- Hoist `BoardItemMenu` out of the `Card` to the item root (`LoadedBoardItemContent` fragment), the same layer that already renders the title badge correctly above the handles (`item-content.tsx`)
- Raise the button to `zIndex: 30`, above the resize handles' `20` (`item-menu.tsx`)
- Error-boundary recovery after editing an errored widget is preserved by switching both boundaries to `resetKeys={[item]}` (react-error-boundary only resets while the fallback is shown), replacing the `resetErrorBoundary` prop the in-card menu used to receive

The resize handles remain fully functional everywhere outside the 24×24 button area.

## Validation

Verified manually in a dev environment (headless Chromium + CDP) with a 10-column board in edit mode:

- `document.elementFromPoint()` at the center of all 7 widget options buttons returns the button (not the handle) — previously the `ne` handle won that hit test in the exact overlap zone (`neOverlapsBtn: true`)
- Clicking the options button opens the menu with *Edit item / Move & resize item / Duplicate item / Remove item*
- The `ne` handle still owns its hit-test area outside the button
- A real mouse drag on the `s` handle resizes a widget (h: 2 → 4), so resize behavior is intact

No tests/e2e added — pure layering/logic fix.

## Documentation

No docs changes needed (no user-facing API, env vars, widgets, or integrations changed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved board item error handling so edit menus remain available when widget content fails to load.
  * Ensured item updates correctly refresh error states and rendered content.
* **Style**
  * Improved the visibility of settings menu icons by adjusting their display priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->