### PR TITLE
fix(startup): stop relying on Docker hostname resolution

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,7 +9,7 @@ http {
 
         # Route websockets traffic to port 3001
         location /websockets {
-            proxy_pass http://${HOSTNAME}:3001;
+            proxy_pass http://127.0.0.1:3001;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "Upgrade";
@@ -18,7 +18,7 @@ http {
 
         # Route all other traffic to port 3000
         location / {
-            proxy_pass http://${HOSTNAME}:3000;
+            proxy_pass http://127.0.0.1:3000;
             proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -43,7 +43,7 @@ async function importCookiesAsync() {
 
 function getBaseUrl() {
   if (typeof window !== "undefined") return window.location.origin;
-  return `http://${process.env.HOSTNAME ?? "localhost"}:3000`;
+  return "http://127.0.0.1:3000";
 }
 
 export const trpcPath = "/api/trpc";

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -21,20 +21,18 @@ fi
 export AUTH_SECRET=$(openssl rand -base64 32)
 
 # Start nginx proxy
-# 1. Replace the HOSTNAME in the nginx template file
-# 2. Create the nginx configuration file from the template
-# 3. Start the nginx server
+# 1. Create the nginx configuration file from the template
+# 2. Start the nginx server
 # Only listen on IPv6 when the host actually has IPv6 configured (#4596).
 # Otherwise nginx aborts with "socket() [::]:7575 failed (97: Address family
 # not supported by protocol)". Check HOMARR_DISABLE_IPV6 first so users can
 # force IPv4-only even when the host supports IPv6, then probe for IPv6
 # addresses via grep (not -s: proc files always report size 0).
-export HOSTNAME
 export NGINX_LISTEN_IPV6=''
 if [ "${HOMARR_DISABLE_IPV6:-false}" != "true" ] && grep -q . /proc/net/if_inet6 2>/dev/null; then
     NGINX_LISTEN_IPV6='listen [::]:7575;'
 fi
-envsubst '${HOSTNAME} ${NGINX_LISTEN_IPV6}' < /etc/nginx/templates/nginx.conf > /etc/nginx/nginx.conf
+envsubst '${NGINX_LISTEN_IPV6}' < /etc/nginx/templates/nginx.conf > /etc/nginx/nginx.conf
 # Start services in the background and store their PIDs
 nginx -g 'daemon off;' &
 NGINX_PID=$!
@@ -67,6 +65,9 @@ terminate() {
 
 trap terminate TERM INT
 
+# Next.js standalone uses HOSTNAME as its bind address. Docker's generated
+# hostname can be unresolvable, so bind explicitly while nginx uses loopback.
+export HOSTNAME=0.0.0.0
 node apps/nextjs/server.js &
 NEXTJS_PID=$!
 


### PR DESCRIPTION
## Summary

- bind the Next.js standalone server to `0.0.0.0` instead of Docker's generated hostname
- route nginx and server-side tRPC to deterministic IPv4 loopback addresses
- remove nginx hostname substitution from container startup

## Root cause

The container used Docker's `HOSTNAME` as the Next.js bind address, both nginx upstreams, and the server-side tRPC target. When the runtime does not resolve its generated 12-character hostname, nginx fails with `host not found in upstream` and Next.js fails with `getaddrinfo EAI_AGAIN`.

No v1.76 PR is a valid revert target. In particular, #6598 only changes the custom PUID/PGID ownership branch, which is skipped in the reported UID/GID 0 startup. The fragile hostname routing predates v1.75.

## Validation

- built commit `9e14027b4` as a full local Docker image with the repo-native build command
- reproduced both exact errors against official `latest` through Compose with the reported 12-character hostname
- confirmed the local image starts with the default documented Compose environment: live/ready `/init` `200`, WebSocket `101`, and Docker socket available
- confirmed the same results under the forced failing hostname, with Next.js bound to `0.0.0.0` and nginx upstreams on `127.0.0.1`
- reused appdata migrated by the broken image and confirmed startup plus a full container restart
- `bash -n scripts/run.sh`
- focused oxfmt and server-side tRPC URL checks

The Docker build completed successfully with existing Next.js/Turbopack warnings. Broad test suites were not run.

- [ ] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the conventional commits guideline
- [x] No shorthand variable names are used
- [x] Documentation is up to date (no public configuration changed)
- [x] No temporary files are checked in and code style follows the repository


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local routing for web traffic and WebSocket connections.
  * Ensured the application server remains accessible from external interfaces while reverse-proxy requests use the local loopback address.
  * Removed reliance on hostname configuration for internal server requests, improving connection consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
