### PR TITLE
fix(mediaServer): use proportional column widths

### DIFF
--- a/packages/integrations/src/emby/emby-integration.ts
+++ b/packages/integrations/src/emby/emby-integration.ts
@@ -10,8 +10,21 @@ import { TestConnectionError } from "../base/test-connection/test-connection-err
 import type { TestingResult } from "../base/test-connection/test-connection-service";
 import type { IMediaServerIntegration } from "../interfaces/media-server/media-server-integration";
 import type { CurrentSessionsInput, StreamSession } from "../interfaces/media-server/media-server-types";
-import { convertJellyfinType } from "../jellyfin/jellyfin-integration";
+import { convertJellyfinType, parseLocation, ticksToMs } from "../jellyfin/jellyfin-integration";
 import type { IMediaReleasesIntegration, MediaRelease, MediaType } from "../types";
+
+const transcodingInfoSchema = z.object({
+  Bitrate: z.number().nullish(),
+  Framerate: z.number().nullish(),
+  AudioChannels: z.number().nullish(),
+  AudioCodec: z.string().nullish(),
+  VideoCodec: z.string().nullish(),
+  Container: z.string().nullish(),
+  IsVideoDirect: z.boolean().nullish(),
+  IsAudioDirect: z.boolean().nullish(),
+  Width: z.number().nullish(),
+  Height: z.number().nullish(),
+});
 
 const sessionSchema = z.object({
   NowPlayingItem: z
@@ -25,6 +38,11 @@ const sessionSchema = z.object({
       IndexNumber: z.number().nullish(),
       Album: z.string().nullish(),
       EpisodeCount: z.number().nullish(),
+      RunTimeTicks: z.number().nullish(),
+      Width: z.number().nullish(),
+      Height: z.number().nullish(),
+      MediaStreams: z.array(z.object({ BitRate: z.number().nullish() })).nullish(),
+      MediaSources: z.array(z.object({ Bitrate: z.number().nullish() })).nullish(),
     })
     .optional(),
   Id: z.string(),
@@ -33,6 +51,15 @@ const sessionSchema = z.object({
   DeviceName: z.string().nullish(),
   UserId: z.string().optional(),
   UserName: z.string().nullish(),
+  RemoteEndPoint: z.string().nullish(),
+  PlayState: z
+    .object({
+      IsPaused: z.boolean().nullish(),
+      PositionTicks: z.number().nullish(),
+      PlayMethod: z.string().nullish(),
+    })
+    .nullish(),
+  TranscodingInfo: transcodingInfoSchema.nullish(),
 });
 
 const itemSchema = z.object({
@@ -113,6 +140,21 @@ export class EmbyIntegration extends Integration implements IMediaServerIntegrat
 
         if (sessionInfo.NowPlayingItem) {
           const isEpisode = sessionInfo.NowPlayingItem.Type === BaseItemKind.Episode;
+          const transcodingInfo = sessionInfo.TranscodingInfo;
+          const positionMs = ticksToMs(sessionInfo.PlayState?.PositionTicks);
+          const durationMs = ticksToMs(sessionInfo.NowPlayingItem.RunTimeTicks);
+          // Emby only reliably fills in MediaSources[].Bitrate for a transcoding session -
+          // /Sessions has no `fields` selector to force it, so fall back to summing the individual
+          // media streams' own bitrates (populated from the source file's metadata) for direct play.
+          const mediaStreamsBitrateBps = sessionInfo.NowPlayingItem.MediaStreams?.reduce(
+            (sum, stream) => sum + (stream.BitRate ?? 0),
+            0,
+          );
+          const bitrateBps =
+            transcodingInfo?.Bitrate ??
+            sessionInfo.NowPlayingItem.MediaSources?.[0]?.Bitrate ??
+            (mediaStreamsBitrateBps || null);
+          const bitrateKbps = bitrateBps !== null ? Math.round(bitrateBps / 1000) : null;
 
           currentlyPlaying = {
             type: convertJellyfinType(sessionInfo.NowPlayingItem.Type),
@@ -124,12 +166,45 @@ export class EmbyIntegration extends Integration implements IMediaServerIntegrat
             albumName: sessionInfo.NowPlayingItem.Album ?? "",
             episodeCount: sessionInfo.NowPlayingItem.EpisodeCount,
             playback: {
-              state: null,
-              positionMs: null,
-              durationMs: null,
+              state: sessionInfo.PlayState?.IsPaused ? "paused" : "playing",
+              positionMs,
+              durationMs,
             },
-            location: null,
-            metadata: null,
+            location: parseLocation(sessionInfo.RemoteEndPoint),
+            metadata: {
+              video: {
+                resolution:
+                  sessionInfo.NowPlayingItem.Width && sessionInfo.NowPlayingItem.Height
+                    ? {
+                        width: sessionInfo.NowPlayingItem.Width,
+                        height: sessionInfo.NowPlayingItem.Height,
+                      }
+                    : null,
+                frameRate: transcodingInfo?.Framerate ?? null,
+              },
+              audio: {
+                channelCount: transcodingInfo?.AudioChannels ?? null,
+                codec: transcodingInfo?.AudioCodec ?? null,
+              },
+              transcoding: {
+                resolution:
+                  transcodingInfo?.Width && transcodingInfo.Height
+                    ? {
+                        width: transcodingInfo.Width,
+                        height: transcodingInfo.Height,
+                      }
+                    : null,
+                target: {
+                  audioCodec: transcodingInfo?.AudioCodec ?? null,
+                  videoCodec: transcodingInfo?.VideoCodec ?? null,
+                },
+                container: transcodingInfo?.Container ?? null,
+                isVideoDirect: transcodingInfo?.IsVideoDirect ?? true,
+                isAudioDirect: transcodingInfo?.IsAudioDirect ?? true,
+                containerChanged: sessionInfo.PlayState?.PlayMethod === "DirectStream",
+              },
+              bitrateKbps,
+            },
           };
         }
 

--- a/packages/integrations/src/jellyfin/jellyfin-integration.ts
+++ b/packages/integrations/src/jellyfin/jellyfin-integration.ts
@@ -18,8 +18,8 @@ import type { IMediaServerIntegration } from "../interfaces/media-server/media-s
 import type { CurrentSessionsInput, StreamSession } from "../interfaces/media-server/media-server-types";
 import type { IMediaReleasesIntegration, MediaRelease, MediaType } from "../types";
 
-function ticksToMs(ticks: number | null | undefined): number | null {
-  return ticks ? Math.round(ticks / 10_000) : null;
+export function ticksToMs(ticks: number | null | undefined): number | null {
+  return ticks == null ? null : Math.round(ticks / 10_000);
 }
 
 // Unlike Plex, Jellyfin doesn't report a session's network location directly - only the

--- a/packages/widgets/src/media-server/component.tsx
+++ b/packages/widgets/src/media-server/component.tsx
@@ -50,7 +50,7 @@ type SortState = { column: SortColumn; descending: boolean } | null;
 
 export const getMediaServerColumnVisibility = (width: number, isAdvanced: boolean) => ({
   user: isAdvanced || width >= 300,
-  // The user (200px) and status (190px) columns together need a floor here, otherwise the
+  // The user (26%) and status (22%) columns together need a floor here, otherwise the
   // currentlyPlaying column - the primary content - gets squeezed to almost nothing.
   status: isAdvanced || width >= 540,
 });
@@ -140,7 +140,7 @@ function StreamTableHeader({
   sortable: boolean;
   sort: SortState;
   onSort: (column: SortColumn) => void;
-  width?: number;
+  width?: number | string;
 }) {
   const active = sort?.column === column;
   const SortIcon = !active ? IconArrowsSort : sort.descending ? IconChevronDown : IconChevronUp;
@@ -285,7 +285,7 @@ export default function MediaServerWidget({
                   sortable={isAdvanced}
                   sort={sort}
                   onSort={toggleSort}
-                  width={200}
+                  width="26%"
                 />
               )}
               <StreamTableHeader
@@ -302,7 +302,7 @@ export default function MediaServerWidget({
                   sortable={isAdvanced}
                   sort={sort}
                   onSort={toggleSort}
-                  width={190}
+                  width="22%"
                 />
               )}
             </Table.Tr>


### PR DESCRIPTION
Fixes the media server streams widget cutting off usernames and client names (like "Emby f…") even when there's plenty of empty space elsewhere in the widget — the columns now scale with the widget's width instead of being stuck at a fixed pixel size.

Also fills in missing data for Emby specifically: streams now show a progress bar, resolution, and bitrate, and the status badge actually reflects transcoding instead of always saying "Direct Play".



- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [ ] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).
- [ ] When using AI; No temp files are checked in, the code style follows the rest of the project

**When contributing a new integration or widget:**

- [x] I confirmed manually that the integration or widget is working with a real system and performed basic smoke
  tests (e.g. what happens if it is offline)
- [x] Optional but recommended: I confirm that I am willing to be added to the `CODEOWNERS` of this feature and will
  provide support and maintain the integration (e.g. in case of breaking or failure)