### PR TITLE
fix(onboarding): keep the account submit disabled until the step advances

### DIFF
--- a/packages/onboarding/src/account.tsx
+++ b/packages/onboarding/src/account.tsx
@@ -104,7 +104,7 @@ const CredentialsSetup = () => {
 
   return (
     <AccountShell title={t("title")} description={t("description")}>
-      <form onSubmit={form.onSubmit((values) => void submitAsync(values))}>
+      <form onSubmit={form.onSubmit((values) => submitAsync(values))}>
         <Stack gap="md">
           <TextInput label={t("username")} autoComplete="username" withAsterisk {...form.getInputProps("username")} />
           <UserCreatePasswordFields
@@ -119,7 +119,7 @@ const CredentialsSetup = () => {
               {submitError}
             </Alert>
           ) : null}
-          <Button type="submit" size="md" loading={mutation.isPending} rightSection={<IconArrowRight size={18} />}>
+          <Button type="submit" size="md" loading={form.submitting} rightSection={<IconArrowRight size={18} />}>
             {t("create")}
           </Button>
         </Stack>


### PR DESCRIPTION
## Summary

In `CredentialsSetup`, the submit button goes idle while the step transition is still running, so it is clickable again during the sign-in and revalidate round trips on a user-creation endpoint.

`submitAsync` correctly awaits the mutation, then `signIn`, then the revalidate. But the sign-in and revalidate happen outside the mutation lifecycle, so `mutation.isPending` goes false as soon as the user row is written, while the rest of the sequence continues. The `void` on the submit handler compounds it: Mantine's `onSubmit` clears `submitting` immediately unless the handler returns a promise (`use-form.mjs:197-208`), so `form.submitting` was never usable either.

Returning the promise and driving the button from `form.submitting` covers the whole sequence, including the `requiresSignIn` early return.

`ExternalGroupSetup` below is deliberately untouched. Its revalidate runs inside an awaited `onSuccess`, and `query-core/mutation.js` only dispatches `success` after awaiting `onSuccess`, so `mutation.isPending` already spans its transition.

## Validation

`@homarr/onboarding` typecheck passes and its 4 spec files (16 tests) pass.

The mechanism was measured on `dev`, which had the same `void` submit handler with the transition additionally unawaited. Sampling the submit button with 1500ms of injected latency, against images differing only in this property:

| | user created | submit button idle | step advances |
| --- | --- | --- | --- |
| `void` handler | t=1721ms | **yes, from t=1721ms** | t=9797ms |
| promise returned | t=1711ms | no, loading throughout | t=9864ms |

Not re-measured on this branch: that needed a local container image per variant, and the same two-line property is being changed here. The onboarding e2e specs on this branch cover the flow in CI.
