### PR TITLE
fix: position calendar error indicator top-left

### DIFF
--- a/packages/widgets/src/calendar/component.module.css
+++ b/packages/widgets/src/calendar/component.module.css
@@ -5,8 +5,8 @@
 }
 
 .errorIndicator {
-  top: calc(var(--mantine-spacing-md) + var(--mantine-spacing-xl));
-  inset-inline-end: 4px;
+  top: 4px;
+  inset-inline-start: 4px;
   z-index: 1;
   padding: 2px;
   border: 1px solid rgb(from var(--mantine-primary-color-filled) r g b / calc(var(--opacity, 1) * 0.45));

--- a/packages/widgets/src/calendar/component.tsx
+++ b/packages/widgets/src/calendar/component.tsx
@@ -293,7 +293,7 @@ const CalendarAgenda = ({
   const monthLabel = new Intl.DateTimeFormat(locale, { month: "long", year: "numeric" }).format(month);
 
   return (
-    <Stack h="100%" w="100%" gap="sm" p="md" style={{ overflow: "hidden" }}>
+    <Stack h="100%" w="100%" gap="sm" p="md" pos="relative" style={{ overflow: "hidden" }}>
       <Group justify="space-between" align="center" wrap="nowrap">
         <Group gap="xs" wrap="nowrap">
           <Tooltip label={t("previousMonth")} events={{ hover: true, focus: true, touch: false }}>
@@ -329,7 +329,7 @@ const CalendarAgenda = ({
             </ActionIcon>
           </Tooltip>
         </Group>
-        <Group gap={0}>
+        <Group className={classes.errorIndicator} gap={0} pos="absolute">
           <IntegrationErrorIndicator results={failedIntegrations} />
           <WidgetQueryErrorIndicator error={queryError} label={queryErrorLabel} />
         </Group>


### PR DESCRIPTION
## Summary

- position the calendar error indicator at the top-left
- remove the advanced-calendar indicator from the header layout flow

## Validation

- `git diff --check`
- typecheck and formatter unavailable in the current checkout (`node_modules` missing)