### PR TITLE
fix(onboarding): await sign-in and revalidation before leaving the user step

### DIFF
--- a/apps/nextjs/src/app/[locale]/init/_steps/user/init-user-form.tsx
+++ b/apps/nextjs/src/app/[locale]/init/_steps/user/init-user-form.tsx
@@ -29,14 +29,18 @@ export const InitUserForm = () => {
    * resolves after both rather than after the user row is written. A sign-in that fails reports the
    * reason and leaves the form on this step.
    */
+  const showFailureNotification = (reason: unknown) => {
+    showErrorNotification({
+      title: tUser("notification.error.title"),
+      message: reason instanceof Error ? reason.message : typeof reason === "string" ? reason : "",
+    });
+  };
+
   const handleSubmitAsync = async (values: FormType) => {
     try {
       await mutateAsync(values);
     } catch (error) {
-      showErrorNotification({
-        title: tUser("notification.error.title"),
-        message: error instanceof Error ? error.message : "",
-      });
+      showFailureNotification(error);
       return;
     }
 
@@ -45,21 +49,22 @@ export const InitUserForm = () => {
       message: tUser("notification.success.message"),
     });
 
-    const signInResult = await signIn("credentials", {
-      name: values.username,
-      password: values.password,
-      redirect: false,
-    });
-
-    if (signInResult?.error) {
-      showErrorNotification({
-        title: tUser("notification.error.title"),
-        message: signInResult.error,
+    try {
+      const signInResult = await signIn("credentials", {
+        name: values.username,
+        password: values.password,
+        redirect: false,
       });
-      return;
-    }
 
-    await revalidatePathActionAsync("/init");
+      if (signInResult?.error) {
+        showFailureNotification(signInResult.error);
+        return;
+      }
+
+      await revalidatePathActionAsync("/init");
+    } catch (error) {
+      showFailureNotification(error);
+    }
   };
 
   return (

--- a/apps/nextjs/src/app/[locale]/init/_steps/user/init-user-form.tsx
+++ b/apps/nextjs/src/app/[locale]/init/_steps/user/init-user-form.tsx
@@ -15,7 +15,7 @@ import { userInitSchema } from "@homarr/validation/user";
 export const InitUserForm = () => {
   const t = useScopedI18n("user");
   const tUser = useScopedI18n("init.step.user");
-  const { mutateAsync, isPending } = clientApi.user.initUser.useMutation();
+  const { mutateAsync } = clientApi.user.initUser.useMutation();
   const form = useZodForm(userInitSchema, {
     initialValues: {
       username: "",
@@ -24,36 +24,49 @@ export const InitUserForm = () => {
     },
   });
 
+  /**
+   * The step advances only once the session exists and `/init` has been revalidated, so the submit
+   * resolves after both rather than after the user row is written. A sign-in that fails reports the
+   * reason and leaves the form on this step.
+   */
   const handleSubmitAsync = async (values: FormType) => {
-    await mutateAsync(values, {
-      onSuccess() {
-        showSuccessNotification({
-          title: tUser("notification.success.title"),
-          message: tUser("notification.success.message"),
-        });
+    try {
+      await mutateAsync(values);
+    } catch (error) {
+      showErrorNotification({
+        title: tUser("notification.error.title"),
+        message: error instanceof Error ? error.message : "",
+      });
+      return;
+    }
 
-        void signIn("credentials", {
-          name: values.username,
-          password: values.password,
-          redirect: false,
-        }).then(async () => {
-          await revalidatePathActionAsync("/init");
-        });
-      },
-      onError: (error) => {
-        showErrorNotification({
-          title: tUser("notification.error.title"),
-          message: error.message,
-        });
-      },
+    showSuccessNotification({
+      title: tUser("notification.success.title"),
+      message: tUser("notification.success.message"),
     });
+
+    const signInResult = await signIn("credentials", {
+      name: values.username,
+      password: values.password,
+      redirect: false,
+    });
+
+    if (signInResult?.error) {
+      showErrorNotification({
+        title: tUser("notification.error.title"),
+        message: signInResult.error,
+      });
+      return;
+    }
+
+    await revalidatePathActionAsync("/init");
   };
 
   return (
     <Stack gap="xl">
       <form
         onSubmit={form.onSubmit(
-          (values) => void handleSubmitAsync(values),
+          (values) => handleSubmitAsync(values),
           (err) => console.log(err),
         )}
       >
@@ -63,7 +76,7 @@ export const InitUserForm = () => {
             passwordInputProps={form.getInputProps("password")}
             confirmPasswordInputProps={form.getInputProps("confirmPassword")}
           />
-          <Button type="submit" fullWidth loading={isPending}>
+          <Button type="submit" fullWidth loading={form.submitting}>
             {t("action.create")}
           </Button>
         </Stack>

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -7,6 +7,42 @@ import { createHomarrContainer } from "./shared/create-homarr-container";
 import { createSqliteDbFileAsync } from "./shared/e2e-db";
 
 describe("Onboarding", () => {
+  test("Credentials onboarding should be successful", async () => {
+    // Arrange
+    const { db, localMountPath } = await createSqliteDbFileAsync();
+    const homarrContainer = await createHomarrContainer({
+      mounts: {
+        "/appdata": localMountPath,
+      },
+    }).start();
+
+    const browser = await chromium.launch();
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const actions = new OnboardingActions(page, db);
+    const assertions = new OnboardingAssertions(page, db);
+
+    try {
+      // Act
+      await page.goto(`http://${homarrContainer.getHost()}:${homarrContainer.getMappedPort(7575)}`);
+      await actions.startOnboardingAsync("scratch");
+      await actions.processUserStepAsync({
+        username: "admin",
+        password: "Comp(exP4sswOrd",
+        confirmPassword: "Comp(exP4sswOrd",
+      });
+      await actions.processSettingsStepAsync();
+      await actions.processIntegrationsStepAsync();
+
+      // Assert
+      await assertions.assertFinishStepVisibleAsync();
+      await assertions.assertUserAndAdminGroupInsertedAsync("admin");
+      await assertions.assertDbOnboardingStepAsync("finish");
+    } finally {
+      await Promise.all([browser.close(), homarrContainer.stop()]);
+    }
+  }, 60_000);
+
   test("External provider onboarding setup should be successful", async () => {
     // Arrange
     const { db, localMountPath } = await createSqliteDbFileAsync();


### PR DESCRIPTION
## Summary

The credentials onboarding e2e test was removed as flaky in 56e6b23a. The flakiness came from the page it exercised, so this fixes that race and restores the test.

`init-user-form.tsx` advanced the onboarding step from a chain nothing awaited:

```ts
onSuccess() {                                          // synchronous
  showSuccessNotification({ ... });
  void signIn("credentials", { ... }).then(async () => {   // fire-and-forget
    await revalidatePathActionAsync("/init");
  });
}
```

`mutateAsync` resolved as soon as the user row was written, while the step advance still depended on a sign-in round trip and a revalidate running later, unobserved. With no `.catch`, a failed sign-in left the user on a submitted form with no error and no advance.

The submit handler now awaits the mutation, the sign-in and the revalidate in sequence, and reports a failed sign-in instead of dropping it. This matches `init-group.tsx`, the sibling step whose e2e test never flaked.

The button moves from `isPending` to `form.submitting`, which is load-bearing rather than cosmetic. Mantine's `onSubmit` (`use-form.mjs:197-208`) clears `submitting` when the handler's returned promise settles; the old code passed `(values) => void handleSubmitAsync(values)`, returning `undefined`, so it cleared immediately. Returning the promise makes the loading state span the whole transition.

## Validation

Repetition cannot demonstrate this: the test passes locally on both old and new code (4/4 and 6/6 respectively, roughly 7-10s per run), because a fast machine wins the race every time. So the transition was measured directly instead, with 1500ms of latency injected via CDP, against two images built from identical source except this fix:

| | user created | submit button idle | step advances |
| --- | --- | --- | --- |
| Before | t=1721ms | **yes, from t=1721ms** | t=9797ms |
| After | t=1711ms | no, loading throughout | t=9864ms |

Before the fix there is an ~8s window in which the user row is written, the submit button has gone idle and re-enabled, and the page is still on the user step with nothing holding the transition. After the fix that window does not exist. Both runs were reproduced, and the transition duration is unchanged, so the fix spans the race rather than hiding it behind extra waiting.

Also run: the full onboarding spec (both tests) passes against the fixed image, and `pnpm --filter nextjs typecheck` is clean.

## What this does not establish

There is no recorded CI failure for this test. The removal commit's own "Container and E2E" run passed, and no failed e2e run is visible on that branch, so I could not match the fix to an observed failure. The evidence above shows an unsynchronized transition and shows this change synchronizing it; it does not prove this was the specific failure CI hit.

One further candidate was deliberately left alone rather than hardened speculatively. `processUserStepAsync` fills Mantine inputs immediately after `waitForSelector`, which resolves on server-rendered HTML before hydration, so a fill can in principle be discarded when React hydrates. Nothing observed suggests it fired, so it is noted rather than papered over.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved onboarding submission with clearer notifications for account creation, sign-in, and other failures.
  - Prevented onboarding from continuing after a submission or sign-in error.
  - Added loading feedback while onboarding is being submitted.
  - Ensured successful onboarding completes the flow and refreshes the appropriate page state.

- **Tests**
  - Added end-to-end coverage for completing credentials-based onboarding and verifying saved setup details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->