### PR TITLE
fix(widgets): stop Health Monitoring system tab firing NOT_FOUND when Proxmox is mixed in

### DIFF
--- a/packages/widgets/src/health-monitoring/component.tsx
+++ b/packages/widgets/src/health-monitoring/component.tsx
@@ -18,16 +18,18 @@ const isClusterIntegration = (integration: { kind: IntegrationKind }) =>
   integration.kind === "proxmox" || integration.kind === "mock";
 
 export default function HealthMonitoringWidget(props: WidgetComponentProps<"healthMonitoring">) {
-  const { data: integrations = [] } = clientApi.integration.byIds.useQuery(props.integrationIds);
+  const { data: integrations, isLoading } = clientApi.integration.byIds.useQuery(props.integrationIds);
   const t = useI18n();
 
-  const clusterIntegrationId = integrations.find(isClusterIntegration)?.id;
+  if (isLoading) return null;
+
+  const clusterIntegrationId = integrations?.find(isClusterIntegration)?.id;
 
   if (!clusterIntegrationId) {
     return <SystemHealthMonitoring {...props} />;
   }
 
-  const otherIntegrationIds = integrations
+  const otherIntegrationIds = (integrations ?? [])
     // We want to have the mock integration also in the system tab, so we use it for both
     .filter((integration) => integration.kind !== "proxmox")
     .map((integration) => integration.id);

--- a/packages/widgets/src/health-monitoring/component.tsx
+++ b/packages/widgets/src/health-monitoring/component.tsx
@@ -18,10 +18,10 @@ const isClusterIntegration = (integration: { kind: IntegrationKind }) =>
   integration.kind === "proxmox" || integration.kind === "mock";
 
 export default function HealthMonitoringWidget(props: WidgetComponentProps<"healthMonitoring">) {
-  const { data: integrations, isLoading } = clientApi.integration.byIds.useQuery(props.integrationIds);
+  const { data: integrations, isLoading, isError } = clientApi.integration.byIds.useQuery(props.integrationIds);
   const t = useI18n();
 
-  if (isLoading) return null;
+  if (isLoading || isError) return null;
 
   const clusterIntegrationId = integrations?.find(isClusterIntegration)?.id;
 

--- a/packages/widgets/src/health-monitoring/component.tsx
+++ b/packages/widgets/src/health-monitoring/component.tsx
@@ -18,10 +18,10 @@ const isClusterIntegration = (integration: { kind: IntegrationKind }) =>
   integration.kind === "proxmox" || integration.kind === "mock";
 
 export default function HealthMonitoringWidget(props: WidgetComponentProps<"healthMonitoring">) {
-  const { data: integrations, isLoading, isError } = clientApi.integration.byIds.useQuery(props.integrationIds);
+  const { data: integrations, isPending, isError } = clientApi.integration.byIds.useQuery(props.integrationIds);
   const t = useI18n();
 
-  if (isLoading || isError) return null;
+  if (isPending || isError) return null;
 
   const clusterIntegrationId = integrations?.find(isClusterIntegration)?.id;
 


### PR DESCRIPTION
Fixes #6618

## Problem
When a Health Monitoring widget mixes a Proxmox integration with other supported kinds, loading the board fires a recurring `getSystemHealthStatus` `NOT_FOUND` tRPC error and pollutes server logs.

## Root cause
On first render `integration.byIds` has not resolved, so `clusterIntegrationId` is undefined and the early-return branch renders `<SystemHealthMonitoring {...props} />` with the **full unfiltered** `integrationIds` (Proxmox ID included). `SystemHealthMonitoring` immediately fires `getSystemHealthStatus` with that list, which hits the stale server allowlist that does not include `proxmox` → `NOT_FOUND`.

## Fix
Defer rendering until `integration.byIds` resolves so the kind-based split is known — Proxmox always routes to the cluster tab and `getSystemHealthStatus` only ever receives system-tab integration IDs.

## Alternative considered
Adding `proxmox` to the `healthMonitoringIntegrationKinds` allowlist would change server semantics; the client-side deferral is the scope-appropriate fix (matches the issue's second proposed option).

Closes #6618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health monitoring widget behavior while integration data is loading or unavailable.
  * Prevented incomplete integration data from causing display issues.
  * The widget remains hidden when integration information is loading or cannot be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->