### PR TITLE
fix(http): preserve SDK headers when injecting User-Agent

### DIFF
--- a/packages/core/src/infrastructure/http/index.ts
+++ b/packages/core/src/infrastructure/http/index.ts
@@ -5,4 +5,5 @@ export {
   createCustomCheckServerIdentity,
   createHttpsAgentAsync,
   fetchWithTrustedCertificatesAsync,
+  mergeHeadersWithUserAgent,
 } from "./request";

--- a/packages/core/src/infrastructure/http/request.ts
+++ b/packages/core/src/infrastructure/http/request.ts
@@ -18,6 +18,14 @@ import packageJson from "../../../../../package.json";
 
 export const getDefaultUserAgent = () => `Homarr/${packageJson.version} (+https://homarr.dev)`;
 
+export const mergeHeadersWithUserAgent = (headers: unknown): Headers => {
+  const mergedHeaders = new Headers(headers as HeadersInit);
+  if (!mergedHeaders.has("user-agent")) {
+    mergedHeaders.set("user-agent", getDefaultUserAgent());
+  }
+  return mergedHeaders;
+};
+
 export const createCustomCheckServerIdentity = (
   trustedHostnames: TrustedCertificateHostname[],
 ): typeof checkServerIdentity => {
@@ -77,30 +85,18 @@ export const fetchWithTrustedCertificatesAsync = async (
       undefined,
       options?.bodyTimeout !== undefined ? { bodyTimeout: options.bodyTimeout } : undefined,
     ));
+  const buildFetchOptions = (fetchOptions: Omit<RequestInit, "dispatcher" | "bodyTimeout" | "timeout">) => ({
+    ...fetchOptions,
+    headers: mergeHeadersWithUserAgent(fetchOptions.headers) as unknown as RequestInit["headers"],
+  });
   if (options?.timeout) {
     const { bodyTimeout: _bodyTimeout, dispatcher: _dispatcher, ...fetchOptions } = options;
     return await withTimeoutAsync(
-      async (signal) =>
-        fetch(url, {
-          ...fetchOptions,
-          headers: {
-            "User-Agent": getDefaultUserAgent(),
-            ...fetchOptions.headers,
-          },
-          signal,
-          dispatcher: agent,
-        }),
+      async (signal) => fetch(url, { ...buildFetchOptions(fetchOptions), signal, dispatcher: agent }),
       options.timeout,
     );
   }
 
   const { bodyTimeout: _bodyTimeout, dispatcher: _dispatcher, ...fetchOptions } = options ?? {};
-  return fetch(url, {
-    ...fetchOptions,
-    headers: {
-      "User-Agent": getDefaultUserAgent(),
-      ...fetchOptions.headers,
-    },
-    dispatcher: agent,
-  });
+  return fetch(url, { ...buildFetchOptions(fetchOptions), dispatcher: agent });
 };

--- a/packages/core/src/test/infrastructure/http/request.spec.ts
+++ b/packages/core/src/test/infrastructure/http/request.spec.ts
@@ -1,6 +1,18 @@
-import { describe, expect, test } from "vitest";
+// @vitest-environment node
 
-import { mergeHeadersWithUserAgent } from "@homarr/core/infrastructure/http";
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { RequestInit } from "undici";
+
+import { describe, expect, test, vi } from "vitest";
+
+import { fetchWithTrustedCertificatesAsync, mergeHeadersWithUserAgent } from "@homarr/core/infrastructure/http";
+
+vi.mock("@homarr/core/infrastructure/certificates", () => ({
+  getAllTrustedCertificatesAsync: vi.fn(async () => []),
+  getTrustedCertificateHostnamesAsync: vi.fn(async () => []),
+}));
 
 describe("mergeHeadersWithUserAgent", () => {
   test("should keep existing headers when given a Headers instance", () => {
@@ -46,5 +58,44 @@ describe("mergeHeadersWithUserAgent", () => {
 
     // Assert
     expect(merged.get("user-agent")).toContain("Homarr/");
+  });
+});
+
+const startCaptureServerAsync = async (): Promise<{
+  server: Server;
+  getReceivedHeaders: () => Record<string, string | string[] | undefined>;
+  port: number;
+}> => {
+  let receivedHeaders: Record<string, string | string[] | undefined> = {};
+  const server = createServer((req, res) => {
+    receivedHeaders = req.headers;
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end("{}");
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const port = (server.address() as AddressInfo).port;
+  return {
+    server,
+    port,
+    getReceivedHeaders: () => receivedHeaders,
+  };
+};
+
+describe("fetchWithTrustedCertificatesAsync", () => {
+  test("should deliver a Headers instance with all headers to the remote server", async () => {
+    // Arrange - the @immich/sdk hands over a Headers instance after merging its defaults
+    const { server, port, getReceivedHeaders } = await startCaptureServerAsync();
+    const headers = new Headers({ "x-api-key": "immich-api-key", Accept: "application/json" });
+
+    // Act
+    const response = await fetchWithTrustedCertificatesAsync(`http://127.0.0.1:${port}/api/server/statistics`, {
+      headers: headers as unknown as RequestInit["headers"],
+    });
+    server.close();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(getReceivedHeaders()["x-api-key"]).toBe("immich-api-key");
+    expect(getReceivedHeaders()["user-agent"]).toContain("Homarr/");
   });
 });

--- a/packages/core/src/test/infrastructure/http/request.spec.ts
+++ b/packages/core/src/test/infrastructure/http/request.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import { mergeHeadersWithUserAgent } from "@homarr/core/infrastructure/http";
+
+describe("mergeHeadersWithUserAgent", () => {
+  test("should keep existing headers when given a Headers instance", () => {
+    // Arrange
+    const headers = new Headers({ "x-api-key": "some-api-key", Accept: "application/json" });
+
+    // Act
+    const merged = mergeHeadersWithUserAgent(headers);
+
+    // Assert
+    expect(merged.get("x-api-key")).toBe("some-api-key");
+    expect(merged.get("accept")).toBe("application/json");
+    expect(merged.get("user-agent")).toContain("Homarr/");
+  });
+
+  test("should keep existing headers when given a record", () => {
+    // Arrange
+    const headers = { "x-api-key": "some-api-key", Accept: "application/json" };
+
+    // Act
+    const merged = mergeHeadersWithUserAgent(headers);
+
+    // Assert
+    expect(merged.get("x-api-key")).toBe("some-api-key");
+    expect(merged.get("accept")).toBe("application/json");
+    expect(merged.get("user-agent")).toContain("Homarr/");
+  });
+
+  test("should not override an existing user-agent in any casing", () => {
+    // Arrange
+    const headers = new Headers({ "USER-AGENT": "custom-agent" });
+
+    // Act
+    const merged = mergeHeadersWithUserAgent(headers);
+
+    // Assert
+    expect(merged.get("user-agent")).toBe("custom-agent");
+  });
+
+  test("should fall back to the default user agent when no headers are provided", () => {
+    // Act
+    const merged = mergeHeadersWithUserAgent(undefined);
+
+    // Assert
+    expect(merged.get("user-agent")).toContain("Homarr/");
+  });
+});

--- a/packages/core/src/test/infrastructure/http/request.spec.ts
+++ b/packages/core/src/test/infrastructure/http/request.spec.ts
@@ -41,6 +41,22 @@ describe("mergeHeadersWithUserAgent", () => {
     expect(merged.get("user-agent")).toContain("Homarr/");
   });
 
+  test("should keep existing headers when given a tuple array", () => {
+    // Arrange
+    const headers: [string, string][] = [
+      ["x-api-key", "some-api-key"],
+      ["Accept", "application/json"],
+    ];
+
+    // Act
+    const merged = mergeHeadersWithUserAgent(headers);
+
+    // Assert
+    expect(merged.get("x-api-key")).toBe("some-api-key");
+    expect(merged.get("accept")).toBe("application/json");
+    expect(merged.get("user-agent")).toContain("Homarr/");
+  });
+
   test("should not override an existing user-agent in any casing", () => {
     // Arrange
     const headers = new Headers({ "USER-AGENT": "custom-agent" });
@@ -88,14 +104,17 @@ describe("fetchWithTrustedCertificatesAsync", () => {
     const headers = new Headers({ "x-api-key": "immich-api-key", Accept: "application/json" });
 
     // Act
-    const response = await fetchWithTrustedCertificatesAsync(`http://127.0.0.1:${port}/api/server/statistics`, {
-      headers: headers as unknown as RequestInit["headers"],
-    });
-    server.close();
+    try {
+      const response = await fetchWithTrustedCertificatesAsync(`http://127.0.0.1:${port}/api/server/statistics`, {
+        headers: headers as unknown as RequestInit["headers"],
+      });
 
-    // Assert
-    expect(response.status).toBe(200);
-    expect(getReceivedHeaders()["x-api-key"]).toBe("immich-api-key");
-    expect(getReceivedHeaders()["user-agent"]).toContain("Homarr/");
+      // Assert
+      expect(response.status).toBe(200);
+      expect(getReceivedHeaders()["x-api-key"]).toBe("immich-api-key");
+      expect(getReceivedHeaders()["user-agent"]).toContain("Homarr/");
+    } finally {
+      server.close();
+    }
   });
 });

--- a/packages/integrations/test/immich-sdk-e2e.spec.ts
+++ b/packages/integrations/test/immich-sdk-e2e.spec.ts
@@ -25,13 +25,15 @@ describe("real @immich/sdk end-to-end through fetchWithTrustedCertificatesAsync"
     const port = (server.address() as AddressInfo).port;
 
     init({ baseUrl: `http://127.0.0.1:${port}/api`, apiKey: "sdk-configured-key" });
-    const stats = await getServerStatistics({
-      fetch: fetchWithTrustedCertificatesAsync as unknown as typeof fetch,
-    });
+    try {
+      const stats = await getServerStatistics({
+        fetch: fetchWithTrustedCertificatesAsync as unknown as typeof fetch,
+      });
 
-    server.close();
-
-    expect(receivedXApiKey).toBe("sdk-configured-key");
-    expect(stats).toMatchObject({ usage: 1000, photos: 5, videos: 2 });
+      expect(receivedXApiKey).toBe("sdk-configured-key");
+      expect(stats).toMatchObject({ usage: 1000, photos: 5, videos: 2 });
+    } finally {
+      server.close();
+    }
   });
 });

--- a/packages/integrations/test/immich-sdk-e2e.spec.ts
+++ b/packages/integrations/test/immich-sdk-e2e.spec.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { getServerStatistics, init } from "@immich/sdk";
+import { describe, expect, test, vi } from "vitest";
+
+import { fetchWithTrustedCertificatesAsync } from "@homarr/core/infrastructure/http";
+
+vi.mock("@homarr/core/infrastructure/certificates", () => ({
+  getAllTrustedCertificatesAsync: vi.fn(async () => []),
+  getTrustedCertificateHostnamesAsync: vi.fn(async () => []),
+}));
+
+describe("real @immich/sdk end-to-end through fetchWithTrustedCertificatesAsync", () => {
+  test("x-api-key set via init() reaches the server", async () => {
+    let receivedXApiKey: string | string[] | undefined;
+    const server = createServer((req, res) => {
+      receivedXApiKey = req.headers["x-api-key"];
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ usage: 1000, photos: 5, videos: 2 }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as AddressInfo).port;
+
+    init({ baseUrl: `http://127.0.0.1:${port}/api`, apiKey: "sdk-configured-key" });
+    const stats = await getServerStatistics({
+      fetch: fetchWithTrustedCertificatesAsync as unknown as typeof fetch,
+    });
+
+    server.close();
+
+    expect(receivedXApiKey).toBe("sdk-configured-key");
+    expect(stats).toMatchObject({ usage: 1000, photos: 5, videos: 2 });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #6672 — the Immich Server Stats widget returning HTTP 401 since v1.76.0 while "Test connection" kept succeeding.

## Root cause

v1.76.0 (#6606) started injecting the default `User-Agent` into `fetchWithTrustedCertificatesAsync` via object spread:

```ts
headers: { "User-Agent": getDefaultUserAgent(), ...fetchOptions.headers }
```

Object-spreading a `Headers` instance yields **no entries** (headers are not own-enumerable properties). The `@immich/sdk` passes exactly that shape — the SDK's oazapfts runtime merges the defaults (including `x-api-key`) into a `Headers` instance before handing it to our custom fetch. The spread silently discarded them all, so Immich requests went out without an API key → `401`.

The connection test escapes this bug because it calls `undiciFetch` directly and never enters `fetchWithTrustedCertificatesAsync` — matching the reporter's observation that "Test connection succeeds" while the widget fails.

## The fix

`mergeHeadersWithUserAgent` builds a real `Headers` instance instead of spreading:

- preserves record / `Headers` / tuple-array inputs (the `Headers` case is the critical one)
- only sets the default UA when no case-insensitive `user-agent` entry exists
- used in both the timeout and non-timeout fetch branches

## Tests

Added `packages/core/src/test/infrastructure/http/request.spec.ts` (4 cases) covering the Headers-instance regression that broke Immich, record input, user-agent casing, and default fallback.

Verified: unit tests pass, `tsc --noEmit` clean, oxlint/oxfmt clean.

@ejs0623 sorry this regression slipped into v1.76.0 — thanks for the thorough rollback comparison and logs, they made this trivial to nail down. Please let us know if this PR resolves the widget for you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request header handling to consistently preserve supplied headers.
  * Ensured the default user agent is added only when one is not already provided.
  * Header handling now works consistently across different header formats and request timeout paths.
  * Fixed authenticated SDK requests so configured API keys are correctly forwarded to connected services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->