### PR TITLE
fix(calendar): keep date numbers aligned regardless of indicator dots

### DIFF
--- a/packages/widgets/src/calendar/calender-day.tsx
+++ b/packages/widgets/src/calendar/calender-day.tsx
@@ -95,7 +95,7 @@ const NotificationIndicator = ({ events, size, marginTop, visible }: Notificatio
     (color): color is string => Boolean(color),
   );
 
-  if (!visible || notificationEvents.length === 0) return null;
+  if (!visible) return null;
 
   return (
     <Flex


### PR DESCRIPTION
NotificationIndicator returned null when a day had no events with an indicatorColor, so the flex column's justify-content: center centered just the date text for those days instead of the text+dot pair every other day gets - shifting empty-day numbers down relative to days with a dot underneath them.

Always render the (possibly empty) indicator row whenever the widget is tall enough to show indicators at all, so every cell reserves the same vertical space and every date number lands on the same line.


- [x] Builds without warnings or errors (`pnpm build`, autofix with `pnpm format:fix`)
- [x] Pull request targets `dev` branch
- [x] Commits follow the [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] No shorthand variable names are used (eg. `x`, `y`, `i` or any abbrevation)
- [x] Documentation is up to date. Create a pull request [here](https://github.com/homarr-labs/documentation/).
- [x] When using AI; No temp files are checked in, the code style follows the rest of the project

**When contributing a new integration or widget:**

- [x] I confirmed manually that the integration or widget is working with a real system and performed basic smoke
  tests (e.g. what happens if it is offline)
- [x] Optional but recommended: I confirm that I am willing to be added to the `CODEOWNERS` of this feature and will
  provide support and maintain the integration (e.g. in case of breaking or failure)