### PR TITLE
feat(auth): support nested OIDC claim paths

### DIFF
--- a/apps/docs/docs/advanced/single-sign-on/index.mdx
+++ b/apps/docs/docs/advanced/single-sign-on/index.mdx
@@ -202,9 +202,9 @@ Homarr supports multiple authentication options, from internal userbase (credent
     | ``AUTH_OIDC_CLIENT_NAME``   | Display name of provider (in login screen)                 | OIDC          |
     | ``AUTH_OIDC_AUTO_LOGIN``    | Automatically redirect to OIDC login                       | false         |
     | ``AUTH_OIDC_SCOPE_OVERWRITE`` | Overwrite default scopes (openid, profile, email)        | openid email profile groups           |
-    | ``AUTH_OIDC_GROUPS_ATTRIBUTE`` | Attribute used for groups (roles) claim                  | groups        |
+    | ``AUTH_OIDC_GROUPS_ATTRIBUTE`` | Attribute used for groups (roles) claim. Dot-separated paths such as `resource_access.homarr.roles` are supported. | groups        |
     | ``AUTH_OIDC_GROUPS_LOCAL_MANAGEMENT`` | Stop syncing group memberships of OIDC users from the groups claim and manage them locally via the group members page instead | false |
-    | ``AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE`` | Overwrite name attribute. By default it will use preferred_username if it does not contain a `@` and otherwise name. | ---          |
+    | ``AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE`` | Overwrite name attribute. Dot-separated paths are supported. By default it will use preferred_username if it does not contain a `@` and otherwise name. | ---          |
     | ``AUTH_OIDC_FORCE_USERINFO`` | Force userinfo endpoint to be used for user information.    | false         |
     | ``AUTH_OIDC_ENABLE_DANGEROUS_ACCOUNT_LINKING`` | Enable account linking for OIDC provider. This will link the OIDC accounts by email. Be sure that you have verified emails to prevent stealing accounts. | false |
     | ``AUTH_OIDC_ENABLE_DANGEROUS_CREDENTIALS_LINKING`` | Link an OIDC identity to an existing credentials user with the same email. The credentials login and existing user data are preserved. Requires the OIDC profile to contain `email_verified: true`. | false |

--- a/packages/auth/events.ts
+++ b/packages/auth/events.ts
@@ -9,7 +9,7 @@ import { groupMembers, groups, users } from "@homarr/db/schema";
 import { colorSchemeCookieKey, everyoneGroup } from "@homarr/definitions";
 
 import { env } from "./env";
-import { extractProfileName } from "./providers/oidc/oidc-provider";
+import { extractProfileName, getProfileValueByPath } from "./providers/oidc/profile";
 
 const logger = createLogger({ module: "authEvents" });
 
@@ -31,16 +31,11 @@ export const createSignInEventHandler = (db: Database): Exclude<NextAuthConfig["
     if (!dbUser) throw new Error("User not found");
 
     const groupsKey = env.AUTH_OIDC_GROUPS_ATTRIBUTE;
+    const profileGroups = profile ? getProfileValueByPath(profile, groupsKey) : undefined;
     // Groups from oidc provider are provided from the profile, it's not typed.
-    if (
-      !env.AUTH_OIDC_GROUPS_LOCAL_MANAGEMENT &&
-      dbUser.provider === "oidc" &&
-      profile &&
-      groupsKey in profile &&
-      Array.isArray(profile[groupsKey])
-    ) {
-      logger.debug(`Using profile groups (${groupsKey}): ${JSON.stringify(profile[groupsKey])}`);
-      await synchronizeGroupsWithExternalForUserAsync(db, user.id, profile[groupsKey] as string[]);
+    if (!env.AUTH_OIDC_GROUPS_LOCAL_MANAGEMENT && dbUser.provider === "oidc" && Array.isArray(profileGroups)) {
+      logger.debug(`Using profile groups (${groupsKey}): ${JSON.stringify(profileGroups)}`);
+      await synchronizeGroupsWithExternalForUserAsync(db, user.id, profileGroups as string[]);
     }
 
     // In ldap-authroization we return the groups from ldap, it's not typed.

--- a/packages/auth/providers/oidc/oidc-provider.ts
+++ b/packages/auth/providers/oidc/oidc-provider.ts
@@ -7,6 +7,7 @@ import { fetchWithTrustedCertificatesAsync } from "@homarr/core/infrastructure/h
 
 import { env } from "../../env";
 import { createRedirectUri } from "../../redirect";
+import { extractProfileName } from "./profile";
 import { assertVerifiedEmailForCredentialsLinking } from "./verified-email";
 
 export const OidcProvider = (headers: ReadonlyHeaders | null): OIDCConfig<Profile> => ({
@@ -76,12 +77,3 @@ export const OidcProvider = (headers: ReadonlyHeaders | null): OIDCConfig<Profil
   // @ts-expect-error `undici` has a `duplex` option
   [customFetch]: fetchWithTrustedCertificatesAsync,
 });
-
-export const extractProfileName = (profile: Profile) => {
-  if (!env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE) {
-    // Use the name as the username if the preferred_username is an email address
-    return profile.preferred_username?.includes("@") ? profile.name : profile.preferred_username;
-  }
-
-  return profile[env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE as keyof typeof profile] as string;
-};

--- a/packages/auth/providers/oidc/profile.ts
+++ b/packages/auth/providers/oidc/profile.ts
@@ -12,10 +12,10 @@ export const getProfileValueByPath = (profile: Profile, path: string): unknown =
   }, profile);
 };
 
-export const extractProfileName = (profile: Profile) => {
+export const extractProfileName = (profile: Profile): string | undefined => {
   if (!env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE) {
     // Use the name as the username if the preferred_username is an email address
-    return profile.preferred_username?.includes("@") ? profile.name : profile.preferred_username;
+    return (profile.preferred_username?.includes("@") ? profile.name : profile.preferred_username) ?? undefined;
   }
 
   const profileName = getProfileValueByPath(profile, env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE);

--- a/packages/auth/providers/oidc/profile.ts
+++ b/packages/auth/providers/oidc/profile.ts
@@ -1,0 +1,23 @@
+import type { Profile } from "@auth/core/types";
+
+import { env } from "../../env";
+
+export const getProfileValueByPath = (profile: Profile, path: string): unknown => {
+  return path.split(".").reduce<unknown>((value, key) => {
+    if (typeof value !== "object" || value === null || !Object.hasOwn(value, key)) {
+      return undefined;
+    }
+
+    return (value as Record<string, unknown>)[key];
+  }, profile);
+};
+
+export const extractProfileName = (profile: Profile) => {
+  if (!env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE) {
+    // Use the name as the username if the preferred_username is an email address
+    return profile.preferred_username?.includes("@") ? profile.name : profile.preferred_username;
+  }
+
+  const profileName = getProfileValueByPath(profile, env.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE);
+  return typeof profileName === "string" ? profileName : undefined;
+};

--- a/packages/auth/providers/oidc/test/profile.spec.ts
+++ b/packages/auth/providers/oidc/test/profile.spec.ts
@@ -66,6 +66,14 @@ describe("extractProfileName", () => {
     expect(extractProfileName(profile)).toBeUndefined();
   });
 
+  test("returns undefined when preferred_username is missing", () => {
+    const profile = {
+      sub: "user-id",
+    } satisfies Profile;
+
+    expect(extractProfileName(profile)).toBeUndefined();
+  });
+
   test("uses a nested name claim when configured", () => {
     mockEnv.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE = "user.profile.display_name";
     const profile = {

--- a/packages/auth/providers/oidc/test/profile.spec.ts
+++ b/packages/auth/providers/oidc/test/profile.spec.ts
@@ -1,0 +1,59 @@
+import type { Profile } from "@auth/core/types";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const mockEnv = vi.hoisted(() => ({
+  AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE: undefined as string | undefined,
+}));
+
+vi.mock("../../../env", () => ({ env: mockEnv }));
+
+import { extractProfileName, getProfileValueByPath } from "../profile";
+
+afterEach(() => {
+  mockEnv.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE = undefined;
+});
+
+describe("getProfileValueByPath", () => {
+  const profile = {
+    sub: "user-id",
+    resource_access: {
+      homarr: {
+        roles: ["admins"],
+      },
+    },
+  } satisfies Profile;
+
+  test("returns a top-level claim", () => {
+    expect(getProfileValueByPath(profile, "sub")).toBe("user-id");
+  });
+
+  test("returns a nested claim", () => {
+    expect(getProfileValueByPath(profile, "resource_access.homarr.roles")).toEqual(["admins"]);
+  });
+
+  test("returns undefined when the path does not exist", () => {
+    expect(getProfileValueByPath(profile, "resource_access.missing.roles")).toBeUndefined();
+  });
+});
+
+describe("extractProfileName", () => {
+  test("uses a nested name claim when configured", () => {
+    mockEnv.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE = "user.profile.display_name";
+    const profile = {
+      sub: "user-id",
+      user: { profile: { display_name: "Nested User" } },
+    } satisfies Profile;
+
+    expect(extractProfileName(profile)).toBe("Nested User");
+  });
+
+  test("returns undefined when the configured claim is not a string", () => {
+    mockEnv.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE = "user.profile";
+    const profile = {
+      sub: "user-id",
+      user: { profile: { display_name: "Nested User" } },
+    } satisfies Profile;
+
+    expect(extractProfileName(profile)).toBeUndefined();
+  });
+});

--- a/packages/auth/providers/oidc/test/profile.spec.ts
+++ b/packages/auth/providers/oidc/test/profile.spec.ts
@@ -37,6 +37,35 @@ describe("getProfileValueByPath", () => {
 });
 
 describe("extractProfileName", () => {
+  test("uses preferred_username when overwrite is not set", () => {
+    const profile = {
+      sub: "user-id",
+      preferred_username: "johndoe",
+    } satisfies Profile;
+
+    expect(extractProfileName(profile)).toBe("johndoe");
+  });
+
+  test("uses name when preferred_username is an email", () => {
+    const profile = {
+      sub: "user-id",
+      preferred_username: "john@example.com",
+      name: "John Doe",
+    } satisfies Profile;
+
+    expect(extractProfileName(profile)).toBe("John Doe");
+  });
+
+  test("returns undefined when the fallback name is null", () => {
+    const profile = {
+      sub: "user-id",
+      preferred_username: "john@example.com",
+      name: null,
+    } satisfies Profile;
+
+    expect(extractProfileName(profile)).toBeUndefined();
+  });
+
   test("uses a nested name claim when configured", () => {
     mockEnv.AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE = "user.profile.display_name";
     const profile = {

--- a/packages/auth/test/events.spec.ts
+++ b/packages/auth/test/events.spec.ts
@@ -1,7 +1,7 @@
 import type { ResponseCookie } from "next/dist/compiled/@edge-runtime/cookies";
 import type { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
 import { cookies } from "next/headers";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { eq } from "@homarr/db";
 import type { Database } from "@homarr/db";
@@ -21,6 +21,12 @@ vi.mock("../env", () => {
     env: mockEnv,
   };
 });
+
+afterEach(() => {
+  mockEnv.AUTH_OIDC_GROUPS_ATTRIBUTE = "someRandomGroupsKey";
+  mockEnv.AUTH_OIDC_GROUPS_LOCAL_MANAGEMENT = false;
+});
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 type HeadersExport = typeof import("next/headers");
 vi.mock("next/headers", async (importOriginal) => {
@@ -143,6 +149,30 @@ describe("createSignInEventHandler should create signInEventHandler", () => {
       await eventHandler?.({
         user: { id: "1", name: "test" },
         profile: { preferred_username: "test", someRandomGroupsKey: ["test"] },
+        account: null,
+      });
+
+      // Assert
+      const dbGroupMembers = await db.query.groupMembers.findFirst({
+        where: eq(groupMembers.userId, "1"),
+      });
+      expect(dbGroupMembers?.groupId).toBe("1");
+    });
+    test("should add missing group membership from a nested claim", async () => {
+      // Arrange
+      mockEnv.AUTH_OIDC_GROUPS_ATTRIBUTE = "resource_access.homarr.roles";
+      const db = createDb();
+      await createUserAsync(db);
+      await createGroupAsync(db);
+      const eventHandler = createSignInEventHandler(db);
+
+      // Act
+      await eventHandler?.({
+        user: { id: "1", name: "test" },
+        profile: {
+          preferred_username: "test",
+          resource_access: { homarr: { roles: ["test"] } },
+        },
         account: null,
       });
 

--- a/packages/auth/test/events.spec.ts
+++ b/packages/auth/test/events.spec.ts
@@ -162,7 +162,7 @@ describe("createSignInEventHandler should create signInEventHandler", () => {
       // Arrange
       mockEnv.AUTH_OIDC_GROUPS_ATTRIBUTE = "resource_access.homarr.roles";
       const db = createDb();
-      await createUserAsync(db);
+      await createUserAsync(db, "oidc");
       await createGroupAsync(db);
       const eventHandler = createSignInEventHandler(db);
 


### PR DESCRIPTION
## Summary

- resolve OIDC profile values through dot-separated claim paths
- support nested group synchronization and nested `AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE`
- preserve v2's provider guard and verified-email credential-linking safeguard
- document nested claims in the SSO reference

This is the current-v2 port of #6294. It deliberately keeps the regenerated Helm values table unchanged; that table must continue to come from the live chart metadata.

## Verification

- focused Auth tests: 23 passed
- `tsc --project packages/auth/tsconfig.json --noEmit`
- `oxfmt --check` on all changed source, test, and documentation files
- `git diff --check origin/release/v2...HEAD`

## Release readiness

This fixes existing Keycloak and other OIDC configurations that expose claims such as `resource_access.homarr.roles` without weakening the v2 auth checks added after the original PR.
