### PR TITLE
fix: keep media stream status at table edge

### DIFF
--- a/packages/widgets/src/media-server/component.tsx
+++ b/packages/widgets/src/media-server/component.tsx
@@ -147,7 +147,7 @@ function StreamTableHeader({
   const SortIcon = !active ? IconArrowsSort : sort.descending ? IconChevronDown : IconChevronUp;
 
   return (
-    <Table.Th w={width} aria-sort={active ? (sort.descending ? "descending" : "ascending") : "none"}>
+    <Table.Th style={{ width }} aria-sort={active ? (sort.descending ? "descending" : "ascending") : "none"}>
       {sortable ? (
         <UnstyledButton className={classes.sortButton} onClick={() => onSort(column)}>
           <Text component="span" size="xs" fw={600} c="dimmed" style={{ letterSpacing: "0.02em" }} truncate>


### PR DESCRIPTION
## Summary
- keep fixed media-stream columns in logical pixels when the board canvas is scaled
- reclaim the unused status-column space for show titles while keeping status at the far-right edge

## Verification
- production Docker harness at 0.7568 board scale and 488px widget width
- title column increased from 98.4px to 193.3px
- all six seeded titles render without clipping; baseline clipped three
- `pnpm --filter @homarr/widgets typecheck`
- `oxfmt --check packages/widgets/src/media-server/component.tsx`
- `git diff --check`