### PR TITLE
fix(downloads): preserve name column width

### DIFF
--- a/packages/widgets/src/downloads/component.tsx
+++ b/packages/widgets/src/downloads/component.tsx
@@ -493,6 +493,7 @@ export default function DownloadClientsWidget({
         title: t("items.name.columnTitle"),
         sortable: true,
         ellipsis: true,
+        width: 240,
         render: (record) => (
           <Tooltip
             key={displayMode}


### PR DESCRIPTION
## Summary

- give the Downloads job-name column a stable 240 px default width
- prevent optional columns from squeezing names down to an unreadable sliver
- keep the existing user-resizable and persisted column behavior unchanged

This is the focused current-v2 port of #6621 and supersedes the broader, conflicting #6122 approach.

## Verification

- `node_modules/.bin/tsc --project packages/widgets/tsconfig.json --noEmit`
- `git diff --check`

## Release readiness

This resolves the still-reproducible layout defect from #4157 without widening release scope.
