### PR TITLE
fix(backup): prompt re-login after restore

### DIFF
--- a/apps/docs/docs/management/backup.mdx
+++ b/apps/docs/docs/management/backup.mdx
@@ -30,8 +30,9 @@ needed to restore encrypted integration credentials.
 Select a Homarr backup ZIP. The browser previews entity counts, board names, and required database migrations before
 the archive is uploaded.
 
-Restoring replaces the current SQLite database and cannot be undone. After a successful restore, the Next.js process
-restarts and the page reloads when Homarr is ready.
+Restoring replaces the current SQLite database and cannot be undone. It also invalidates the current database session.
+After a successful management restore, Homarr waits for the restarted server and sends the administrator to sign in
+again. The first-run onboarding restore keeps its existing board destination.
 
 A backup can be restored on another Homarr instance. When its `SECRET_ENCRYPTION_KEY` differs, Homarr re-encrypts stored
 integration secrets for the target instance. Version metadata is used to apply compatible migrations.

--- a/apps/nextjs/src/components/backup/database-restore-flow.tsx
+++ b/apps/nextjs/src/components/backup/database-restore-flow.tsx
@@ -204,8 +204,12 @@ export const DatabaseRestoreFlow = ({ variant = "card", onRestoreComplete }: Dat
     }
 
     onRestoreComplete?.();
-    const destination =
-      variant === "standalone" && homeBoardName ? `/boards/${encodeURIComponent(homeBoardName)}` : null;
+    let destination: string | null = null;
+    if (variant === "standalone" && homeBoardName) {
+      destination = `/boards/${encodeURIComponent(homeBoardName)}`;
+    } else if (variant === "card") {
+      destination = "/auth/login";
+    }
     startReadinessCheck(restartAfterMs, destination);
   }, [file, onRestoreComplete, startReadinessCheck, t, variant]);
 
@@ -317,6 +321,7 @@ export const DatabaseRestoreFlow = ({ variant = "card", onRestoreComplete }: Dat
       <RestoreProgressPanel
         active
         status={restoreStatus}
+        reloginRequired={variant === "card"}
         onRetry={() => startReadinessCheck(0)}
         onReload={() => window.location.reload()}
       />

--- a/apps/nextjs/src/components/backup/restore-progress-panel.tsx
+++ b/apps/nextjs/src/components/backup/restore-progress-panel.tsx
@@ -11,11 +11,18 @@ export type RestoreProgressStatus = "restoring" | "restarting" | "timedOut";
 interface RestoreProgressPanelProps {
   active: boolean;
   status: RestoreProgressStatus;
+  reloginRequired?: boolean;
   onRetry: () => void;
   onReload: () => void;
 }
 
-export const RestoreProgressPanel = ({ active, status, onRetry, onReload }: RestoreProgressPanelProps) => {
+export const RestoreProgressPanel = ({
+  active,
+  status,
+  reloginRequired = false,
+  onRetry,
+  onReload,
+}: RestoreProgressPanelProps) => {
   const t = useI18n("management.page.tool.backup.restore");
   const tCommon = useI18n("common");
   const reduceMotion = useReducedMotion();
@@ -62,6 +69,12 @@ export const RestoreProgressPanel = ({ active, status, onRetry, onReload }: Rest
             </Text>
           </div>
         </Group>
+
+        {reloginRequired && !isRestoring ? (
+          <Text size="sm" c="dimmed">
+            {t("progress.relogin")}
+          </Text>
+        ) : null}
 
         {isTimedOut ? (
           <Group>

--- a/packages/translation/src/lang/en.json
+++ b/packages/translation/src/lang/en.json
@@ -6456,7 +6456,8 @@
             },
             "progress": {
               "title": "Restoring database...",
-              "restarting": "Restarting server"
+              "restarting": "Restarting server",
+              "relogin": "Restoring the database invalidated your current session. Homarr will send you to sign in when the server is ready."
             },
             "timeout": {
               "title": "Server did not come back online",


### PR DESCRIPTION
## What changed

- keep v2’s existing readiness polling after a SQLite restore
- explain that a management restore invalidates the current database session
- once Homarr is ready, send the administrator to `/auth/login` instead of silently reloading the stale management page
- retain the first-run onboarding restore’s existing board destination
- update the backup documentation

## Why

This is the minimal v2 port of the user-facing behavior from #6624. That PR contains unrelated branch drift and should not be merged wholesale.

## Validation

- focused restore-flow tests: 2 files, 5 tests passed
- `@homarr/nextjs` and `@homarr/translation` typechecks passed
- Docusaurus production build passed
- focused oxfmt and `git diff --check` passed

A final real backup/restore/re-login rehearsal is still required on the immutable release candidate.