### PR TITLE
fix(backup): prompt re-login after database restore and log restore errors

### DIFF
--- a/apps/nextjs/src/app/api/backup/import/route.ts
+++ b/apps/nextjs/src/app/api/backup/import/route.ts
@@ -12,9 +12,13 @@ import { auth } from "@homarr/auth/next";
 import { env } from "@homarr/common/env";
 import { DB_CASING } from "@homarr/core/infrastructure/db/constants";
 import { dbEnv } from "@homarr/core/infrastructure/db/env";
+import { createLogger } from "@homarr/core/infrastructure/logs";
+import { ErrorWithMetadata } from "@homarr/core/infrastructure/logs/error";
 import { db } from "@homarr/db";
 
 import { findMigrationsFolder } from "../shared";
+
+const logger = createLogger({ module: "backupImportRoute" });
 
 const REQUIRED_ZIP_ENTRIES = ["db.sqlite", "metadata.json"] as const;
 const ALGORITHM = "aes-256-cbc";
@@ -174,22 +178,26 @@ export async function POST(req: Request) {
         const sidecar = `${dbPath}${suffix}`;
         if (fs.existsSync(sidecar)) fs.unlinkSync(sidecar);
       } catch (cleanupErr) {
-        console.error(`Failed to remove ${suffix} file:`, cleanupErr);
+        logger.warn("Failed to remove SQLite sidecar file after restore", { suffix, dbPath, cause: cleanupErr });
       }
     }
 
     setTimeout(() => {
-      console.log("Database restored, restarting server...");
+      logger.info("Database restored, restarting server...");
       process.exit(0);
     }, 500);
 
     return NextResponse.json({ success: true, message: "Database restored. Server is restarting..." });
   } catch (error) {
-    console.error("[backup/import] Restore failed:", error);
+    logger.error(new ErrorWithMetadata("Backup restore failed", { dbPath }, { cause: error }));
     const message = error instanceof Error ? error.message : "Unknown error";
     return NextResponse.json({ error: `Restore failed: ${message}` }, { status: 500 });
   } finally {
-    tempDb?.close();
+    try {
+      tempDb?.close();
+    } catch (closeErr) {
+      logger.warn("Failed to close temporary database after restore", { cause: closeErr });
+    }
     if (fs.existsSync(tempPath)) {
       try {
         fs.unlinkSync(tempPath);

--- a/apps/nextjs/src/app/api/backup/migrations/route.ts
+++ b/apps/nextjs/src/app/api/backup/migrations/route.ts
@@ -3,7 +3,12 @@ import path from "path";
 
 import { NextResponse } from "next/server";
 
+import { createLogger } from "@homarr/core/infrastructure/logs";
+import { ErrorWithMetadata } from "@homarr/core/infrastructure/logs/error";
+
 import { findMigrationsFolder } from "../shared";
+
+const logger = createLogger({ module: "backupMigrationsRoute" });
 
 interface JournalEntry {
   idx: number;
@@ -56,7 +61,7 @@ export async function GET() {
       },
     );
   } catch (error) {
-    console.error("[backup/migrations] Failed to read migrations:", error);
+    logger.error(new ErrorWithMetadata("Failed to read migration files", {}, { cause: error }));
     const message = error instanceof Error ? error.message : "Unknown error";
     return NextResponse.json({ error: `Failed to read migrations: ${message}` }, { status: 500 });
   }

--- a/apps/nextjs/src/components/backup/database-restore-flow.tsx
+++ b/apps/nextjs/src/components/backup/database-restore-flow.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
-import { Alert, Button, Group, Loader, rem, Stack, Text } from "@mantine/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Alert, Button, Group, Loader, rem, Stack, Text, ThemeIcon } from "@mantine/core";
 import type { FileWithPath } from "@mantine/dropzone";
 import { Dropzone, MIME_TYPES } from "@mantine/dropzone";
-import { IconAlertTriangle, IconArrowRight, IconFileZip, IconUpload, IconX } from "@tabler/icons-react";
+import { IconAlertTriangle, IconArrowRight, IconCheck, IconFileZip, IconUpload, IconX } from "@tabler/icons-react";
 
 import "@mantine/dropzone/styles.css";
 
@@ -30,7 +30,16 @@ export const DatabaseRestoreFlow = ({ variant = "card", onRestoreComplete }: Dat
   const apiDoneRef = useRef(false);
   const animDoneRef = useRef(false);
   const apiErrorRef = useRef<string | null>(null);
+  const redirectTimerRef = useRef<number | null>(null);
   const { analysis, loading, error: analysisError, migrationProgress, analyzeFile, reset } = useBackupAnalysis();
+
+  useEffect(() => {
+    return () => {
+      if (redirectTimerRef.current !== null) {
+        window.clearTimeout(redirectTimerRef.current);
+      }
+    };
+  }, []);
 
   const handleFileDrop = useCallback(
     (files: FileWithPath[]) => {
@@ -45,6 +54,10 @@ export const DatabaseRestoreFlow = ({ variant = "card", onRestoreComplete }: Dat
   );
 
   const handleClear = useCallback(() => {
+    if (redirectTimerRef.current !== null) {
+      window.clearTimeout(redirectTimerRef.current);
+      redirectTimerRef.current = null;
+    }
     setFile(null);
     setStep("upload");
     setImportError(null);
@@ -65,8 +78,19 @@ export const DatabaseRestoreFlow = ({ variant = "card", onRestoreComplete }: Dat
 
     if (!animDoneRef.current) return;
     onRestoreComplete?.();
-    window.location.reload();
+    setStep("complete");
+    redirectTimerRef.current = window.setTimeout(() => {
+      window.location.assign("/auth/login");
+    }, 2000);
   }, [onRestoreComplete]);
+
+  const handleSignInAgain = useCallback(() => {
+    if (redirectTimerRef.current !== null) {
+      window.clearTimeout(redirectTimerRef.current);
+      redirectTimerRef.current = null;
+    }
+    window.location.assign("/auth/login");
+  }, []);
 
   const handleConfirm = useCallback(async () => {
     if (!file) return;
@@ -209,6 +233,23 @@ export const DatabaseRestoreFlow = ({ variant = "card", onRestoreComplete }: Dat
         migrations={analysis?.migrations.pending ?? []}
         onComplete={handleAnimationComplete}
       />
+    );
+  }
+
+  if (step === "complete") {
+    return (
+      <Stack gap="md" align="center" py="lg">
+        <ThemeIcon size={64} radius="xl" color="green" variant="light">
+          <IconCheck size={32} style={{ width: rem(40), height: rem(40) }} stroke={1.5} />
+        </ThemeIcon>
+        <Text size="lg" fw={600} ta="center">
+          {t("complete.title")}
+        </Text>
+        <Text size="sm" c="dimmed" ta="center" maw={480}>
+          {t("complete.message")}
+        </Text>
+        <Button onClick={handleSignInAgain}>{t("complete.button")}</Button>
+      </Stack>
     );
   }
 

--- a/apps/nextjs/src/components/backup/database-restore-flow.tsx
+++ b/apps/nextjs/src/components/backup/database-restore-flow.tsx
@@ -113,7 +113,8 @@ export const DatabaseRestoreFlow = ({ variant = "card", onRestoreComplete }: Dat
           apiErrorRef.current = `Server returned ${response.status}`;
         }
       }
-    } catch {
+    } catch (error) {
+      console.error("Restore request failed", error);
       apiErrorRef.current = t("failed.title");
     } finally {
       apiDoneRef.current = true;

--- a/apps/nextjs/src/components/backup/types.ts
+++ b/apps/nextjs/src/components/backup/types.ts
@@ -25,6 +25,6 @@ export interface BackupAnalysis {
   migrations: MigrationStatus;
 }
 
-export type RestoreStep = "upload" | "preview" | "confirm" | "restoring" | "error";
+export type RestoreStep = "upload" | "preview" | "confirm" | "restoring" | "complete" | "error";
 
 export const PREVIEW_TABLE_KEYS = ["board", "user", "app", "integration", "item", "media", "search_engine"] as const;

--- a/apps/nextjs/src/components/backup/use-backup-analysis.ts
+++ b/apps/nextjs/src/components/backup/use-backup-analysis.ts
@@ -168,6 +168,7 @@ export const useBackupAnalysis = () => {
           dbRef.current = null;
         }
       } catch (err) {
+        console.error("Backup analysis failed", err);
         setError(err instanceof Error ? err.message : t("analyzeError"));
       } finally {
         setLoading(false);

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -5276,7 +5276,8 @@
             },
             "complete": {
               "title": "Restore Complete",
-              "message": "Database has been restored successfully. The server is restarting — please refresh the page in a few seconds."
+              "message": "Database has been restored successfully and the server has restarted. Your previous session was invalidated, so you need to sign in again to see the restored board.",
+              "button": "Sign in now"
             },
             "failed": {
               "title": "Restore Failed"


### PR DESCRIPTION
## Summary

Fixes #6622 — restoring a `.zip` backup showed an empty board (or a contextless login redirect) until a manual hard refresh.

### Root cause
Homarr uses Auth.js with `session: { strategy: "database" }` (`packages/auth/configuration.ts`). Restoring a backup **replaces `db.sqlite` on disk**, which invalidates the current session. The old client code did a silent `window.location.reload()` after the progress animation, so users landed on an empty board or the login screen with no explanation.

### Changes
- **`database-restore-flow.tsx`**: after a successful restore, show an explicit "Restore Complete — session invalidated" panel and auto-redirect to `/auth/login` (plus a manual "Sign in now" button). Uses `window.location.assign` to a different URL so the browser cannot restore the stale board document from bfcache.
- **`use-backup-analysis.ts`**: log backup analysis failures to the browser console.
- **`api/backup/import/route.ts`** & **`api/backup/migrations/route.ts`**: route restore errors through `createLogger` + `ErrorWithMetadata` (console + Redis transports) instead of raw `console.error`, and wrap the temporary DB close so a close failure cannot 500 a successful restore.

### Test instructions
1. On `main`, export a backup (Settings → Tools → Backup & Restore).
2. Modify boards, then restore the backup.
3. Before: empty board / silent login redirect until a manual hard refresh.
4. After: clear "session invalidated" message, auto-redirect to login, boards render immediately after signing in.

Also verify restore error logging appears in the container logs (e.g. try restoring a corrupt/foreign ZIP).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Backup restoration now shows a completion screen, supports immediate sign-in, and automatically redirects after a short delay.
  - Added broader localization for the WUD integration, widgets, icon picker, backup flows, and other interface areas.
  - TrueNAS storage metrics now reflect usable root dataset capacity.

- **Bug Fixes**
  - Smart-home actions report failures more reliably and refresh entity state immediately.
  - Home Assistant actions now authenticate correctly.
  - Improved backup and migration error reporting.

- **Documentation**
  - Updated Helm, TrueNAS, smart-home, automation, and developer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->