### PR TITLE
fix(downloads-widget): give the name column a wider default width

### DIFF
--- a/packages/widgets/src/downloads/component.tsx
+++ b/packages/widgets/src/downloads/component.tsx
@@ -489,6 +489,7 @@ export default function DownloadClientsWidget({
         title: t("items.name.columnTitle"),
         sortable: true,
         ellipsis: true,
+        width: 240,
         render: (record) => (
           <Tooltip
             label={buildHoverTooltip(record, t)}


### PR DESCRIPTION
Closes #4157.

Every column in this table has an explicit pixel width except name, which is left unwidthed on purpose so it expands into whatever space is left. That part's correct. The problem is there's no floor on it, so once someone enables enough of the optional columns, name gets squeezed down to almost nothing, which is exactly what the screenshot in the issue shows.

Someone in the comments already worked out a good default a while back using custom CSS, weighting name way above progress/size/time. That whole CSS variable mechanism doesn't exist in the codebase anymore though, the widget's been rebuilt on mantine-datatable since then. Went with the simplest fix that fits how the table works today: set width: 240 on the name column, the same property every sibling column already uses, just previously missing on this one. Columns here are resizable and that state persists per user, so this only changes the starting width, not a hard cap, nobody's existing customization changes.

- [x] Builds without warnings or errors, pnpm typecheck clean, pnpm lint shows the same 59 pre-existing warnings before and after this change, none of them on this line
- [x] Targets dev
- [x] Commit follows conventional commits
- [x] No shorthand variable names, nothing new introduced
- [x] No temp files checked in, matches the existing code style in this file exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Set the downloads table’s name column to a fixed width of 240 pixels for more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->