### PR TITLE
feat: retain application log history

### DIFF
--- a/apps/docs/docs/management/logs/index.mdx
+++ b/apps/docs/docs/management/logs/index.mdx
@@ -1,0 +1,34 @@
+---
+tags:
+  - Administration
+  - Logs
+  - Troubleshooting
+---
+
+# Logs
+
+The logs page shows recent Homarr application logs and continues updating as new events occur. Use it to investigate
+widget, integration, and server errors without opening the container logs separately.
+
+## Opening the logs page
+
+Navigate to **Management** > **Tools** > **Logs**. The page and widget log links are only available to users with the
+**View logs** permission.
+
+When a widget reports an error, **Check logs for more details** opens the logs page in a new tab and marks the time when
+the widget displayed the error. The related server error normally appears immediately above that marker. If those logs
+have already been removed from the retained history, the marker explains that they are no longer available.
+
+## Retained and live logs
+
+Homarr retains the latest 5,000 log events in Redis. Opening the page first loads this history and then continues with
+live events without a gap. The history is bounded, so older events are removed automatically.
+
+The history survives normal application restarts when the configured Redis instance persists its data. For complete
+platform-level history, startup failures, or events older than the retained limit, use the logs provided by Docker or
+your deployment platform.
+
+## Display controls
+
+The severity selector applies to both retained and live events. Selecting a different level redraws the existing view
+using that threshold. The font-size control changes the terminal text size and is remembered in the browser.

--- a/apps/nextjs/src/app/[locale]/manage/tools/logs/client.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/tools/logs/client.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import type { ComponentType } from "react";
 import dynamic from "next/dynamic";
+
+interface ClientSideTerminalComponentProps {
+  focusTimestamp?: number;
+}
 
 export const ClientSideTerminalComponent = dynamic(
   () => import("./terminal").then(({ TerminalComponent }) => TerminalComponent),
   {
     ssr: false,
   },
-);
+) as ComponentType<ClientSideTerminalComponentProps>;

--- a/apps/nextjs/src/app/[locale]/manage/tools/logs/client.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/tools/logs/client.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import type { ComponentType } from "react";
 import dynamic from "next/dynamic";
 
 interface ClientSideTerminalComponentProps {
   focusTimestamp?: number;
 }
 
-export const ClientSideTerminalComponent = dynamic(
+export const ClientSideTerminalComponent = dynamic<ClientSideTerminalComponentProps>(
   () => import("./terminal").then(({ TerminalComponent }) => TerminalComponent),
   {
     ssr: false,
   },
-) as ComponentType<ClientSideTerminalComponentProps>;
+);

--- a/apps/nextjs/src/app/[locale]/manage/tools/logs/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/tools/logs/page.tsx
@@ -39,14 +39,9 @@ export default async function LogsManagementPage({ searchParams }: LogsManagemen
     notFound();
   }
 
-  const { focus } = await searchParams;
-  let focusTimestamp: number | undefined;
-  if (focus !== undefined) {
-    const parsedFocusTimestamp = Number(focus);
-    if (Number.isSafeInteger(parsedFocusTimestamp) && parsedFocusTimestamp > 0) {
-      focusTimestamp = parsedFocusTimestamp;
-    }
-  }
+  const parsedFocusTimestamp = Number((await searchParams).focus);
+  const focusTimestamp =
+    Number.isSafeInteger(parsedFocusTimestamp) && parsedFocusTimestamp > 0 ? parsedFocusTimestamp : undefined;
 
   return (
     <LogContextProvider defaultLevel={logsEnv.LEVEL}>

--- a/apps/nextjs/src/app/[locale]/manage/tools/logs/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/tools/logs/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata() {
 }
 
 interface LogsManagementPageProps {
-  searchParams: Promise<{ focus?: string }>;
+  searchParams: Promise<{ focus?: string | string[] }>;
 }
 
 export default async function LogsManagementPage({ searchParams }: LogsManagementPageProps) {
@@ -39,9 +39,14 @@ export default async function LogsManagementPage({ searchParams }: LogsManagemen
     notFound();
   }
 
-  const parsedFocusTimestamp = Number((await searchParams).focus);
-  const focusTimestamp =
-    Number.isSafeInteger(parsedFocusTimestamp) && parsedFocusTimestamp > 0 ? parsedFocusTimestamp : undefined;
+  const focus = (await searchParams).focus;
+  let focusTimestamp: number | undefined;
+  if (typeof focus === "string") {
+    const parsedFocusTimestamp = Number(focus);
+    if (Number.isSafeInteger(parsedFocusTimestamp) && parsedFocusTimestamp > 0) {
+      focusTimestamp = parsedFocusTimestamp;
+    }
+  }
 
   return (
     <LogContextProvider defaultLevel={logsEnv.LEVEL}>

--- a/apps/nextjs/src/app/[locale]/manage/tools/logs/page.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/tools/logs/page.tsx
@@ -29,10 +29,23 @@ export async function generateMetadata() {
   };
 }
 
-export default async function LogsManagementPage() {
+interface LogsManagementPageProps {
+  searchParams: Promise<{ focus?: string }>;
+}
+
+export default async function LogsManagementPage({ searchParams }: LogsManagementPageProps) {
   const session = await auth();
   if (!session?.user.permissions.includes("other-view-logs")) {
     notFound();
+  }
+
+  const { focus } = await searchParams;
+  let focusTimestamp: number | undefined;
+  if (focus !== undefined) {
+    const parsedFocusTimestamp = Number(focus);
+    if (Number.isSafeInteger(parsedFocusTimestamp) && parsedFocusTimestamp > 0) {
+      focusTimestamp = parsedFocusTimestamp;
+    }
   }
 
   return (
@@ -45,7 +58,7 @@ export default async function LogsManagementPage() {
         </Group>
       </Group>
       <Box style={{ borderRadius: 6 }} h={fullHeightWithoutHeaderAndFooter} p="md" bg="black">
-        <ClientSideTerminalComponent />
+        <ClientSideTerminalComponent focusTimestamp={focusTimestamp} />
       </Box>
     </LogContextProvider>
   );

--- a/apps/nextjs/src/app/[locale]/manage/tools/logs/terminal.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/tools/logs/terminal.tsx
@@ -37,27 +37,21 @@ const getFocusMarker = (
   };
 };
 
-const findMarkerLine = (terminal: Terminal, markerText: string) => {
+const findMarkerLine = (terminal: Terminal, linesFromEnd: number) => {
   const buffer = terminal.buffer.active;
-  let logicalLine = "";
-  let logicalLineStart = 0;
+  const logicalLineStarts: number[] = [];
+  const cursorLine = buffer.baseY + buffer.cursorY;
 
-  for (let index = 0; index < buffer.length; index++) {
+  for (let index = 0; index <= cursorLine; index++) {
     const line = buffer.getLine(index);
     if (!line) continue;
 
     if (!line.isWrapped) {
-      logicalLine = "";
-      logicalLineStart = index;
-    }
-    logicalLine += line.translateToString(true);
-
-    if (logicalLine.includes(markerText)) {
-      return logicalLineStart;
+      logicalLineStarts.push(index);
     }
   }
 
-  return null;
+  return logicalLineStarts.at(-linesFromEnd) ?? null;
 };
 
 const renderMessages = ({
@@ -78,24 +72,35 @@ const renderMessages = ({
   const activeLevelSet = new Set(activeLevels);
   const visibleMessages = messages.filter((message) => activeLevelSet.has(message.level));
   const focusMarker = getFocusMarker(messages, visibleMessages, focusTimestamp, markerText, expiredMarkerText);
-  const output = visibleMessages.flatMap((message, index) => {
+  const output: string[] = [];
+  let markerOutputIndex: number | null = null;
+
+  visibleMessages.forEach((message, index) => {
     if (focusMarker?.index === index) {
-      return [`\x1b[33m--- ${focusMarker.text} ---\x1b[0m`, message.message];
+      markerOutputIndex = output.length;
+      output.push(`\x1b[33m--- ${focusMarker.text} ---\x1b[0m`);
     }
-    return [message.message];
+    output.push(message.message);
   });
 
   if (focusMarker?.index === visibleMessages.length) {
+    markerOutputIndex = output.length;
     output.push(`\x1b[33m--- ${focusMarker.text} ---\x1b[0m`);
   }
 
+  let markerLinesFromEnd: number | null = null;
+  if (markerOutputIndex !== null) {
+    markerLinesFromEnd =
+      1 + output.slice(markerOutputIndex).reduce((lineCount, line) => lineCount + line.split(/\r?\n/).length, 0);
+  }
+
   terminal.write(`\x1bc${output.join("\r\n")}${output.length > 0 ? "\r\n" : ""}`, () => {
-    if (!focusMarker) {
+    if (markerLinesFromEnd === null) {
       terminal.scrollToBottom();
       return;
     }
 
-    const markerLine = findMarkerLine(terminal, focusMarker.text);
+    const markerLine = findMarkerLine(terminal, markerLinesFromEnd);
     if (markerLine !== null) {
       terminal.scrollToLine(markerLine);
     }

--- a/apps/nextjs/src/app/[locale]/manage/tools/logs/terminal.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/tools/logs/terminal.tsx
@@ -15,7 +15,7 @@ import { useLogContext } from "./log-context";
 import classes from "./terminal.module.css";
 
 const ALL_LOG_LEVELS = [...logLevels];
-const TERMINAL_SCROLLBACK_LINES = LOG_HISTORY_MAX_ENTRIES * 4;
+const TERMINAL_SCROLLBACK_LINES = LOG_HISTORY_MAX_ENTRIES * 20;
 
 const getFocusMarker = (
   messages: LoggerMessage[],

--- a/apps/nextjs/src/app/[locale]/manage/tools/logs/terminal.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/tools/logs/terminal.tsx
@@ -7,25 +7,176 @@ import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
 
 import { clientApi } from "@homarr/api/client";
+import type { LoggerMessage, LogLevel } from "@homarr/core/infrastructure/logs/constants";
+import { LOG_HISTORY_MAX_ENTRIES, logLevels } from "@homarr/core/infrastructure/logs/constants";
+import { useI18n } from "@homarr/translation/client";
 
 import { useLogContext } from "./log-context";
 import classes from "./terminal.module.css";
 
-export const TerminalComponent = () => {
+const ALL_LOG_LEVELS = [...logLevels];
+const TERMINAL_SCROLLBACK_LINES = LOG_HISTORY_MAX_ENTRIES * 4;
+
+interface FocusMarker {
+  index: number;
+  text: string;
+}
+
+const getFocusMarker = (
+  messages: LoggerMessage[],
+  visibleMessages: LoggerMessage[],
+  focusTimestamp: number | undefined,
+  markerText: string,
+  expiredMarkerText: string,
+): FocusMarker | null => {
+  if (focusTimestamp === undefined) return null;
+
+  let oldestTimestamp = Number.POSITIVE_INFINITY;
+  for (const message of messages) {
+    oldestTimestamp = Math.min(oldestTimestamp, message.timestamp.getTime());
+  }
+  if (oldestTimestamp === Number.POSITIVE_INFINITY || focusTimestamp < oldestTimestamp) {
+    return { index: 0, text: expiredMarkerText };
+  }
+
+  let markerIndex = 0;
+  for (const [index, message] of visibleMessages.entries()) {
+    if (message.timestamp.getTime() <= focusTimestamp) {
+      markerIndex = index + 1;
+    }
+  }
+
+  return {
+    index: markerIndex,
+    text: markerText,
+  };
+};
+
+const findMarkerLine = (terminal: Terminal, markerText: string) => {
+  const buffer = terminal.buffer.active;
+  let logicalLine = "";
+  let logicalLineStart = 0;
+
+  for (let index = 0; index < buffer.length; index++) {
+    const line = buffer.getLine(index);
+    if (!line) continue;
+
+    if (!line.isWrapped) {
+      logicalLine = "";
+      logicalLineStart = index;
+    }
+    logicalLine += line.translateToString(true);
+
+    if (logicalLine.includes(markerText)) {
+      return logicalLineStart;
+    }
+  }
+
+  return null;
+};
+
+const renderMessages = ({
+  terminal,
+  messages,
+  activeLevels,
+  focusTimestamp,
+  markerText,
+  expiredMarkerText,
+}: {
+  terminal: Terminal;
+  messages: LoggerMessage[];
+  activeLevels: LogLevel[];
+  focusTimestamp: number | undefined;
+  markerText: string;
+  expiredMarkerText: string;
+}) => {
+  const activeLevelSet = new Set(activeLevels);
+  const visibleMessages = messages.filter((message) => activeLevelSet.has(message.level));
+  const focusMarker = getFocusMarker(messages, visibleMessages, focusTimestamp, markerText, expiredMarkerText);
+  const output = visibleMessages.flatMap((message, index) => {
+    if (focusMarker?.index === index) {
+      return [`\x1b[33m--- ${focusMarker.text} ---\x1b[0m`, message.message];
+    }
+    return [message.message];
+  });
+
+  if (focusMarker?.index === visibleMessages.length) {
+    output.push(`\x1b[33m--- ${focusMarker.text} ---\x1b[0m`);
+  }
+
+  terminal.reset();
+  if (output.length === 0) return;
+
+  terminal.write(`${output.join("\r\n")}\r\n`, () => {
+    if (!focusMarker) {
+      terminal.scrollToBottom();
+      return;
+    }
+
+    const markerLine = findMarkerLine(terminal, focusMarker.text);
+    if (markerLine !== null) {
+      terminal.scrollToLine(markerLine);
+    }
+  });
+};
+
+interface TerminalComponentProps {
+  focusTimestamp?: number;
+}
+
+export const TerminalComponent = ({ focusTimestamp }: TerminalComponentProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const { activeLevels, fontSize } = useLogContext();
+  const t = useI18n();
 
   const terminalRef = useRef<Terminal>(null);
   const fitAddonRef = useRef<FitAddon>(null);
+  const messagesRef = useRef<LoggerMessage[]>([]);
+  const initialFontSizeRef = useRef(fontSize);
+  const activeLevelsRef = useRef(activeLevels);
+  const markerTextRef = useRef(t("log.context.widgetError"));
+  const expiredMarkerTextRef = useRef(t("log.context.expiredWidgetError"));
+  const focusTimestampRef = useRef(focusTimestamp);
+
+  activeLevelsRef.current = activeLevels;
+  markerTextRef.current = t("log.context.widgetError");
+  expiredMarkerTextRef.current = t("log.context.expiredWidgetError");
+  focusTimestampRef.current = focusTimestamp;
+
+  const redrawTerminal = () => {
+    const terminal = terminalRef.current;
+    if (!terminal) return;
+
+    renderMessages({
+      terminal,
+      messages: messagesRef.current,
+      activeLevels: activeLevelsRef.current,
+      focusTimestamp: focusTimestampRef.current,
+      markerText: markerTextRef.current,
+      expiredMarkerText: expiredMarkerTextRef.current,
+    });
+  };
 
   clientApi.log.subscribe.useSubscription(
     {
-      levels: activeLevels,
+      levels: ALL_LOG_LEVELS,
     },
     {
-      onData(data) {
-        terminalRef.current?.writeln(data.message);
-        terminalRef.current?.refresh(0, terminalRef.current.rows - 1);
+      onData(event) {
+        if (event.type === "history") {
+          messagesRef.current = event.messages.slice(-LOG_HISTORY_MAX_ENTRIES);
+          redrawTerminal();
+          return;
+        }
+
+        messagesRef.current.push(event.message);
+        if (messagesRef.current.length > LOG_HISTORY_MAX_ENTRIES) {
+          messagesRef.current.shift();
+        }
+
+        if (activeLevelsRef.current.includes(event.message.level)) {
+          terminalRef.current?.writeln(event.message.message);
+        }
       },
       onError(err) {
         alert(err);
@@ -44,22 +195,26 @@ export const TerminalComponent = () => {
       cursorBlink: false,
       disableStdin: true,
       convertEol: true,
-      fontSize,
+      fontSize: initialFontSizeRef.current,
+      scrollback: TERMINAL_SCROLLBACK_LINES,
     });
     terminalRef.current.open(ref.current);
     terminalRef.current.loadAddon(canvasAddon);
 
-    setTimeout(() => {
+    const fitTimeout = window.setTimeout(() => {
       const fitAddon = new FitAddon();
       fitAddonRef.current = fitAddon;
       terminalRef.current?.loadAddon(fitAddon);
       fitAddon.fit();
+      redrawTerminal();
     });
 
     return () => {
+      window.clearTimeout(fitTimeout);
       canvasAddon.dispose();
       terminalRef.current?.dispose();
       terminalRef.current = null;
+      fitAddonRef.current = null;
     };
   }, []);
 
@@ -68,6 +223,10 @@ export const TerminalComponent = () => {
     terminalRef.current.options.fontSize = fontSize;
     fitAddonRef.current?.fit();
   }, [fontSize]);
+
+  useEffect(() => {
+    redrawTerminal();
+  }, [activeLevels, focusTimestamp]);
 
   return <Box ref={ref} id="terminal" className={classes.outerTerminal} h="100%"></Box>;
 };

--- a/apps/nextjs/src/app/[locale]/manage/tools/logs/terminal.tsx
+++ b/apps/nextjs/src/app/[locale]/manage/tools/logs/terminal.tsx
@@ -17,37 +17,22 @@ import classes from "./terminal.module.css";
 const ALL_LOG_LEVELS = [...logLevels];
 const TERMINAL_SCROLLBACK_LINES = LOG_HISTORY_MAX_ENTRIES * 4;
 
-interface FocusMarker {
-  index: number;
-  text: string;
-}
-
 const getFocusMarker = (
   messages: LoggerMessage[],
   visibleMessages: LoggerMessage[],
   focusTimestamp: number | undefined,
   markerText: string,
   expiredMarkerText: string,
-): FocusMarker | null => {
+) => {
   if (focusTimestamp === undefined) return null;
 
-  let oldestTimestamp = Number.POSITIVE_INFINITY;
-  for (const message of messages) {
-    oldestTimestamp = Math.min(oldestTimestamp, message.timestamp.getTime());
-  }
-  if (oldestTimestamp === Number.POSITIVE_INFINITY || focusTimestamp < oldestTimestamp) {
+  const oldestTimestamp = messages[0]?.timestamp.getTime();
+  if (oldestTimestamp === undefined || focusTimestamp < oldestTimestamp) {
     return { index: 0, text: expiredMarkerText };
   }
 
-  let markerIndex = 0;
-  for (const [index, message] of visibleMessages.entries()) {
-    if (message.timestamp.getTime() <= focusTimestamp) {
-      markerIndex = index + 1;
-    }
-  }
-
   return {
-    index: markerIndex,
+    index: visibleMessages.findLastIndex((message) => message.timestamp.getTime() <= focusTimestamp) + 1,
     text: markerText,
   };
 };
@@ -104,10 +89,7 @@ const renderMessages = ({
     output.push(`\x1b[33m--- ${focusMarker.text} ---\x1b[0m`);
   }
 
-  terminal.reset();
-  if (output.length === 0) return;
-
-  terminal.write(`${output.join("\r\n")}\r\n`, () => {
+  terminal.write(`\x1bc${output.join("\r\n")}${output.length > 0 ? "\r\n" : ""}`, () => {
     if (!focusMarker) {
       terminal.scrollToBottom();
       return;
@@ -134,8 +116,8 @@ export const TerminalComponent = ({ focusTimestamp }: TerminalComponentProps) =>
   const messagesRef = useRef<LoggerMessage[]>([]);
   const initialFontSizeRef = useRef(fontSize);
   const activeLevelsRef = useRef(activeLevels);
-  const markerTextRef = useRef(t("log.context.widgetError"));
-  const expiredMarkerTextRef = useRef(t("log.context.expiredWidgetError"));
+  const markerTextRef = useRef("");
+  const expiredMarkerTextRef = useRef("");
   const focusTimestampRef = useRef(focusTimestamp);
 
   activeLevelsRef.current = activeLevels;

--- a/packages/api/src/router/log.ts
+++ b/packages/api/src/router/log.ts
@@ -11,6 +11,10 @@ import { createTRPCRouter, permissionRequiredProcedure } from "../trpc";
 
 const logger = createLogger({ module: "logRouter" });
 
+type LogSubscriptionEvent =
+  | { type: "history"; messages: LoggerMessage[] }
+  | { type: "message"; message: LoggerMessage };
+
 export const logRouter = createTRPCRouter({
   subscribe: permissionRequiredProcedure
     .requiresPermission("other-view-logs")
@@ -20,15 +24,61 @@ export const logRouter = createTRPCRouter({
       }),
     )
     .subscription(({ input }) => {
-      return observable<LoggerMessage>((emit) => {
-        const unsubscribe = loggingChannel.subscribe((data) => {
-          if (!input.levels.includes(data.level)) return;
-          emit.next(data);
-        });
-        logger.info("A tRPC client has connected to the logging procedure");
+      return observable<LogSubscriptionEvent>((emit) => {
+        let isClosed = false;
+        let unsubscribe: (() => void) | null = null;
+        let isHistoryLoaded = false;
+        const bufferedMessages: LoggerMessage[] = [];
+
+        const onMessage = (message: LoggerMessage) => {
+          if (!input.levels.includes(message.level)) return;
+
+          if (!isHistoryLoaded) {
+            bufferedMessages.push(message);
+            return;
+          }
+
+          emit.next({ type: "message", message });
+        };
+
+        void loggingChannel
+          .subscribeAsync(onMessage)
+          .then(async (unsubscribeFromLogging) => {
+            if (isClosed) {
+              unsubscribeFromLogging();
+              return;
+            }
+
+            unsubscribe = unsubscribeFromLogging;
+            logger.info("A tRPC client has connected to the logging procedure");
+
+            const history = (await loggingChannel.getRecentAsync()).filter((message) =>
+              input.levels.includes(message.level),
+            );
+            if (isClosed) return;
+
+            emit.next({ type: "history", messages: history });
+
+            const historyIds = new Set(history.map((message) => message.id));
+            isHistoryLoaded = true;
+            for (const message of bufferedMessages) {
+              if (!historyIds.has(message.id)) {
+                emit.next({ type: "message", message });
+              }
+            }
+            bufferedMessages.length = 0;
+          })
+          .catch((error: unknown) => {
+            unsubscribe?.();
+            unsubscribe = null;
+            if (!isClosed) {
+              emit.error(error);
+            }
+          });
 
         return () => {
-          unsubscribe();
+          isClosed = true;
+          unsubscribe?.();
         };
       });
     }),

--- a/packages/api/src/router/test/log.spec.ts
+++ b/packages/api/src/router/test/log.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { Session } from "@homarr/auth";
+import type { LoggerMessage } from "@homarr/redis";
+
+import { logRouter } from "../log";
+
+const mocks = vi.hoisted(() => ({
+  getRecentAsync: vi.fn(),
+  subscribeAsync: vi.fn(),
+}));
+
+vi.mock("@homarr/redis", () => ({
+  loggingChannel: {
+    getRecentAsync: mocks.getRecentAsync,
+    subscribeAsync: mocks.subscribeAsync,
+  },
+}));
+
+const session = {
+  user: {
+    id: "log-viewer",
+    permissions: ["other-view-logs"],
+    colorScheme: "light",
+  },
+  expires: new Date(0).toISOString(),
+} satisfies Session;
+
+const createMessage = (id: string, timestamp: number): LoggerMessage => ({
+  id,
+  timestamp: new Date(timestamp),
+  level: "info",
+  message: id,
+});
+
+describe("log.subscribe", () => {
+  test("emits history before buffered live messages without duplicates", async () => {
+    const historyDeferred = Promise.withResolvers<LoggerMessage[]>();
+    let onMessage: ((message: LoggerMessage) => void) | undefined;
+    const unsubscribe = vi.fn();
+
+    mocks.subscribeAsync.mockImplementation(async (callback: (message: LoggerMessage) => void) => {
+      onMessage = callback;
+      return unsubscribe;
+    });
+    mocks.getRecentAsync.mockReturnValue(historyDeferred.promise);
+
+    const caller = logRouter.createCaller({
+      db: null as never,
+      deviceType: undefined,
+      session,
+    });
+    const subscription = await caller.subscribe({ levels: ["info"] });
+    const events: object[] = [];
+    const observer = subscription.subscribe({
+      next(event) {
+        events.push(event);
+      },
+    });
+
+    await vi.waitFor(() => expect(mocks.getRecentAsync).toHaveBeenCalledOnce());
+
+    const retainedMessage = createMessage("retained", 1);
+    const liveMessage = createMessage("live", 2);
+    onMessage?.(retainedMessage);
+    onMessage?.(liveMessage);
+    historyDeferred.resolve([retainedMessage]);
+
+    await vi.waitFor(() =>
+      expect(events).toEqual([
+        { type: "history", messages: [retainedMessage] },
+        { type: "message", message: liveMessage },
+      ]),
+    );
+
+    observer.unsubscribe();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/infrastructure/logs/constants.ts
+++ b/packages/core/src/infrastructure/logs/constants.ts
@@ -1,12 +1,15 @@
+import z from "zod/v4";
+
 export const logLevels = ["error", "warn", "info", "debug"] as const;
 export type LogLevel = (typeof logLevels)[number];
 
-export interface LoggerMessage {
-  id: string;
-  timestamp: Date;
-  message: string;
-  level: LogLevel;
-}
+export const loggerMessageSchema = z.object({
+  id: z.string(),
+  timestamp: z.date(),
+  message: z.string(),
+  level: z.enum(logLevels),
+});
+export type LoggerMessage = z.infer<typeof loggerMessageSchema>;
 
 export const LOG_HISTORY_MAX_ENTRIES = 5_000;
 export const LOG_HISTORY_KEY = "list:logging:history";

--- a/packages/core/src/infrastructure/logs/constants.ts
+++ b/packages/core/src/infrastructure/logs/constants.ts
@@ -1,6 +1,17 @@
 export const logLevels = ["error", "warn", "info", "debug"] as const;
 export type LogLevel = (typeof logLevels)[number];
 
+export interface LoggerMessage {
+  id: string;
+  timestamp: Date;
+  message: string;
+  level: LogLevel;
+}
+
+export const LOG_HISTORY_MAX_ENTRIES = 5_000;
+export const LOG_HISTORY_KEY = "list:logging:history";
+export const LOG_PUBLISH_CHANNEL = "pubSub:logging";
+
 export const logLevelConfiguration = {
   error: {
     prefix: "🔴",

--- a/packages/core/src/infrastructure/logs/transports/redis-transport.ts
+++ b/packages/core/src/infrastructure/logs/transports/redis-transport.ts
@@ -25,9 +25,6 @@ export class RedisTransport extends Transport {
       this.emit("logged", info);
     });
 
-    // Is only initialized here because it did not work when initialized in the constructor or outside the class
-    this.redis ??= createRedisClient();
-
     const message: LoggerMessage = {
       id: randomUUID(),
       timestamp: new Date(),
@@ -36,15 +33,24 @@ export class RedisTransport extends Transport {
     };
     const serializedMessage = stringify(message);
 
-    this.redis
-      .multi()
-      .lpush(LOG_HISTORY_KEY, serializedMessage)
-      .ltrim(LOG_HISTORY_KEY, 0, LOG_HISTORY_MAX_ENTRIES - 1)
-      .publish(LOG_PUBLISH_CHANNEL, serializedMessage)
-      .exec()
-      .catch(() => {
-        // Ignore errors
+    callback();
+
+    void Promise.resolve()
+      .then(() => {
+        // Is only initialized here because it did not work when initialized in the constructor or outside the class
+        if (!this.redis) {
+          this.redis = createRedisClient();
+          this.redis.options.maxRetriesPerRequest = 1;
+          this.redis.on("error", () => undefined);
+        }
+
+        return this.redis
+          .multi()
+          .lpush(LOG_HISTORY_KEY, serializedMessage)
+          .ltrim(LOG_HISTORY_KEY, 0, LOG_HISTORY_MAX_ENTRIES - 1)
+          .publish(LOG_PUBLISH_CHANNEL, serializedMessage)
+          .exec();
       })
-      .finally(callback);
+      .catch(() => undefined);
   }
 }

--- a/packages/core/src/infrastructure/logs/transports/redis-transport.ts
+++ b/packages/core/src/infrastructure/logs/transports/redis-transport.ts
@@ -1,8 +1,11 @@
-import superjson from "superjson";
+import { randomUUID } from "node:crypto";
+import { stringify } from "superjson";
 import Transport from "winston-transport";
 
 import type { RedisClient } from "../../redis/client";
 import { createRedisClient } from "../../redis/client";
+import type { LoggerMessage } from "../constants";
+import { LOG_HISTORY_KEY, LOG_HISTORY_MAX_ENTRIES, LOG_PUBLISH_CHANNEL } from "../constants";
 
 const messageSymbol = Symbol.for("message");
 const levelSymbol = Symbol.for("level");
@@ -13,12 +16,11 @@ const levelSymbol = Symbol.for("level");
 //
 export class RedisTransport extends Transport {
   private redis: RedisClient | null = null;
-  public static readonly publishChannel = "pubSub:logging";
 
   /**
-   * Log the info to the Redis channel
+   * Retain the log in a bounded Redis list and publish it to live subscribers.
    */
-  log(info: { [messageSymbol]: string; [levelSymbol]: string }, callback: () => void) {
+  log(info: { [messageSymbol]: string; [levelSymbol]: LoggerMessage["level"] }, callback: () => void) {
     setImmediate(() => {
       this.emit("logged", info);
     });
@@ -26,19 +28,23 @@ export class RedisTransport extends Transport {
     // Is only initialized here because it did not work when initialized in the constructor or outside the class
     this.redis ??= createRedisClient();
 
+    const message: LoggerMessage = {
+      id: randomUUID(),
+      timestamp: new Date(),
+      message: info[messageSymbol],
+      level: info[levelSymbol],
+    };
+    const serializedMessage = stringify(message);
+
     this.redis
-      .publish(
-        RedisTransport.publishChannel,
-        superjson.stringify({
-          message: info[messageSymbol],
-          level: info[levelSymbol],
-        }),
-      )
-      .then(() => {
-        callback();
-      })
+      .multi()
+      .lpush(LOG_HISTORY_KEY, serializedMessage)
+      .ltrim(LOG_HISTORY_KEY, 0, LOG_HISTORY_MAX_ENTRIES - 1)
+      .publish(LOG_PUBLISH_CHANNEL, serializedMessage)
+      .exec()
       .catch(() => {
         // Ignore errors
-      });
+      })
+      .finally(callback);
   }
 }

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -1,9 +1,15 @@
 import { parse } from "superjson";
 
 import type { LoggerMessage } from "@homarr/core/infrastructure/logs/constants";
-import { LOG_HISTORY_KEY, LOG_HISTORY_MAX_ENTRIES } from "@homarr/core/infrastructure/logs/constants";
+import {
+  loggerMessageSchema,
+  LOG_HISTORY_KEY,
+  LOG_HISTORY_MAX_ENTRIES,
+  LOG_PUBLISH_CHANNEL,
+} from "@homarr/core/infrastructure/logs/constants";
 
 import { createListChannel, createSubPubChannel } from "./lib/channel";
+import { ChannelSubscriptionTracker } from "./lib/channel-subscription-tracker";
 import { createRedisConnection } from "./lib/connection";
 
 export {
@@ -21,14 +27,29 @@ export const pingUrlChannel = createListChannel<string>("ping-url");
 
 export type { LoggerMessage } from "@homarr/core/infrastructure/logs/constants";
 
-const liveLoggingChannel = createSubPubChannel<LoggerMessage>("logging", { persist: false });
 const loggingHistoryClient = createRedisConnection();
 
+const parseLoggerMessage = (message: string): LoggerMessage | null => {
+  try {
+    const result = loggerMessageSchema.safeParse(parse<unknown>(message));
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+};
+
 export const loggingChannel = {
-  subscribe: liveLoggingChannel.subscribe,
-  subscribeAsync: liveLoggingChannel.subscribeAsync,
+  subscribeAsync: (callback: (message: LoggerMessage) => void) =>
+    ChannelSubscriptionTracker.subscribeAsync(LOG_PUBLISH_CHANNEL, (message) => {
+      const parsedMessage = parseLoggerMessage(message);
+      if (parsedMessage) callback(parsedMessage);
+    }),
   getRecentAsync: async () => {
-    const messages = await loggingHistoryClient.lrange(LOG_HISTORY_KEY, 0, LOG_HISTORY_MAX_ENTRIES - 1);
-    return messages.map((message) => parse<LoggerMessage>(message)).toReversed();
+    const messages =
+      (await loggingHistoryClient?.lrange(LOG_HISTORY_KEY, 0, LOG_HISTORY_MAX_ENTRIES - 1).catch(() => [])) ?? [];
+    return messages
+      .map(parseLoggerMessage)
+      .filter((message): message is LoggerMessage => message !== null)
+      .toReversed();
   },
 };

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -1,6 +1,10 @@
-import type { LogLevel } from "@homarr/core/infrastructure/logs/constants";
+import { parse } from "superjson";
+
+import type { LoggerMessage } from "@homarr/core/infrastructure/logs/constants";
+import { LOG_HISTORY_KEY, LOG_HISTORY_MAX_ENTRIES } from "@homarr/core/infrastructure/logs/constants";
 
 import { createListChannel, createSubPubChannel } from "./lib/channel";
+import { createRedisConnection } from "./lib/connection";
 
 export {
   handshakeAsync,
@@ -15,9 +19,16 @@ export const pingChannel = createSubPubChannel<
 >("ping");
 export const pingUrlChannel = createListChannel<string>("ping-url");
 
-export interface LoggerMessage {
-  message: string;
-  level: LogLevel;
-}
+export type { LoggerMessage } from "@homarr/core/infrastructure/logs/constants";
 
-export const loggingChannel = createSubPubChannel<LoggerMessage>("logging");
+const liveLoggingChannel = createSubPubChannel<LoggerMessage>("logging", { persist: false });
+const loggingHistoryClient = createRedisConnection();
+
+export const loggingChannel = {
+  subscribe: liveLoggingChannel.subscribe,
+  subscribeAsync: liveLoggingChannel.subscribeAsync,
+  getRecentAsync: async () => {
+    const messages = await loggingHistoryClient.lrange(LOG_HISTORY_KEY, 0, LOG_HISTORY_MAX_ENTRIES - 1);
+    return messages.map((message) => parse<LoggerMessage>(message)).toReversed();
+  },
+};

--- a/packages/redis/src/lib/channel-subscription-tracker.ts
+++ b/packages/redis/src/lib/channel-subscription-tracker.ts
@@ -58,14 +58,18 @@ export class ChannelSubscriptionTracker {
 
     const channelSubscriptions = this.subscriptions.get(channelName) ?? new Map<string, SubscriptionCallback>();
     const id = randomUUID();
-    let ready = this.subscriptionReadiness.get(channelName) ?? Promise.resolve();
+    let ready = this.subscriptionReadiness.get(channelName);
 
-    // If there are no subscriptions to the channel, subscribe to it
-    if (channelSubscriptions.size === 0) {
+    // Subscribe when this channel has no active or pending Redis subscription.
+    if (!ready) {
       logger.debug("Subscribing to redis channel", { channel: channelName });
       ready = this.redis.subscribe(channelName).then(() => undefined);
       this.subscriptionReadiness.set(channelName, ready);
-      void ready.catch(() => undefined);
+      void ready.catch(() => {
+        if (this.subscriptionReadiness.get(channelName) === ready) {
+          this.subscriptionReadiness.delete(channelName);
+        }
+      });
     }
 
     logger.debug("Adding redis channel callback", { channel: channelName, id });

--- a/packages/redis/src/lib/channel-subscription-tracker.ts
+++ b/packages/redis/src/lib/channel-subscription-tracker.ts
@@ -18,6 +18,7 @@ type SubscriptionCallback = (message: string) => MaybePromise<void>;
  */
 export class ChannelSubscriptionTracker {
   private static subscriptions = new Map<string, Map<string, SubscriptionCallback>>();
+  private static subscriptionReadiness = new Map<string, Promise<void>>();
   private static redis = createRedisConnection();
   private static listenerActive = false;
 
@@ -28,6 +29,25 @@ export class ChannelSubscriptionTracker {
    * @returns a function to unsubscribe from the channel
    */
   public static subscribe(channelName: string, callback: SubscriptionCallback) {
+    return this.registerSubscription(channelName, callback).unsubscribe;
+  }
+
+  /**
+   * Subscribes to a channel and resolves once Redis confirms the subscription.
+   */
+  public static async subscribeAsync(channelName: string, callback: SubscriptionCallback) {
+    const subscription = this.registerSubscription(channelName, callback);
+
+    try {
+      await subscription.ready;
+      return subscription.unsubscribe;
+    } catch (error) {
+      subscription.unsubscribe();
+      throw error;
+    }
+  }
+
+  private static registerSubscription(channelName: string, callback: SubscriptionCallback) {
     logger.debug("Adding redis channel callback", { channel: channelName });
 
     // We only want to activate the listener once
@@ -38,11 +58,14 @@ export class ChannelSubscriptionTracker {
 
     const channelSubscriptions = this.subscriptions.get(channelName) ?? new Map<string, SubscriptionCallback>();
     const id = randomUUID();
+    let ready = this.subscriptionReadiness.get(channelName) ?? Promise.resolve();
 
     // If there are no subscriptions to the channel, subscribe to it
     if (channelSubscriptions.size === 0) {
       logger.debug("Subscribing to redis channel", { channel: channelName });
-      void this.redis.subscribe(channelName);
+      ready = this.redis.subscribe(channelName).then(() => undefined);
+      this.subscriptionReadiness.set(channelName, ready);
+      void ready.catch(() => undefined);
     }
 
     logger.debug("Adding redis channel callback", { channel: channelName, id });
@@ -50,24 +73,26 @@ export class ChannelSubscriptionTracker {
 
     this.subscriptions.set(channelName, channelSubscriptions);
 
-    // Return a function to unsubscribe
-    return () => {
+    const unsubscribe = () => {
       logger.debug("Removing redis channel callback", { channel: channelName, id });
 
-      const channelSubscriptions = this.subscriptions.get(channelName);
-      if (!channelSubscriptions) return;
+      const currentSubscriptions = this.subscriptions.get(channelName);
+      if (!currentSubscriptions) return;
 
-      channelSubscriptions.delete(id);
+      currentSubscriptions.delete(id);
 
       // If there are no subscriptions to the channel, unsubscribe from it
-      if (channelSubscriptions.size >= 1) {
+      if (currentSubscriptions.size >= 1) {
         return;
       }
 
       logger.debug("Unsubscribing from redis channel", { channel: channelName });
       void this.redis.unsubscribe(channelName);
       this.subscriptions.delete(channelName);
+      this.subscriptionReadiness.delete(channelName);
     };
+
+    return { ready, unsubscribe };
   }
 
   /**

--- a/packages/redis/src/lib/channel.ts
+++ b/packages/redis/src/lib/channel.ts
@@ -1,4 +1,4 @@
-import superjson, { parse } from "superjson";
+import superjson from "superjson";
 
 import { createId } from "@homarr/common";
 
@@ -7,12 +7,6 @@ import { createRedisConnection } from "./connection";
 
 const publisher = createRedisConnection();
 const lastDataClient = createRedisConnection();
-
-const deserializeCallback =
-  <TData>(callback: (data: TData) => void) =>
-  (message: string) => {
-    callback(parse(message));
-  };
 
 /**
  * Creates a new pub/sub channel.
@@ -35,19 +29,9 @@ export const createSubPubChannel = <TData>(name: string, { persist }: { persist:
           }
         });
       }
-      return ChannelSubscriptionTracker.subscribe(channelName, deserializeCallback(callback));
-    },
-    /**
-     * Subscribes to the channel and resolves once Redis confirms the subscription.
-     */
-    subscribeAsync: async (callback: (data: TData) => void) => {
-      if (persist) {
-        const data = await lastDataClient.get(lastChannelName);
-        if (data) {
-          callback(superjson.parse(data));
-        }
-      }
-      return await ChannelSubscriptionTracker.subscribeAsync(channelName, deserializeCallback(callback));
+      return ChannelSubscriptionTracker.subscribe(channelName, (message) => {
+        callback(superjson.parse(message));
+      });
     },
     /**
      * Publish data to the channel with last data saved.

--- a/packages/redis/src/lib/channel.ts
+++ b/packages/redis/src/lib/channel.ts
@@ -1,4 +1,4 @@
-import superjson from "superjson";
+import superjson, { parse } from "superjson";
 
 import { createId } from "@homarr/common";
 
@@ -7,6 +7,12 @@ import { createRedisConnection } from "./connection";
 
 const publisher = createRedisConnection();
 const lastDataClient = createRedisConnection();
+
+const deserializeCallback =
+  <TData>(callback: (data: TData) => void) =>
+  (message: string) => {
+    callback(parse(message));
+  };
 
 /**
  * Creates a new pub/sub channel.
@@ -29,9 +35,19 @@ export const createSubPubChannel = <TData>(name: string, { persist }: { persist:
           }
         });
       }
-      return ChannelSubscriptionTracker.subscribe(channelName, (message) => {
-        callback(superjson.parse(message));
-      });
+      return ChannelSubscriptionTracker.subscribe(channelName, deserializeCallback(callback));
+    },
+    /**
+     * Subscribes to the channel and resolves once Redis confirms the subscription.
+     */
+    subscribeAsync: async (callback: (data: TData) => void) => {
+      if (persist) {
+        const data = await lastDataClient.get(lastChannelName);
+        if (data) {
+          callback(superjson.parse(data));
+        }
+      }
+      return await ChannelSubscriptionTracker.subscribeAsync(channelName, deserializeCallback(callback));
     },
     /**
      * Publish data to the channel with last data saved.

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -8385,6 +8385,10 @@
     }
   },
   "log": {
+    "context": {
+      "widgetError": "Widget reported an error around this time",
+      "expiredWidgetError": "Logs around this widget error are no longer retained"
+    },
     "level": {
       "option": {
         "debug": "Debug",

--- a/packages/widgets/src/errors/base-component.tsx
+++ b/packages/widgets/src/errors/base-component.tsx
@@ -19,14 +19,13 @@ export const BaseWidgetError = (props: BaseWidgetErrorProps) => {
   const t = useI18n();
   const { data: session } = useSession();
   const [errorTimestamp] = useState(Date.now);
-  const canViewLogs = session?.user.permissions.includes("other-view-logs") ?? false;
 
   return (
     <Stack h="100%" align="center" justify="center" gap="md" data-homarr-widget-error>
       <props.icon size={40} />
       <Stack gap={0}>
         <Text ta="center">{translateIfNecessary(t, props.message)}</Text>
-        {props.showLogsLink && canViewLogs && (
+        {props.showLogsLink && session?.user.permissions.includes("other-view-logs") && (
           <Anchor
             component={Link}
             href={`/manage/tools/logs?focus=${errorTimestamp}`}

--- a/packages/widgets/src/errors/base-component.tsx
+++ b/packages/widgets/src/errors/base-component.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { Anchor, Button, Stack, Text } from "@mantine/core";
 
+import { useSession } from "@homarr/auth/client";
 import type { stringOrTranslation } from "@homarr/translation";
 import { translateIfNecessary } from "@homarr/translation";
 import { useI18n } from "@homarr/translation/client";
@@ -15,14 +17,23 @@ export interface BaseWidgetErrorProps {
 
 export const BaseWidgetError = (props: BaseWidgetErrorProps) => {
   const t = useI18n();
+  const { data: session } = useSession();
+  const [errorTimestamp] = useState(Date.now);
+  const canViewLogs = session?.user.permissions.includes("other-view-logs") ?? false;
 
   return (
     <Stack h="100%" align="center" justify="center" gap="md" data-homarr-widget-error>
       <props.icon size={40} />
       <Stack gap={0}>
         <Text ta="center">{translateIfNecessary(t, props.message)}</Text>
-        {props.showLogsLink && (
-          <Anchor component={Link} href="/manage/tools/logs" target="_blank" ta="center" size="sm">
+        {props.showLogsLink && canViewLogs && (
+          <Anchor
+            component={Link}
+            href={`/manage/tools/logs?focus=${errorTimestamp}`}
+            target="_blank"
+            ta="center"
+            size="sm"
+          >
             {t("common.action.checkLogs")}
           </Anchor>
         )}

--- a/packages/widgets/src/errors/component.spec.ts
+++ b/packages/widgets/src/errors/component.spec.ts
@@ -11,6 +11,10 @@ vi.mock("@homarr/translation/client", () => ({
   useI18n: () => (key: string) => key,
 }));
 
+vi.mock("@homarr/auth/client", () => ({
+  useSession: () => ({ data: null }),
+}));
+
 const matchMedia = (query: string) => ({
   matches: false,
   media: query,


### PR DESCRIPTION
## Summary

- retain the latest 5,000 application log events in Redis and replay them before live events
- focus permission-aware widget log links around the reported error time
- refilter retained logs when severity changes and document the logs page behavior

## Validation

- focused typechecks for core, Redis, API, widgets, Next.js, and docs on Node 24.18.0
- Redis runtime harness covering history replay, live delivery, metadata, retention cap, and restart persistence
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a logs management guide covering permissions, retention, external logs, and display controls.
  * Logs pages can open at a specific error timestamp, with markers for matching and expired logs.
  * Widget errors show a logs link when permitted.
  * Log history is retained and displayed before incoming live messages, with duplicates removed.
  * Added localized messaging for expired related logs.

* **Bug Fixes**
  * Improved log subscription reliability and handling of Redis or connection failures.
  * Added validation for log messages and safer rendering of buffered history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->