### PR TITLE
fix(settings): move board access control out of the nested form

### DIFF
--- a/apps/nextjs/src/app/[locale]/boards/[name]/settings/_settings-form.tsx
+++ b/apps/nextjs/src/app/[locale]/boards/[name]/settings/_settings-form.tsx
@@ -178,35 +178,37 @@ export const BoardSettingsForm = ({ board, permissions, hasFullAccess, hideVisib
   const isPending = savePartialSettings.isPending || saveLayouts.isPending;
 
   return (
-    <form onSubmit={form.onSubmit((values) => void handleSubmitAsync(values))}>
-      <Stack gap="xl">
-        <GeneralSettingsContent board={board} form={form} />
-        <LayoutSettingsContent form={form} />
-        <BackgroundSettingsContent form={form} />
-        <ColorSettingsContent form={form} />
-        <CustomCssSettingsContent form={form} />
-        <BehaviorSettingsContent form={form} />
+    <Stack gap="xl">
+      <form onSubmit={form.onSubmit((values) => void handleSubmitAsync(values))}>
+        <Stack gap="xl">
+          <GeneralSettingsContent board={board} form={form} />
+          <LayoutSettingsContent form={form} />
+          <BackgroundSettingsContent form={form} />
+          <ColorSettingsContent form={form} />
+          <CustomCssSettingsContent form={form} />
+          <BehaviorSettingsContent form={form} />
 
-        {hasFullAccess && (
-          <SectionCard title={tSection("access.title")}>
-            <BoardAccessSettings board={board} initialPermissions={permissions} />
-          </SectionCard>
-        )}
+          {form.isDirty() && (
+            <UnsavedChangesBar>
+              <Button type="button" disabled={isPending} variant="default" onClick={handleDiscard}>
+                {t("common.action.discard")}
+              </Button>
+              <Button loading={isPending} type="submit" disabled={!form.isValid()}>
+                {t("common.action.saveChanges")}
+              </Button>
+            </UnsavedChangesBar>
+          )}
+        </Stack>
+      </form>
 
-        {hasFullAccess && <DangerZoneSettingsContent hideVisibility={hideVisibility} />}
+      {hasFullAccess && (
+        <SectionCard title={tSection("access.title")}>
+          <BoardAccessSettings board={board} initialPermissions={permissions} />
+        </SectionCard>
+      )}
 
-        {form.isDirty() && (
-          <UnsavedChangesBar>
-            <Button type="button" disabled={isPending} variant="default" onClick={handleDiscard}>
-              {t("common.action.discard")}
-            </Button>
-            <Button loading={isPending} type="submit" disabled={!form.isValid()}>
-              {t("common.action.saveChanges")}
-            </Button>
-          </UnsavedChangesBar>
-        )}
-      </Stack>
-    </form>
+      {hasFullAccess && <DangerZoneSettingsContent hideVisibility={hideVisibility} />}
+    </Stack>
   );
 };
 


### PR DESCRIPTION
## Issue
Fixes #6653 — **Unable to save group permissions on board**.

Clicking `Save group permission` (or `Save user permission`) on a board did nothing and just reloaded the page. Console shows React `#418` (hydration mismatch) on reload.

## Root cause
The unified board settings form (`_settings-form.tsx`) wrapped `<BoardAccessSettings>` — which renders its own `<form>` via `GroupAccessForm`/`UsersAccessForm` — **inside** the outer board-settings `<form>`. Nested `<form>` elements are invalid HTML. It triggers `<form> cannot contain a nested <form>`, React hydration breaks on the inner form, so its `onSubmit` is never attached and `<button type="submit">Save group permission` triggers a native submit → page reload, nothing persisted.

Affects both user and group saves (shared `AccessSettings`), and explains the manual `boardGroupPermission` SQL-insert workaround (DB/display path is fine — only the save UI is broken).

## Fix
The outer `<form>` now scopes only the six board-settings sections (general, layout, background, appearance, customCss, behavior). The **Access control** and **Danger zone** sections (independent; own mutations/forms) render **outside** the form as siblings — matching the original intent of unified-form PR #6541 ("Access + Danger Zone remain independent").

## Verification
Controlled A/B on current `dev`, real browser end-to-end:
- **Before (buggy):** adding a group then clicking `Save group permission` does **not** fire the mutation (no tRPC request) and does **not** persist — `boardGroupPermission` unchanged.
- **After (fix):** same flow fires `POST /api/trpc/board.saveGroupBoardPermissions` → 200, **persists** the row, no reload, no console errors.
- `turbo typecheck --filter=@homarr/nextjs` and `oxlint` pass.

Matches the maintainer's earlier in-progress nested-form fixes (e.g. `991e79310`, `f0b153aa3` "avoid nested board settings forms") which were never merged into `dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the settings page layout to better organize editable settings, access controls, and danger-zone options.
  * Kept the unsaved-changes notification positioned with the editable settings for clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->