### PR TITLE
fix(docs): generate valid integration links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,378 +62,378 @@
 <tr><td align="center">
 <a href="https://homarr.dev/docs/integrations/adguard-home" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/adguard-home.svg" alt="AdGuard Home" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">AdGuard<br/>Home</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/anchor" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/anchor.svg" alt="Anchor" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Anchor</p>
 </a>
 </td>
 <td align="center">
-<a href="null" target="_blank" rel="noreferrer noopener">
+<a href="https://homarr.dev/docs/integrations/archiveteam-warrior" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/png/archiveteam-warrior.png" alt="ArchiveTeam Warrior" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">ArchiveTeam<br/>Warrior</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/aria2" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/PapirusDevelopmentTeam/papirus_icons@latest/src/system_downloads_3.svg" alt="Aria2" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Aria2</p>
 </a>
 </td>
 <td align="center">
-<a href="null" target="_blank" rel="noreferrer noopener">
+<a href="https://homarr.dev/docs/integrations/audiobookshelf" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/audiobookshelf.svg" alt="Audiobookshelf" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Audiobookshelf</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/bazarr" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/bazarr.svg" alt="Bazarr" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Bazarr</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/beszel" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/beszel.svg" alt="Beszel" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Beszel</p>
 </a>
 </td></tr>
 <tr><td align="center">
 <a href="https://homarr.dev/docs/integrations/coolify" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/coolify.svg" alt="Coolify" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Coolify</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/dash-dot" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/png/dashdot.png" alt="Dash." width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Dash.</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/deluge" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/deluge.svg" alt="Deluge" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Deluge</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/emby" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/emby.svg" alt="Emby" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Emby</p>
 </a>
 </td>
 <td align="center">
-<a href="null" target="_blank" rel="noreferrer noopener">
+<a href="https://homarr.dev/docs/integrations/glances" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/glances.svg" alt="Glances" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Glances</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/gluetun" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/gluetun.svg" alt="Gluetun" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Gluetun</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/gotify" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/gotify.svg" alt="Gotify" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Gotify</p>
 </a>
 </td></tr>
 <tr><td align="center">
 <a href="https://homarr.dev/docs/integrations/home-assistant" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/home-assistant.svg" alt="Home Assistant" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Home<br/>Assistant</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/ical" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/ical.svg" alt="iCal" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">iCal</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/immich" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/immich.svg" alt="Immich" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Immich</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/jellyfin" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/jellyfin.svg" alt="Jellyfin" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Jellyfin</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/jellyseerr" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/jellyseerr.svg" alt="Jellyseerr" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Jellyseerr</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/lidarr" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/lidarr.svg" alt="Lidarr" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Lidarr</p>
 </a>
 </td>
 <td align="center">
-<a href="null" target="_blank" rel="noreferrer noopener">
+<a href="https://homarr.dev/docs/integrations/navidrome" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/navidrome.svg" alt="Navidrome" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Navidrome</p>
 </a>
 </td></tr>
 <tr><td align="center">
 <a href="https://homarr.dev/docs/integrations/nextcloud" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/nextcloud.svg" alt="Nextcloud" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Nextcloud</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/ntfy" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/ntfy.svg" alt="ntfy" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">ntfy</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/nzbget" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/nzbget.svg" alt="NZBGet" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">NZBGet</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/open-media-vault" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/openmediavault.svg" alt="OpenMediaVault" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">OpenMediaVault</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/opnsense" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/opnsense.svg" alt="OPNsense" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">OPNsense</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/overseerr" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/overseerr.svg" alt="Overseerr" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Overseerr</p>
 </a>
 </td>
 <td align="center">
-<a href="null" target="_blank" rel="noreferrer noopener">
+<a href="https://homarr.dev/docs/integrations/paperless-ngx" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/paperless-ngx.svg" alt="Paperless-ngx" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Paperless-ngx</p>
 </a>
 </td></tr>
 <tr><td align="center">
 <a href="https://homarr.dev/docs/integrations/patchmon" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/patchmon.svg" alt="PatchMon" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">PatchMon</p>
 </a>
 </td>
 <td align="center">
-<a href="null" target="_blank" rel="noreferrer noopener">
+<a href="https://homarr.dev/docs/integrations/peanut" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/peanut.svg" alt="PeaNUT" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">PeaNUT</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/pi-hole" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/pi-hole.svg" alt="Pi-hole" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Pi-hole</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/plex" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/plex.svg" alt="Plex" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Plex</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/prowlarr" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/prowlarr.svg" alt="Prowlarr" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Prowlarr</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/proxmox" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/proxmox.svg" alt="Proxmox" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Proxmox</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/q-bittorent" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/qbittorrent.svg" alt="qBittorrent" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">qBittorrent</p>
 </a>
 </td></tr>
 <tr><td align="center">
 <a href="https://homarr.dev/docs/integrations/radarr" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/radarr.svg" alt="Radarr" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Radarr</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/readarr" target="_blank" rel="noreferrer noopener">
-  <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/readarr.svg" alt="Readarr" width="90" height="90" />
-  <br/>  
+  <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@main/png/readarr.png" alt="Readarr" width="90" height="90" />
+  <br/>
   <p align="center">Readarr</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/sabnzbd" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/sabnzbd.svg" alt="SABnzbd" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">SABnzbd</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/seerr" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/seerr.svg" alt="Seerr" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Seerr</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/slskd" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/slskd.svg" alt="Slskd" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Slskd</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/sonarr" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/sonarr.svg" alt="Sonarr" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Sonarr</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/speedtest-tracker" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/speedtest-tracker.png" alt="Speedtest Tracker" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Speedtest<br/>Tracker</p>
 </a>
 </td></tr>
 <tr><td align="center">
 <a href="https://homarr.dev/docs/integrations/synology" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/synology.svg" alt="Synology DiskStation" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Synology<br/>DiskStation</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/tdarr" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/png/tdarr.png" alt="Tdarr" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Tdarr</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/technitium-dns" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/technitium.svg" alt="Technitium DNS" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Technitium<br/>DNS</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/tracearr" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/tracearr.svg" alt="Tracearr" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Tracearr</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/traefik" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/traefik.svg" alt="Traefik" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Traefik</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/transmission" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/transmission.svg" alt="Transmission" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Transmission</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/truenas" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/truenas.svg" alt="TrueNAS" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">TrueNAS</p>
 </a>
 </td></tr>
 <tr><td align="center">
 <a href="https://homarr.dev/docs/integrations/umami" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/umami.svg" alt="Umami" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Umami</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/unifi-controller" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/png/unifi.png" alt="Unifi Controller" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Unifi<br/>Controller</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/unraid" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/unraid.svg" alt="Unraid" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Unraid</p>
 </a>
 </td>
 <td align="center">
-<a href="null" target="_blank" rel="noreferrer noopener">
+<a href="https://homarr.dev/docs/integrations/uptime-kuma" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/uptime-kuma.svg" alt="Uptime Kuma" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">Uptime<br/>Kuma</p>
 </a>
 </td>
 <td align="center">
 <a href="https://homarr.dev/docs/integrations/whats-up-docker" target="_blank" rel="noreferrer noopener">
   <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@master/svg/whats-up-docker.svg" alt="What's Up Docker" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">What's<br/>Up<br/>Docker</p>
 </a>
 </td></tr>

--- a/scripts/update-integration-list.mts
+++ b/scripts/update-integration-list.mts
@@ -1,5 +1,9 @@
 import { readFile, writeFile } from "fs/promises";
-import { integrationDefs } from "../packages/definitions/src/integration";
+import {
+  getIntegrationDocumentationUrl,
+  integrationDefs,
+  integrationKinds,
+} from "../packages/definitions/src/integration";
 
 const FILE = "docs/README.md";
 const MAX_COLUMNS_PER_ROW = 7;
@@ -21,19 +25,29 @@ async function updateIntegrationList() {
   }
 
   // Generate the new integration list
-  const integrations = Object.values(integrationDefs)
-    .filter((def) => def.name !== "Mock")
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const integrations = integrationKinds
+    .filter((kind) => kind !== "mock")
+    .map((kind) => ({
+      ...integrationDefs[kind],
+      documentationUrl: getIntegrationDocumentationUrl(kind),
+    }))
+    .toSorted((a, b) => a.name.localeCompare(b.name));
   const tableRows: string[] = [];
   let currentRow: string[] = [];
 
   integrations.forEach((integration) => {
-    currentRow.push(`<td align="center">
-<a href="${integration.documentationUrl}" target="_blank" rel="noreferrer noopener">
+    const cellBody = `
   <img src="${integration.iconUrl}" alt="${integration.name}" width="90" height="90" />
-  <br/>  
+  <br/>
   <p align="center">${integration.name.replaceAll(" ", "<br/>")}</p>
-</a>
+`;
+    let cellContent = `<div>${cellBody}</div>`;
+    if (integration.documentationUrl !== null) {
+      cellContent = `<a href="${integration.documentationUrl}" target="_blank" rel="noreferrer noopener">${cellBody}</a>`;
+    }
+
+    currentRow.push(`<td align="center">
+${cellContent}
 </td>`);
 
     if (currentRow.length === MAX_COLUMNS_PER_ROW) {
@@ -67,4 +81,7 @@ ${endMarker}`;
   await writeFile(FILE, newContent, "utf8");
 }
 
-updateIntegrationList().catch(console.error);
+updateIntegrationList().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- derive integration documentation URLs through the canonical definitions helper
- keep integrations without documentation visible without emitting invalid links
- regenerate the integration README with 54 valid documentation URLs
- make generator errors fail the process instead of being logged as success

## Validation

- generator executed twice with an identical output hash
- zero href null or href undefined values
- oxfmt check
- oxlint with warnings denied
- git diff --check