### PR TITLE
feat (v2 stocks widget):Add a "Show details" toggle to the stock widget's compact view

### DIFF
--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -3533,6 +3533,10 @@
               "label": "1 Month"
             }
           }
+        },
+        "showDetails": {
+          "label": "Show details",
+          "description": "Show the name, change, and time range in the compact view. Turn off for just the symbol and price."
         }
       }
     },

--- a/packages/widgets/src/stocks/component.spec.ts
+++ b/packages/widgets/src/stocks/component.spec.ts
@@ -33,7 +33,7 @@ describe("stock summary", () => {
 
 describe("stock layout", () => {
   it("keeps compact widgets focused on symbol and price", () => {
-    expect(getStockLayout(320, 100)).toMatchObject({
+    expect(getStockLayout(320, 100, true)).toMatchObject({
       showName: false,
       showChange: false,
       showRange: false,
@@ -42,12 +42,12 @@ describe("stock layout", () => {
   });
 
   it("reveals secondary data only when both axes have room", () => {
-    expect(getStockLayout(320, 160)).toMatchObject({
+    expect(getStockLayout(320, 160, true)).toMatchObject({
       showName: false,
       showChange: true,
       showRange: true,
     });
-    expect(getStockLayout(320, 220)).toMatchObject({
+    expect(getStockLayout(320, 220, true)).toMatchObject({
       showName: true,
       showChange: true,
       showRange: true,
@@ -56,12 +56,20 @@ describe("stock layout", () => {
   });
 
   it("exposes the complete summary when the widget is roomy", () => {
-    expect(getStockLayout(640, 360)).toEqual({
+    expect(getStockLayout(640, 360, true)).toEqual({
       showName: true,
       showChange: true,
       showRange: true,
       graphHeight: "75%",
       priceOrder: 1,
+    });
+  });
+
+  it("hides name, change, and range regardless of size when showDetails is off", () => {
+    expect(getStockLayout(640, 360, false)).toMatchObject({
+      showName: false,
+      showChange: false,
+      showRange: false,
     });
   });
 });

--- a/packages/widgets/src/stocks/component.tsx
+++ b/packages/widgets/src/stocks/component.tsx
@@ -43,11 +43,11 @@ export interface StockLayout {
   priceOrder: 1 | 2;
 }
 
-export function getStockLayout(width: number, height: number): StockLayout {
+export function getStockLayout(width: number, height: number, showDetails: boolean): StockLayout {
   return {
-    showName: width >= 300 && height >= 190,
-    showChange: width >= 260 && height >= 130,
-    showRange: width >= 220 && height >= 130,
+    showName: showDetails && width >= 300 && height >= 190,
+    showChange: showDetails && width >= 260 && height >= 130,
+    showRange: showDetails && width >= 220 && height >= 130,
     graphHeight: height >= 320 ? "75%" : height >= 220 ? "68%" : "48%",
     priceOrder: width >= 280 && height >= 120 ? 1 : 2,
   };
@@ -92,7 +92,7 @@ export default function StockPriceWidget({
   const stockValuesChangePercentage = summary.changePercentage === null ? null : round(summary.changePercentage);
   const stockGraphValues = summary.graphValues;
   const trendColor = stockValuesChange > 0 ? "green.7" : stockValuesChange < 0 ? "red.7" : "gray.6";
-  const layout = getStockLayout(width, height);
+  const layout = getStockLayout(width, height, options.showDetails);
   const formatValue = (value: number) => numberFormatter.format(round(value));
   const formatSignedValue = (value: number) => `${value > 0 ? "+" : ""}${formatValue(value)}`;
 

--- a/packages/widgets/src/stocks/index.ts
+++ b/packages/widgets/src/stocks/index.ts
@@ -41,6 +41,10 @@ export const { definition, componentLoader } = createWidgetDefinition("stockPric
           label: (t) => t(`widget.stockPrice.option.timeInterval.option.${value}.label`),
         })),
       }),
+      showDetails: factory.switch({
+        defaultValue: true,
+        withDescription: true,
+      }),
     }));
   },
 }).withDynamicImport(() => import("./component"));


### PR DESCRIPTION
This adds a toggle to hide all the extra information that floods the widget in smaller sizes; the advanced menu is untouched.

<p align="center">
  <img src="https://github.com/user-attachments/assets/44ebd10a-bff2-4069-9ed8-cb6eb89b71dc" width="45%" />
  <img src="https://github.com/user-attachments/assets/604df450-a903-4995-a48b-851fbedcbfee" width="45%" />
</p>


**Thank you for your contribution. Please ensure that your pull request meets the following pull request:**

- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).
- [x] When using AI; No temp files are checked in, the code style follows the rest of the project

**When contributing a new integration or widget:**

- [x] I confirmed manually that the integration or widget is working with a real system and performed basic smoke
  tests (e.g. what happens if it is offline)
- [x] Optional but recommended: I confirm that I am willing to be added to the `CODEOWNERS` of this feature and will
  provide support and maintain the integration (e.g. in case of breaking or failure)