### PR TITLE
fix: preserve board item radius while scaling

### DIFF
--- a/apps/nextjs/src/components/board/layout/scaled-board-canvas.module.css
+++ b/apps/nextjs/src/components/board/layout/scaled-board-canvas.module.css
@@ -23,6 +23,11 @@
    * zoom and enlarges everything together.
    */
   --mantine-scale: var(--board-canvas-ui-scale, 1);
+  --mantine-radius-xs: calc(0.25rem * var(--board-canvas-inverse-scale, 1));
+  --mantine-radius-sm: calc(0.25rem * var(--board-canvas-inverse-scale, 1));
+  --mantine-radius-md: calc(0.5rem * var(--board-canvas-inverse-scale, 1));
+  --mantine-radius-lg: calc(0.75rem * var(--board-canvas-inverse-scale, 1));
+  --mantine-radius-xl: calc(1rem * var(--board-canvas-inverse-scale, 1));
   /* Keep a subtle boundary inset without widening the visual gap too much. */
   --board-grid-item-inset: calc(var(--mantine-spacing-xs) / 2);
   --mantine-spacing-xs: calc(0.625rem * var(--board-canvas-ui-scale, 1));


### PR DESCRIPTION
## Summary

- compensate Mantine radius tokens inside the existing fixed board canvas
- keep the current canvas scaling behavior unchanged
- keep the global Mantine radius defaults unchanged

## Verification

- verified the real board at canvas scale `0.4509`
- verified `xs`, `sm`, `md`, `lg`, and `xl` render physically as `4`, `4`, `8`, `12`, and `16px`
- ran oxfmt and `git diff --check`
- tests not run for this CSS-only change
