### PR TITLE
docs: Proxmox certificate obtention instructions

### DIFF
--- a/apps/docs/docs/management/certificates/index.mdx
+++ b/apps/docs/docs/management/certificates/index.mdx
@@ -56,19 +56,17 @@ Every integration has its own way of obtaining certificates.
 Generally it is recommended to search for the documentation of the integration you are using.
 Most of the time you can find the certificate in the file system of the integration.
 The certificate file needs to be uploaded to Homarr. To first get the file on your computer you can either:
-- use [SCP (copy a file over SSH)](https://www.man7.org/linux/man-pages/man1/scp.1.html)
-- use `cat /path/to/file` to print the certificate in order to recreate the file on your machine
+- use `scp user@host:/path/to/file ./certificate.pem`
+- use `cat /path/to/file` to print the certificate. Then recreate the file on your machine.
 
 Below you can find instructions for some of the integrations.
 
 ### Pi-hole (v6)
-
 Since version 6 of Pi-hole, the web interface can be accessed through HTTPS.
 The certificate can be found in the path `/etc/pihole/tls_ca.crt`.
 You can find more details regarding SSL / TLS for Pi-hole [here](https://docs.pi-hole.net/api/tls/).
 
 ### Proxmox
-
-By default, Proxmox Virtual Environment (PVE) will automatically redirect HTTP traffic to HTTPS using a self-signed certificate, hereby necessitating uploading the certificate to Homarr.
-The certificate can be found in the path `/etc/pve/pve-root-ca.pem`.
+By default, Proxmox VE uses a node certificate signed by the cluster. You only need to configure Homarr with the certificate of a single node.
+The certificate can be found in any node on the path `/etc/pve/pve-root-ca.pem`.
 You can learn more about certificate management in Proxmox [here](https://pve.proxmox.com/wiki/Certificate_Management).

--- a/apps/docs/docs/management/certificates/index.mdx
+++ b/apps/docs/docs/management/certificates/index.mdx
@@ -63,3 +63,8 @@ Below you can find instructions for some of the integrations.
 Since version 6 of Pi-hole, the web interface can be accessed through HTTPS.
 The certificate can be found in the path `/etc/pihole/tls_ca.crt`. To add the certificate, this file needs to be copied and uploaded to Homarr.
 You can find more details regarding SSL / TLS for Pi-hole [here](https://docs.pi-hole.net/api/tls/).
+
+### Proxmox
+By default, Proxmox Virtual Environment (PVE) will automatically redirect HTTP traffic to HTTPS using a self-signed certificate, hereby necessitating uploading the certificate to Homarr.
+The certificate can be found in the path `/etc/pve/pve-root-ca.pem`. To add the certificate, this file needs to be copied and uploaded to Homarr.
+You can learn more about certificate management in Proxmox [here](https://pve.proxmox.com/wiki/Certificate_Management).

--- a/apps/docs/docs/management/certificates/index.mdx
+++ b/apps/docs/docs/management/certificates/index.mdx
@@ -52,19 +52,23 @@ The certificates are stored in the `/appdata/trusted-certificates` directory whi
 This means you can automate the update of the certificates by simply replacing or adding a new file in the directory.
 
 ## Obtaining certificates
-
 Every integration has its own way of obtaining certificates.
 Generally it is recommended to search for the documentation of the integration you are using.
 Most of the time you can find the certificate in the file system of the integration.
+The certificate file needs to be uploaded to Homarr. To first get the file on your computer you can either:
+- use [SCP (copy a file over SSH)](https://www.man7.org/linux/man-pages/man1/scp.1.html)
+- use `cat /path/to/file` to print the certificate in order to recreate the file on your machine
+
 Below you can find instructions for some of the integrations.
 
 ### Pi-hole (v6)
 
 Since version 6 of Pi-hole, the web interface can be accessed through HTTPS.
-The certificate can be found in the path `/etc/pihole/tls_ca.crt`. To add the certificate, this file needs to be copied and uploaded to Homarr.
+The certificate can be found in the path `/etc/pihole/tls_ca.crt`.
 You can find more details regarding SSL / TLS for Pi-hole [here](https://docs.pi-hole.net/api/tls/).
 
 ### Proxmox
+
 By default, Proxmox Virtual Environment (PVE) will automatically redirect HTTP traffic to HTTPS using a self-signed certificate, hereby necessitating uploading the certificate to Homarr.
-The certificate can be found in the path `/etc/pve/pve-root-ca.pem`. To add the certificate, this file needs to be copied and uploaded to Homarr.
+The certificate can be found in the path `/etc/pve/pve-root-ca.pem`.
 You can learn more about certificate management in Proxmox [here](https://pve.proxmox.com/wiki/Certificate_Management).


### PR DESCRIPTION
<br/>
<div align="center">
  <img src="https://homarr.dev/img/logo.png" height="80" alt="" />
  <h3>Homarr</h3>
</div>

**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] (N/A)Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] (N/A) No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] (N/A) Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).
- [x] When using AI; No temp files are checked in, the code style follows the rest of the project (I wrote the changes and had AI spell check)

My first commit adds the instructions to get the PVE self-signed certificate, and the second one reworks the section a bit to be more legible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an executable SCP example for transferring certificate files and clarified when to use `cat`.
  * Separated Pi-hole certificate guidance from general upload instructions.
  * Updated Proxmox guidance to cover cluster-signed node certificates and single-node configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->