### PR TITLE
fix(unraid): use byte-based memory metrics

### DIFF
--- a/packages/integrations/src/unraid/unraid-integration.ts
+++ b/packages/integrations/src/unraid/unraid-integration.ts
@@ -39,9 +39,8 @@ export class UnraidIntegration extends Integration implements ISystemHealthMonit
     const cpuUtilization = systemInfo.metrics.cpu.cpus.reduce((acc, val) => acc + val.percentTotal, 0);
     const cpuCount = systemInfo.info.cpu.cores;
 
-    // We use "info" object instead of the stats since this is the exact amount the kernel sees, which is what Unraid displays.
-    const totalMemory = systemInfo.info.memory.layout.reduce((acc, layout) => layout.size + acc, 0);
-    const usedMemory = totalMemory * (systemInfo.metrics.memory.percentTotal / 100);
+    const totalMemory = systemInfo.metrics.memory.total;
+    const usedMemory = Math.max(totalMemory - systemInfo.metrics.memory.available, 0);
     const uptime = dayjs(systemInfo.info.os.uptime);
 
     return {
@@ -136,11 +135,6 @@ export class UnraidIntegration extends Integration implements ISystemHealthMonit
             brand,
             cores,
             threads
-          },
-          memory {
-            layout {
-              size     
-            }
           }
         }
       }

--- a/packages/integrations/src/unraid/unraid-types.ts
+++ b/packages/integrations/src/unraid/unraid-types.ts
@@ -60,13 +60,6 @@ export const unraidSystemInfoSchema = z.object({
       cores: z.number(),
       threads: z.number(),
     }),
-    memory: z.object({
-      layout: z.array(
-        z.object({
-          size: z.number(),
-        }),
-      ),
-    }),
   }),
 });
 


### PR DESCRIPTION
## What

- calculate Unraid memory from `metrics.memory.total` and `metrics.memory.available`, which are reported in bytes
- clamp used memory to zero for inconsistent upstream values
- stop querying and validating `info.memory.layout`, whose units vary across Unraid versions

This is the minimal `release/v2` port of #6749 without duplicating its regression-test file. That PR's two focused tests and hosted CI are already green; this port was revalidated against the current v2 integration.

Closes #6745.

## Verification

- `pnpm turbo typecheck --filter=@homarr/integrations`
- synthetic 32 GiB total / 20 GiB available response produced 12 GiB used and 20 GiB available
- inconsistent 32 GiB total / 40 GiB available response produced 0 GiB used and capped available memory at 32 GiB
