### PR TITLE
fix: stabilize e2e login hydration

### DIFF
--- a/e2e/assistant-management.spec.ts
+++ b/e2e/assistant-management.spec.ts
@@ -3,6 +3,7 @@ import { describe, test } from "vitest";
 
 import { createHomarrContainer } from "./shared/create-homarr-container";
 import { createSqliteDbFileAsync } from "./shared/e2e-db";
+import { loginAsync } from "./shared/login";
 import { seedAdminUserAsync } from "./shared/seed-admin-user";
 import * as sqliteSchema from "../packages/db/schema/sqlite";
 
@@ -40,13 +41,7 @@ describe("Assistant management", () => {
     const page = await context.newPage();
 
     try {
-      await page.goto(`${baseUrl}/auth/login`);
-      await page.getByLabel("Username").fill(adminCredentials.username);
-      await page.locator("#password").fill(adminCredentials.password);
-      await page.getByRole("button", { name: "Login" }).click();
-      await expect(page).not.toHaveURL(/\/auth\/login/, { timeout: 30_000 });
-
-      await page.goto(`${baseUrl}/manage/assistant`);
+      await loginAsync({ page, baseUrl, credentials: adminCredentials, destination: "/manage/assistant" });
       await expect(page.getByRole("heading", { name: "Assistant" })).toBeVisible();
       await expect(page.getByText("Connection ready")).toBeVisible();
       await expect(page.getByText("Encrypted API key saved")).toBeVisible();

--- a/e2e/lazy-widgets.spec.ts
+++ b/e2e/lazy-widgets.spec.ts
@@ -8,6 +8,7 @@ import { describe, test } from "vitest";
 import * as sqliteSchema from "../packages/db/schema/sqlite";
 import { createHomarrContainer } from "./shared/create-homarr-container";
 import { createSqliteDbFileAsync } from "./shared/e2e-db";
+import { loginAsync } from "./shared/login";
 import { seedAdminUserAsync } from "./shared/seed-admin-user";
 
 const adminCredentials = {
@@ -116,15 +117,7 @@ describe("lazy widget application graph", () => {
     let releaseRefresh: (() => void) | undefined;
 
     try {
-      await page.goto(`${baseUrl}/auth/login`);
-      await page.getByLabel("Username").fill(adminCredentials.username);
-      await page.locator("#password").fill(adminCredentials.password);
-      const signedIn = page.waitForURL((url) => url.origin === baseUrl && url.pathname === "/", {
-        waitUntil: "commit",
-        timeout: 60_000,
-      });
-      await page.locator("css=button[type='submit']").click();
-      await signedIn;
+      await loginAsync({ page, baseUrl, credentials: adminCredentials });
 
       const visibleBoard = page.locator("[data-homarr-dev-benchmark-board]").filter({ visible: true }).first();
       await expect(visibleBoard).toBeVisible({ timeout: 30_000 });


### PR DESCRIPTION
## What
- use the shared hydration-aware login helper in the two failing E2E specs
- preserve each spec's existing post-login destination

## Validation
- exact failing CI image: assistant-management and lazy-widgets specs pass together
- focused oxlint and oxfmt checks pass