### PR TITLE
fix(beszel): restore balanced system grid layout

### DIFF
--- a/apps/docs/docs/widgets/beszel-system-grid/index.mdx
+++ b/apps/docs/docs/widgets/beszel-system-grid/index.mdx
@@ -16,7 +16,7 @@ import beszelSystemGrid from "./img/beszel-system-grid.png";
 
 <WidgetHeader widget={beszelSystemGridWidget} categories={["System Monitoring"]} />
 
-This widget displays all your Beszel-monitored systems as a responsive card grid. Each card shows real-time metrics like CPU, memory, disk, network, temperature, and more. Cards adapt their layout based on available space. If Beszel reports multiple filesystems, the disk bar exposes a hover breakdown for the root disk and each extra mount.
+This widget displays all your Beszel-monitored systems as a responsive card grid. Each card shows real-time metrics like CPU, memory, disk, network, temperature, and more. Resizing the widget adjusts its rows and columns to keep the cards balanced. If Beszel reports multiple filesystems, the disk bar exposes a hover breakdown for the root disk and each extra mount.
 
 Select a system card to open the complete statistics view, including system, filesystem, Docker, historical, and realtime charts.
 

--- a/packages/widgets/src/beszel-system-grid/component.tsx
+++ b/packages/widgets/src/beszel-system-grid/component.tsx
@@ -123,19 +123,12 @@ const MIN_CELL_HEIGHT = 80;
 const ADVANCED_MIN_CELL_WIDTH = 320;
 const ADVANCED_MIN_CELL_HEIGHT = 420;
 
-const getColCount = (width: number, _height: number, itemCount: number, minCellWidth = MIN_CELL_WIDTH): number => {
+const getColCount = (width: number, height: number, itemCount: number, minCellWidth = MIN_CELL_WIDTH): number => {
   if (itemCount <= 1) return 1;
   const maxCols = Math.min(itemCount, Math.max(1, Math.floor(width / minCellWidth)));
-
-  let best = 1;
-  for (let c = 1; c <= maxCols; c++) {
-    const emptyCells = (c - (itemCount % c)) % c;
-    const bestEmpty = (best - (itemCount % best)) % best;
-    if (emptyCells < bestEmpty || (emptyCells === bestEmpty && c > best)) {
-      best = c;
-    }
-  }
-  return best;
+  const aspectRatio = width / Math.max(height, MIN_CELL_HEIGHT);
+  const idealCols = Math.round(Math.sqrt(itemCount * aspectRatio));
+  return Math.min(maxCols, Math.max(1, idealCols));
 };
 
 interface MetricRowProps {


### PR DESCRIPTION
## Summary

- restore height-aware Beszel system grid column selection
- use rounded aspect-ratio sizing to avoid prime system counts collapsing into 1×N or N×1 layouts
- document responsive row and column balancing

## Validation

- reproduced 5×1 and 1×5 stretched layouts in a local demo instance
- compared wide and narrow post-fix geometry against the supplied reference screenshots
- verified the earlier four-system square widget remains 2×2
- `git diff --check`

## Root cause

The empty-cell divisor heuristic introduced in #6389 ignored widget height. The fixed logical dimensions from the newer board layout exposed that latent behavior, but the DND implementation itself did not modify the Beszel grid.