### PR TITLE
fix(docker): normalize container CPU usage

### DIFF
--- a/packages/request-handler/src/docker.ts
+++ b/packages/request-handler/src/docker.ts
@@ -481,13 +481,14 @@ export function calculateCpuUsage(stats: ContainerStats): number {
     return 0;
   }
 
-  const numberOfCpus = stats.cpu_stats.online_cpus;
-  const usage = stats.cpu_stats.system_cpu_usage;
-  if (!usage || usage === 0) {
+  const cpuDelta = stats.cpu_stats.cpu_usage.total_usage - (stats.precpu_stats?.cpu_usage?.total_usage ?? 0);
+  const systemDelta = (stats.cpu_stats.system_cpu_usage ?? 0) - (stats.precpu_stats?.system_cpu_usage ?? 0);
+
+  if (systemDelta <= 0 || cpuDelta < 0) {
     return 0;
   }
 
-  return (stats.cpu_stats.cpu_usage.total_usage / usage) * numberOfCpus * 100;
+  return (cpuDelta / systemDelta) * 100;
 }
 
 export function calculateMemoryUsage(stats: ContainerStats): number {

--- a/packages/request-handler/src/test/docker.spec.ts
+++ b/packages/request-handler/src/test/docker.spec.ts
@@ -72,16 +72,16 @@ describe("calculateCpuUsage", () => {
     const stats = createStats({
       cpu_stats: { online_cpus: 4, cpu_usage: { total_usage: 2000 }, system_cpu_usage: 10000 },
     });
-    // (2000 / 10000) * 4 * 100 = 80
-    expect(calculateCpuUsage(stats)).toBe(80);
+    // (2000 / 10000) * 100 = 20
+    expect(calculateCpuUsage(stats)).toBe(20);
   });
 
   test("should handle fractional CPU usage", () => {
     const stats = createStats({
       cpu_stats: { online_cpus: 2, cpu_usage: { total_usage: 500 }, system_cpu_usage: 100000 },
     });
-    // (500 / 100000) * 2 * 100 = 1
-    expect(calculateCpuUsage(stats)).toBe(1);
+    // (500 / 100000) * 100 = 0.5
+    expect(calculateCpuUsage(stats)).toBe(0.5);
   });
 });
 


### PR DESCRIPTION
## What

- report Docker container CPU as a 0-100% share of the whole machine instead of Docker's per-core scale
- use current/previous counter deltas when `precpu_stats` is available
- preserve cumulative fallback behavior for one-shot and Podman responses without previous counters
- update existing calculation expectations to the normalized scale

This is the focused current-v2 port of #6250. It keeps the current one-shot collection behavior that was restored by #6357, so no extra per-refresh sampling delay is introduced.

## Verification

- `pnpm vitest run packages/request-handler/src/test/docker.spec.ts` (20 passed)
- `pnpm turbo typecheck --filter=@homarr/request-handler`
- synthetic checks: cumulative fallback 20%, delta 20%, idle 0%, full-machine boundary 100%
