### PR TITLE
fix: refine configurable header defaults

### DIFF
--- a/apps/docs/static/api/open-api-schema.json
+++ b/apps/docs/static/api/open-api-schema.json
@@ -4387,7 +4387,7 @@
                             "enum": ["input", "icon"]
                           },
                           "logoDisplay": {
-                            "default": "logo",
+                            "default": "logoAndText",
                             "type": "string",
                             "enum": ["logo", "logoAndText"]
                           },

--- a/apps/nextjs/src/components/layout/header/configurable-header.module.css
+++ b/apps/nextjs/src/components/layout/header/configurable-header.module.css
@@ -16,7 +16,10 @@
   display: flex;
   align-items: center;
   gap: var(--mantine-spacing-sm);
+  box-sizing: border-box;
   min-width: 0;
+  height: 100%;
+  padding-inline-end: rem(10px);
   overflow-x: auto;
   scrollbar-width: none;
 }

--- a/packages/db/migrations/mysql/0048_add_header_preferences_and_branding.sql
+++ b/packages/db/migrations/mysql/0048_add_header_preferences_and_branding.sql
@@ -1,4 +1,4 @@
-ALTER TABLE `user` ADD `header_preferences` text DEFAULT ('{"version":3,"visible":true,"searchDisplay":"input","logoDisplay":"logo","zones":{"left":[{"type":"builtin","id":"logo"}],"center":[{"type":"builtin","id":"search"}],"right":[{"type":"builtin","id":"boardEdit"},{"type":"builtin","id":"boardSettings"},{"type":"builtin","id":"user"}]}}') NOT NULL;
+ALTER TABLE `user` ADD `header_preferences` text DEFAULT ('{"version":3,"visible":true,"searchDisplay":"input","logoDisplay":"logoAndText","zones":{"left":[{"type":"builtin","id":"logo"}],"center":[{"type":"builtin","id":"search"}],"right":[{"type":"builtin","id":"boardEdit"},{"type":"builtin","id":"boardSettings"},{"type":"builtin","id":"user"}]}}') NOT NULL;
 --> statement-breakpoint
 INSERT IGNORE INTO `serverSetting` (`setting_key`, `value`)
 VALUES ('branding', '{"json":{"appName":"Homarr","greeting":"","logoImageUrl":null,"faviconImageUrl":null,"primaryColor":"#fa5252","secondaryColor":"#fd7e14","lockPrimaryColor":false,"signInBackgroundImageUrl":null,"signInBackgroundOverlay":0.55,"authBranding":{"showAppName":true,"showLogo":true,"showGreeting":true},"defaultRadius":"md"}}');

--- a/packages/db/migrations/mysql/meta/0048_snapshot.json
+++ b/packages/db/migrations/mysql/meta/0048_snapshot.json
@@ -2620,7 +2620,7 @@
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false,
-          "default": "('{\"version\":3,\"visible\":true,\"searchDisplay\":\"input\",\"logoDisplay\":\"logo\",\"zones\":{\"left\":[{\"type\":\"builtin\",\"id\":\"logo\"}],\"center\":[{\"type\":\"builtin\",\"id\":\"search\"}],\"right\":[{\"type\":\"builtin\",\"id\":\"boardEdit\"},{\"type\":\"builtin\",\"id\":\"boardSettings\"},{\"type\":\"builtin\",\"id\":\"user\"}]}}')"
+          "default": "('{\"version\":3,\"visible\":true,\"searchDisplay\":\"input\",\"logoDisplay\":\"logoAndText\",\"zones\":{\"left\":[{\"type\":\"builtin\",\"id\":\"logo\"}],\"center\":[{\"type\":\"builtin\",\"id\":\"search\"}],\"right\":[{\"type\":\"builtin\",\"id\":\"boardEdit\"},{\"type\":\"builtin\",\"id\":\"boardSettings\"},{\"type\":\"builtin\",\"id\":\"user\"}]}}')"
         },
         "completed_manage_tour": {
           "name": "completed_manage_tour",

--- a/packages/db/migrations/postgresql/0014_add_header_preferences_and_branding.sql
+++ b/packages/db/migrations/postgresql/0014_add_header_preferences_and_branding.sql
@@ -1,4 +1,4 @@
-ALTER TABLE "user" ADD COLUMN "header_preferences" text DEFAULT '{"version":3,"visible":true,"searchDisplay":"input","logoDisplay":"logo","zones":{"left":[{"type":"builtin","id":"logo"}],"center":[{"type":"builtin","id":"search"}],"right":[{"type":"builtin","id":"boardEdit"},{"type":"builtin","id":"boardSettings"},{"type":"builtin","id":"user"}]}}' NOT NULL;
+ALTER TABLE "user" ADD COLUMN "header_preferences" text DEFAULT '{"version":3,"visible":true,"searchDisplay":"input","logoDisplay":"logoAndText","zones":{"left":[{"type":"builtin","id":"logo"}],"center":[{"type":"builtin","id":"search"}],"right":[{"type":"builtin","id":"boardEdit"},{"type":"builtin","id":"boardSettings"},{"type":"builtin","id":"user"}]}}' NOT NULL;
 --> statement-breakpoint
 INSERT INTO "serverSetting" ("setting_key", "value")
 VALUES ('branding', '{"json":{"appName":"Homarr","greeting":"","logoImageUrl":null,"faviconImageUrl":null,"primaryColor":"#fa5252","secondaryColor":"#fd7e14","lockPrimaryColor":false,"signInBackgroundImageUrl":null,"signInBackgroundOverlay":0.55,"authBranding":{"showAppName":true,"showLogo":true,"showGreeting":true},"defaultRadius":"md"}}')

--- a/packages/db/migrations/postgresql/meta/0014_snapshot.json
+++ b/packages/db/migrations/postgresql/meta/0014_snapshot.json
@@ -2485,7 +2485,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'{\"version\":3,\"visible\":true,\"searchDisplay\":\"input\",\"logoDisplay\":\"logo\",\"zones\":{\"left\":[{\"type\":\"builtin\",\"id\":\"logo\"}],\"center\":[{\"type\":\"builtin\",\"id\":\"search\"}],\"right\":[{\"type\":\"builtin\",\"id\":\"boardEdit\"},{\"type\":\"builtin\",\"id\":\"boardSettings\"},{\"type\":\"builtin\",\"id\":\"user\"}]}}'"
+          "default": "'{\"version\":3,\"visible\":true,\"searchDisplay\":\"input\",\"logoDisplay\":\"logoAndText\",\"zones\":{\"left\":[{\"type\":\"builtin\",\"id\":\"logo\"}],\"center\":[{\"type\":\"builtin\",\"id\":\"search\"}],\"right\":[{\"type\":\"builtin\",\"id\":\"boardEdit\"},{\"type\":\"builtin\",\"id\":\"boardSettings\"},{\"type\":\"builtin\",\"id\":\"user\"}]}}'"
         },
         "completed_manage_tour": {
           "name": "completed_manage_tour",

--- a/packages/db/migrations/sqlite/0046_add_header_preferences_and_branding.sql
+++ b/packages/db/migrations/sqlite/0046_add_header_preferences_and_branding.sql
@@ -1,4 +1,4 @@
-ALTER TABLE `user` ADD `header_preferences` text DEFAULT '{"version":3,"visible":true,"searchDisplay":"input","logoDisplay":"logo","zones":{"left":[{"type":"builtin","id":"logo"}],"center":[{"type":"builtin","id":"search"}],"right":[{"type":"builtin","id":"boardEdit"},{"type":"builtin","id":"boardSettings"},{"type":"builtin","id":"user"}]}}' NOT NULL;
+ALTER TABLE `user` ADD `header_preferences` text DEFAULT '{"version":3,"visible":true,"searchDisplay":"input","logoDisplay":"logoAndText","zones":{"left":[{"type":"builtin","id":"logo"}],"center":[{"type":"builtin","id":"search"}],"right":[{"type":"builtin","id":"boardEdit"},{"type":"builtin","id":"boardSettings"},{"type":"builtin","id":"user"}]}}' NOT NULL;
 --> statement-breakpoint
 INSERT INTO `serverSetting` (`setting_key`, `value`)
 VALUES ('branding', '{"json":{"appName":"Homarr","greeting":"","logoImageUrl":null,"faviconImageUrl":null,"primaryColor":"#fa5252","secondaryColor":"#fd7e14","lockPrimaryColor":false,"signInBackgroundImageUrl":null,"signInBackgroundOverlay":0.55,"authBranding":{"showAppName":true,"showLogo":true,"showGreeting":true},"defaultRadius":"md"}}')

--- a/packages/db/migrations/sqlite/meta/0046_snapshot.json
+++ b/packages/db/migrations/sqlite/meta/0046_snapshot.json
@@ -2551,7 +2551,7 @@
           "primaryKey": false,
           "notNull": true,
           "autoincrement": false,
-          "default": "'{\"version\":3,\"visible\":true,\"searchDisplay\":\"input\",\"logoDisplay\":\"logo\",\"zones\":{\"left\":[{\"type\":\"builtin\",\"id\":\"logo\"}],\"center\":[{\"type\":\"builtin\",\"id\":\"search\"}],\"right\":[{\"type\":\"builtin\",\"id\":\"boardEdit\"},{\"type\":\"builtin\",\"id\":\"boardSettings\"},{\"type\":\"builtin\",\"id\":\"user\"}]}}'"
+          "default": "'{\"version\":3,\"visible\":true,\"searchDisplay\":\"input\",\"logoDisplay\":\"logoAndText\",\"zones\":{\"left\":[{\"type\":\"builtin\",\"id\":\"logo\"}],\"center\":[{\"type\":\"builtin\",\"id\":\"search\"}],\"right\":[{\"type\":\"builtin\",\"id\":\"boardEdit\"},{\"type\":\"builtin\",\"id\":\"boardSettings\"},{\"type\":\"builtin\",\"id\":\"user\"}]}}'"
         },
         "completed_manage_tour": {
           "name": "completed_manage_tour",

--- a/packages/validation/src/header-preferences.ts
+++ b/packages/validation/src/header-preferences.ts
@@ -104,7 +104,7 @@ export const headerPreferencesSchema = z
     version: z.literal(headerPreferencesVersion),
     visible: z.boolean(),
     searchDisplay: z.enum(headerSearchDisplayValues),
-    logoDisplay: z.enum(headerLogoDisplayValues).default("logo"),
+    logoDisplay: z.enum(headerLogoDisplayValues).default("logoAndText"),
     zones: headerZonesSchema,
   })
   .strict();
@@ -154,7 +154,7 @@ const migrateLegacyItems = (
   version: headerPreferencesVersion,
   visible,
   searchDisplay: "input",
-  logoDisplay: "logo",
+  logoDisplay: "logoAndText",
   zones: {
     left: zones.left.map(createBuiltinHeaderItem),
     center: zones.center.map(createBuiltinHeaderItem),
@@ -208,7 +208,7 @@ export const defaultHeaderPreferences = {
   version: headerPreferencesVersion,
   visible: true,
   searchDisplay: "input",
-  logoDisplay: "logo",
+  logoDisplay: "logoAndText",
   zones: {
     left: [createBuiltinHeaderItem("logo")],
     center: [createBuiltinHeaderItem("search")],


### PR DESCRIPTION
## Summary
- prevent configurable header zones from clipping account indicators
- default logo header items to the logo and text variant across validation and database migrations
- sync migration snapshots and the generated OpenAPI default

## Validation
- browser-verified before and after on a writable SQLite demo
- HTTP 200 and HMR WebSocket 101 verified
- tests, lint, and builds not run by request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated default header branding to display both the logo and accompanying text.

* **Bug Fixes**
  * Standardized logo display defaults across supported databases, API documentation, and preference handling.
  * Improved header layout sizing and added end padding while preserving horizontal overflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->