### PR TITLE
fix(truenas): keep reporting pools without usable dataset space

### DIFF
--- a/apps/docs/docs/integrations/truenas/index.mdx
+++ b/apps/docs/docs/integrations/truenas/index.mdx
@@ -27,7 +27,7 @@ import Alert from '@theme/Admonition';
       ]}
 />
 
-The storage values shown by these widgets use the root ZFS dataset's usable `used` and `available` space, including RAIDZ parity overhead and dataset limits.
+The storage values shown by these widgets come from each pool's root ZFS dataset, so they already account for RAIDZ parity overhead and dataset limits and match what `zfs list` and the TrueNAS web interface report. When a pool cannot report its dataset space, Homarr falls back to the pool's physical values, which read higher on RAIDZ.
 
 ### Adding the integration
 <AddingIntegration />

--- a/packages/integrations/src/truenas/test/truenas-integration.spec.ts
+++ b/packages/integrations/src/truenas/test/truenas-integration.spec.ts
@@ -277,6 +277,19 @@ describe("TrueNasIntegration", () => {
     expect(result.fileSystem).toMatchObject(physicalFallbackFileSystem);
   });
 
+  test("falls back to physical pool space when the dataset response fails schema validation", async () => {
+    ws.setResponder((method) =>
+      method === "pool.dataset.query" ? { unexpected: "not an array" } : happyResponder(method),
+    );
+    const integration = createIntegration(credentials);
+
+    const result = await integration.getSystemInfoAsync();
+
+    expect(result.fileSystem).toMatchObject(physicalFallbackFileSystem);
+    // A malformed payload must not take the rest of the system info down with it.
+    expect(result).toMatchObject({ cpuTemp: 45, memAvailableInBytes: 6_000_000_000, uptime: 3600 });
+  });
+
   test("falls back to physical pool space when the dataset query is rejected", async () => {
     ws.setResponder((method) =>
       method === "pool.dataset.query"

--- a/packages/integrations/src/truenas/test/truenas-integration.spec.ts
+++ b/packages/integrations/src/truenas/test/truenas-integration.spec.ts
@@ -59,10 +59,12 @@ const ws = vi.hoisted(() => {
       }
 
       const result = responder(payload.method as string, (payload.params as unknown[] | undefined) ?? []);
+      // A responder returning an Error mimics a method the server rejects, e.g. an unsupported filter.
+      const body = result instanceof Error ? { error: { message: result.message } } : { result };
       const envelope =
         payload.jsonrpc === "2.0"
-          ? { jsonrpc: "2.0", id: payload.id, result }
-          : { msg: "result", id: payload.id, result };
+          ? { jsonrpc: "2.0", id: payload.id, ...body }
+          : { msg: "result", id: payload.id, ...body };
       this.respond(JSON.stringify(envelope));
     }
 
@@ -91,7 +93,10 @@ const ws = vi.hoisted(() => {
   };
 });
 
+const logs = vi.hoisted(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }));
+
 vi.mock("ws", () => ({ WebSocket: ws.FakeWebSocket }));
+vi.mock("@homarr/core/infrastructure/logs", () => ({ createLogger: () => logs }));
 vi.mock("@homarr/core/infrastructure/certificates", () => ({
   getAllTrustedCertificatesAsync: vi.fn().mockResolvedValue([]),
   getTrustedCertificateHostnamesAsync: vi.fn().mockResolvedValue([]),
@@ -167,6 +172,11 @@ const happyResponder = (method: string) => {
 
 const emptyAggregations = () => ({ min: {}, mean: {}, max: {} });
 
+// `pool.query` reports 500 allocated of a 1000 byte pool, leaving 500 free.
+const physicalFallbackFileSystem = [{ deviceName: "tank", available: "500", used: "500", percentage: 50 }];
+
+const ERROR_MESSAGE_LIMIT = 200;
+
 let integrationCounter = 0;
 const createIntegration = (decryptedSecrets: IntegrationSecret[]) =>
   new TrueNasIntegration({
@@ -188,6 +198,7 @@ describe("TrueNasIntegration", () => {
     ws.constructedUrls.length = 0;
     ws.failures.length = 0;
     ws.setResponder(happyResponder);
+    logs.warn.mockClear();
   });
 
   test("fetches and maps system info over the JSON-RPC API", async () => {
@@ -228,6 +239,99 @@ describe("TrueNasIntegration", () => {
       fileSystem: [{ deviceName: "tank", available: "300", used: "200", percentage: 40 }],
       smart: [{ deviceName: "tank", healthy: true, overallStatus: "ONLINE", temperature: null }],
     });
+  });
+
+  test("falls back to physical pool space when the root dataset is not returned", async () => {
+    ws.setResponder((method) => (method === "pool.dataset.query" ? [] : happyResponder(method)));
+    const integration = createIntegration(credentials);
+
+    const result = await integration.getSystemInfoAsync();
+
+    expect(result.fileSystem).toMatchObject(physicalFallbackFileSystem);
+    // Dropping the pool would also hide its health status.
+    expect(result.smart).toMatchObject([{ deviceName: "tank", healthy: true, overallStatus: "ONLINE" }]);
+  });
+
+  test("falls back to physical pool space when the root dataset reports no usable values", async () => {
+    ws.setResponder((method) =>
+      method === "pool.dataset.query"
+        ? [{ id: "tank", used: { parsed: null }, available: null }]
+        : happyResponder(method),
+    );
+    const integration = createIntegration(credentials);
+
+    const result = await integration.getSystemInfoAsync();
+
+    expect(result.fileSystem).toMatchObject(physicalFallbackFileSystem);
+  });
+
+  test("falls back to physical pool space when the root dataset omits the requested properties", async () => {
+    // Datasets that cannot report space, e.g. while locked, come back without `used` and `available`.
+    ws.setResponder((method) =>
+      method === "pool.dataset.query" ? [{ id: "tank", locked: true }] : happyResponder(method),
+    );
+    const integration = createIntegration(credentials);
+
+    const result = await integration.getSystemInfoAsync();
+
+    expect(result.fileSystem).toMatchObject(physicalFallbackFileSystem);
+  });
+
+  test("falls back to physical pool space when the dataset query is rejected", async () => {
+    ws.setResponder((method) =>
+      method === "pool.dataset.query"
+        ? new Error("[EINVAL] filters: Value error, Invalid operation: in")
+        : happyResponder(method),
+    );
+    const integration = createIntegration(credentials);
+
+    const result = await integration.getSystemInfoAsync();
+
+    expect(result.fileSystem).toMatchObject(physicalFallbackFileSystem);
+    // A rejected dataset query must not take the rest of the system info down with it.
+    expect(result).toMatchObject({ cpuTemp: 45, memAvailableInBytes: 6_000_000_000, uptime: 3600 });
+  });
+
+  test("logs the truncated rejection reason rather than the generic wrapper message", async () => {
+    // TrueNAS answers a rejected method with its Python traceback, which runs to several kilobytes.
+    ws.setResponder((method) =>
+      method === "pool.dataset.query"
+        ? new Error(`[EINVAL] query-filters ${"x".repeat(5000)}`)
+        : happyResponder(method),
+    );
+    const integration = createIntegration(credentials);
+
+    await integration.getSystemInfoAsync();
+
+    const logged = logs.warn.mock.calls.find(([message]) => String(message).includes("Could not retrieve"));
+    const reason = String((logged?.[1] as { error?: string } | undefined)?.error);
+    // The decorator would otherwise surface only "An unknown error occured while executing Integration method".
+    expect(reason).toContain("[EINVAL] query-filters");
+    expect(reason).toHaveLength(ERROR_MESSAGE_LIMIT + 1); // truncated, plus the ellipsis
+  });
+
+  test("keeps reporting a pool that is unhealthy but has no usable dataset space", async () => {
+    ws.setResponder((method) => {
+      if (method === "pool.query")
+        return [
+          { name: "tank", status: "ONLINE", healthy: true, free: 500, size: 1000, allocated: 500 },
+          { name: "backup", status: "DEGRADED", healthy: false, free: 10, size: 100, allocated: 90 },
+        ];
+      if (method === "pool.dataset.query") return [{ id: "tank", used: { parsed: 200 }, available: { parsed: 300 } }];
+      return happyResponder(method);
+    });
+    const integration = createIntegration(credentials);
+
+    const result = await integration.getSystemInfoAsync();
+
+    expect(result.smart).toMatchObject([
+      { deviceName: "tank", healthy: true, overallStatus: "ONLINE" },
+      { deviceName: "backup", healthy: false, overallStatus: "DEGRADED" },
+    ]);
+    expect(result.fileSystem).toMatchObject([
+      { deviceName: "tank", available: "300", used: "200", percentage: 40 },
+      { deviceName: "backup", available: "10", used: "90", percentage: 90 },
+    ]);
   });
 
   test("reports zero usage for an empty root dataset", async () => {

--- a/packages/integrations/src/truenas/truenas-integration.ts
+++ b/packages/integrations/src/truenas/truenas-integration.ts
@@ -171,15 +171,15 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
    * A pool is left out when its usable space is unavailable, so the caller keeps reporting the pool with
    * its physical values instead of dropping it, which would also hide its health status:
    *   - request rejected  → method or `extra.properties` unsupported, or the API key lacks the dataset role
+   *   - response rejected → the payload does not match the expected shape
    *   - dataset missing   → the pool's root dataset was not returned by the query
    *   - property absent   → the dataset does not report `used` / `available`, e.g. while locked
    */
   private async getUsableSpaceByPoolAsync(poolNames: string[]) {
     const usableSpaceByPool = new Map<string, { used: number; available: number }>();
 
-    let datasets: unknown;
     try {
-      datasets = await this.requestAsync("pool.dataset.query", [
+      const datasets = await this.requestAsync("pool.dataset.query", [
         [["id", "in", poolNames]],
         {
           extra: {
@@ -187,21 +187,19 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
           },
         },
       ]);
+
+      for (const dataset of await poolDatasetSchema.parseAsync(datasets)) {
+        const used = dataset.used?.parsed;
+        const available = dataset.available?.parsed;
+        if (typeof used !== "number" || typeof available !== "number") continue;
+
+        usableSpaceByPool.set(dataset.id, { used, available });
+      }
     } catch (error) {
       logger.warn("Could not retrieve root dataset space, continuing with physical pool space", {
         url: this.integration.url,
         error: describeRequestError(error),
       });
-      return usableSpaceByPool;
-    }
-
-    const parsedDatasets = await poolDatasetSchema.parseAsync(datasets);
-    for (const dataset of parsedDatasets) {
-      const used = dataset.used?.parsed;
-      const available = dataset.available?.parsed;
-      if (typeof used !== "number" || typeof available !== "number") continue;
-
-      usableSpaceByPool.set(dataset.id, { used, available });
     }
 
     return usableSpaceByPool;

--- a/packages/integrations/src/truenas/truenas-integration.ts
+++ b/packages/integrations/src/truenas/truenas-integration.ts
@@ -15,6 +15,20 @@ const logger = createLogger({ module: "trueNasIntegration" });
 
 const NETWORK_MULTIPLIER = 100;
 
+const ERROR_MESSAGE_LIMIT = 200;
+
+/**
+ * The error decorator replaces a rejected request with a generic message and moves the actionable
+ * reason to `cause`. TrueNAS puts its middleware traceback in there, several kilobytes of it, so the
+ * reason is truncated before it reaches a log line that repeats on every poll.
+ */
+const describeRequestError = (error: unknown) => {
+  const cause = error instanceof Error ? error.cause : undefined;
+  const reason = cause instanceof Error ? cause.message : error instanceof Error ? error.message : String(error);
+
+  return reason.length > ERROR_MESSAGE_LIMIT ? `${reason.slice(0, ERROR_MESSAGE_LIMIT)}…` : reason;
+};
+
 export class TrueNasIntegration extends Integration implements ISystemHealthMonitoringIntegration {
   private client?: TrueNasClient;
 
@@ -108,9 +122,10 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
       .map((pool) => {
         if (pool.allocated !== null && pool.size !== null && pool.free !== null) {
           return {
-            ...pool,
+            name: pool.name,
+            status: pool.status,
+            healthy: pool.healthy,
             allocated: pool.allocated,
-            size: pool.size,
             free: pool.free,
           };
         }
@@ -119,39 +134,77 @@ export class TrueNasIntegration extends Integration implements ISystemHealthMoni
       })
       .filter((pool) => pool !== null);
 
-    if (activePools.length === 0) return [];
-
-    const datasets = await this.requestAsync("pool.dataset.query", [
-      [["id", "in", activePools.map((pool) => pool.name)]],
-      {
-        extra: {
-          properties: ["used", "available"],
-        },
-      },
-    ]);
-    const parsedDatasets = await poolDatasetSchema.parseAsync(datasets);
-
-    const poolsWithUsableSpace = activePools
-      .map((pool) => {
-        const dataset = parsedDatasets.find((candidate) => candidate.id === pool.name);
-        if (!dataset || dataset.used.parsed === null || dataset.available.parsed === null) return null;
-
-        return {
-          name: pool.name,
-          status: pool.status,
-          healthy: pool.healthy,
-          used: dataset.used.parsed,
-          available: dataset.available.parsed,
-        };
-      })
-      .filter((pool) => pool !== null);
-
     logger.debug("Retrieved pools", {
       url: this.integration.url,
       totalCount: result.length,
-      activeCount: poolsWithUsableSpace.length,
+      activeCount: activePools.length,
     });
-    return poolsWithUsableSpace;
+
+    if (activePools.length === 0) return [];
+
+    const usableSpaceByPool = await this.getUsableSpaceByPoolAsync(activePools.map((pool) => pool.name));
+
+    return activePools.map((pool) => {
+      const usableSpace = usableSpaceByPool.get(pool.name);
+      if (!usableSpace) {
+        logger.warn("Falling back to physical pool space, the root dataset reported no usable space", {
+          url: this.integration.url,
+          pool: pool.name,
+        });
+      }
+
+      return {
+        name: pool.name,
+        status: pool.status,
+        healthy: pool.healthy,
+        used: usableSpace?.used ?? pool.allocated,
+        available: usableSpace?.available ?? pool.free,
+      };
+    });
+  }
+
+  /**
+   * Returns the usable space of each pool's root ZFS dataset, keyed by pool name. Unlike the physical
+   * `pool.query` values, these account for RAIDZ parity overhead and dataset limits, matching `zfs list`.
+   * See https://github.com/homarr-labs/homarr/issues/6566
+   *
+   * A pool is left out when its usable space is unavailable, so the caller keeps reporting the pool with
+   * its physical values instead of dropping it, which would also hide its health status:
+   *   - request rejected  → method or `extra.properties` unsupported, or the API key lacks the dataset role
+   *   - dataset missing   → the pool's root dataset was not returned by the query
+   *   - property absent   → the dataset does not report `used` / `available`, e.g. while locked
+   */
+  private async getUsableSpaceByPoolAsync(poolNames: string[]) {
+    const usableSpaceByPool = new Map<string, { used: number; available: number }>();
+
+    let datasets: unknown;
+    try {
+      datasets = await this.requestAsync("pool.dataset.query", [
+        [["id", "in", poolNames]],
+        {
+          extra: {
+            properties: ["used", "available"],
+          },
+        },
+      ]);
+    } catch (error) {
+      logger.warn("Could not retrieve root dataset space, continuing with physical pool space", {
+        url: this.integration.url,
+        error: describeRequestError(error),
+      });
+      return usableSpaceByPool;
+    }
+
+    const parsedDatasets = await poolDatasetSchema.parseAsync(datasets);
+    for (const dataset of parsedDatasets) {
+      const used = dataset.used?.parsed;
+      const available = dataset.available?.parsed;
+      if (typeof used !== "number" || typeof available !== "number") continue;
+
+      usableSpaceByPool.set(dataset.id, { used, available });
+    }
+
+    return usableSpaceByPool;
   }
 
   /**
@@ -292,11 +345,16 @@ const poolSchema = z.array(
   }),
 );
 
+// Properties are absent or unparsed for datasets that do not report them, e.g. while locked,
+// so they are optional here and the pool falls back to its physical values instead of failing
+// the whole request, which would also drop cpu, memory and network data
+const poolDatasetPropertySchema = z.object({ parsed: z.number().min(0).nullish() }).nullish();
+
 const poolDatasetSchema = z.array(
   z.object({
     id: z.string(),
-    used: z.object({ parsed: z.number().min(0).nullable() }),
-    available: z.object({ parsed: z.number().min(0).nullable() }),
+    used: poolDatasetPropertySchema,
+    available: poolDatasetPropertySchema,
   }),
 );
 


### PR DESCRIPTION
## Summary

Follow-up hardening for #6567, which switched TrueNAS storage reporting from the physical `pool.query` values to the root ZFS dataset's usable space. That fix is correct, but it made every pool's presence in the widget depend on a second request succeeding.

`getPoolsAsync` returns one list that feeds both `fileSystem` and `smart`. As merged, a pool with no matching `pool.dataset.query` entry was dropped from that list entirely, so it lost its health status as well as its storage numbers. With a single pool the widget showed nothing at all, since `system-disks` throws `NoIntegrationDataError` on an empty `fileSystem`. A dataset returned without the requested properties failed schema validation and took CPU, memory, network and uptime down with it.

This PR keeps the more accurate dataset values as the primary source and falls back to the physical pool values when they are unavailable, instead of dropping the pool:

- `getUsableSpaceByPoolAsync` returns usable space keyed by pool name. A pool missing from that map keeps its `pool.query` values. Because pool `size` equals `allocated + free`, the fallback percentage is identical to the pre-#6567 calculation.
- Both the dataset request and the validation of its response are wrapped, so neither a rejection nor an unexpected payload fails the whole request. By this point `pool.query` has already succeeded on the same authenticated socket, so a failure here is method-specific: `extra.properties` unsupported, or an API key without the dataset role.
- `used` and `available` are now optional in the schema, so a dataset that does not report them falls back rather than failing validation.
- The fallback logs a warning naming the pool, and `activeCount` in the debug line means active pools again.

`describeRequestError` reads through `cause`, because `HandleIntegrationErrors` wraps every method and replaces the rejection with a generic message. Without it the warning read "An unknown error occured while executing Integration method". It also truncates at 200 characters, since TrueNAS answers a rejected method with its middleware traceback, several kilobytes of it, on a line that repeats every poll.

## Validation

Verified against TrueNAS 25.04.2.6 with two pools, complementing the 25.10.5 validation in #6566.

Storage values are unchanged on the happy path and no fallback warning fires. For a RAIDZ pool the root dataset reports 32.2 TiB used / 7.33 TiB available where the physical pool reports 66.5 TiB allocated / 15.4 TiB free, matching what the TrueNAS UI and `zfs list` show.

Confirmed on that system:

- The `["id", "in", names]` filter works on 25.04, so the lowercase operator is not specific to 25.10.
- Root dataset ids equal pool names, and properties arrive as `{parsed, rawvalue, value, source, source_info}`.
- Sending the uppercase operator reproduces `[EINVAL] query-filters: Invalid operation: IN` from #6566 on this version too. With that rejection, both pools still report with physical values, SMART is intact, and CPU, memory and uptime are unaffected. The logged reason is the truncated `[EINVAL]` text rather than the generic wrapper or the full traceback.

Seven tests added. The six fallback tests were each confirmed to fail against the implementation they harden. Not covered by real hardware: the system has no encrypted or locked datasets, so the omitted-properties guard is exercised only against a synthetic response shape.

`@homarr/integrations`: 24 tests pass, typecheck clean, lint clean apart from one warning that already exists on `dev`.

## Checklist

- [x] Builds without warnings or errors
- [x] Pull request targets `dev` branch
- [x] Commits follow the conventional commits guideline
- [x] No shorthand variable names are used
- [x] Documentation is up to date (`apps/docs/docs/integrations/truenas/index.mdx`, which also corrects wording that read as though parity overhead counted toward usable space)
- [x] No temp files are checked in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TrueNAS storage reporting when dataset information is unavailable, invalid, incomplete, or cannot be retrieved.
  - Falls back to physical pool values while preserving pool health status.
  - Limits error details to prevent excessively long log messages.

- **Documentation**
  - Clarified that storage values come from each pool’s root ZFS dataset.
  - Documented how RAIDZ parity and dataset limits affect reported values.
  - Confirmed alignment with `zfs list` and the TrueNAS interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->