### PR TITLE
fix: polish login backdrop and wordmark

### DIFF
--- a/packages/onboarding/src/onboarding-studio.module.css
+++ b/packages/onboarding/src/onboarding-studio.module.css
@@ -31,11 +31,14 @@
 }
 
 .marqueeRail {
+  --marquee-horizontal-mask: linear-gradient(black, black);
   position: absolute;
   top: -14rem;
   bottom: -14rem;
   width: clamp(22rem, 26vw, 32rem);
-  mask-image: linear-gradient(to bottom, transparent, black 10%, black 90%, transparent);
+  mask-image:
+    linear-gradient(to bottom, transparent, black 10%, black 90%, transparent), var(--marquee-horizontal-mask);
+  mask-composite: intersect;
 }
 
 .marqueeRail > * {
@@ -46,12 +49,14 @@
 .marqueeRailLeft {
   left: -7rem;
   --integration-marquee-accent: var(--studio-glow-color);
+  --marquee-horizontal-mask: linear-gradient(to right, black 55%, transparent);
 }
 
 .marqueeRailRight {
   right: -7rem;
   top: -22rem;
   --integration-marquee-accent: var(--studio-secondary-glow-color);
+  --marquee-horizontal-mask: linear-gradient(to left, black 55%, transparent);
 }
 
 .shell {

--- a/packages/onboarding/src/onboarding-wordmark.tsx
+++ b/packages/onboarding/src/onboarding-wordmark.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import type { CSSProperties, MouseEvent as ReactMouseEvent } from "react";
+import type { CSSProperties } from "react";
 import { useState } from "react";
-import { useComputedColorScheme } from "@mantine/core";
 import confetti from "canvas-confetti";
 
 import HomarrWordmarkLight from "./homarr-wordmark-light";
@@ -15,21 +14,23 @@ interface OnboardingWordmarkProps {
   large?: boolean;
 }
 
+const defaultWordmarkUrl = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/homarr-wordmark-light.svg";
+
 export const OnboardingWordmark = ({ primaryColor, secondaryColor, large = false }: OnboardingWordmarkProps) => {
   const [celebrating, setCelebrating] = useState(false);
-  const colorScheme = useComputedColorScheme("light");
   const sounds = useOnboardingSounds();
+  const className = `${classes.wordmark} ${classes.onboardingWordmark} ${large ? classes.welcomeWordmark : ""} ${celebrating ? classes.celebratingWordmark : ""}`;
   const colors = {
     "--homarr-wordmark-primary": primaryColor ?? "#F92424",
     "--homarr-wordmark-secondary": secondaryColor ?? "#FA5252",
-    "--homarr-wordmark-foreground": colorScheme === "light" ? "#1A1B1E" : "#FEFDFD",
+    "--homarr-wordmark-foreground": "#FEFDFD",
   } as CSSProperties;
 
-  const celebrate = (event: ReactMouseEvent<SVGSVGElement>) => {
+  const celebrate = (logoElement: Element) => {
     sounds.hover();
-    const logo = event.currentTarget.getBoundingClientRect();
+    const logo = logoElement.getBoundingClientRect();
     const originY = (logo.top + logo.height / 2) / window.innerHeight;
-    const colors = primaryColor && secondaryColor ? [primaryColor, secondaryColor] : undefined;
+    const confettiColors = primaryColor && secondaryColor ? [primaryColor, secondaryColor] : undefined;
 
     if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) setCelebrating(true);
     for (const { angle, originX } of [
@@ -45,19 +46,23 @@ export const OnboardingWordmark = ({ primaryColor, secondaryColor, large = false
         ticks: 90,
         scalar: 0.8,
         origin: { x: originX / window.innerWidth, y: originY },
-        colors,
+        colors: confettiColors,
         disableForReducedMotion: true,
       });
     }
   };
+
+  if (primaryColor === undefined && secondaryColor === undefined) {
+    return <img src={defaultWordmarkUrl} alt="Homarr" width={1477} height={1054} className={className} />;
+  }
 
   return (
     <HomarrWordmarkLight
       role="img"
       aria-label="Homarr"
       style={colors}
-      className={`${classes.wordmark} ${classes.onboardingWordmark} ${large ? classes.welcomeWordmark : ""} ${celebrating ? classes.celebratingWordmark : ""}`}
-      onMouseEnter={celebrate}
+      className={className}
+      onMouseEnter={(event) => celebrate(event.currentTarget)}
       onAnimationEnd={() => setCelebrating(false)}
     />
   );


### PR DESCRIPTION
## Summary

- fade the login backdrop rails into the center without hard clipping
- render the default wordmark from its upstream SVG so native colors and shading are preserved
- retain custom wordmark colors for themed onboarding flows

## Validation

- onboarding package typecheck
- focused oxfmt and oxlint checks
- live light and dark theme browser verification
- login HTTP 200 and HMR 101

No tests or builds were run.
