### PR TITLE
fix(integrations): preserve Nextcloud subpaths

### DIFF
--- a/packages/integrations/src/nextcloud/nextcloud-url.ts
+++ b/packages/integrations/src/nextcloud/nextcloud-url.ts
@@ -1,0 +1,10 @@
+export const createNextcloudCalendarServerUrl = (integrationUrl: string) => {
+  const calendarServerUrl = new URL(integrationUrl);
+  const integrationPath = calendarServerUrl.pathname.replace(/\/+$/, "");
+
+  calendarServerUrl.pathname = `${integrationPath}/remote.php/dav/`;
+  calendarServerUrl.search = "";
+  calendarServerUrl.hash = "";
+
+  return calendarServerUrl.toString();
+};

--- a/packages/integrations/src/nextcloud/nextcloud-url.ts
+++ b/packages/integrations/src/nextcloud/nextcloud-url.ts
@@ -1,8 +1,11 @@
 export const createNextcloudCalendarServerUrl = (integrationUrl: string) => {
   const calendarServerUrl = new URL(integrationUrl);
   const integrationPath = calendarServerUrl.pathname.replace(/\/+$/, "");
+  const davPath = "/remote.php/dav";
 
-  calendarServerUrl.pathname = `${integrationPath}/remote.php/dav/`;
+  calendarServerUrl.pathname = integrationPath.endsWith(davPath)
+    ? `${integrationPath}/`
+    : `${integrationPath}${davPath}/`;
   calendarServerUrl.search = "";
   calendarServerUrl.hash = "";
 

--- a/packages/integrations/src/nextcloud/nextcloud.integration.ts
+++ b/packages/integrations/src/nextcloud/nextcloud.integration.ts
@@ -21,6 +21,7 @@ import type { ICalendarIntegration } from "../interfaces/calendar/calendar-integ
 import type { CalendarEvent } from "../interfaces/calendar/calendar-types";
 import type { Notification } from "../interfaces/notifications/notification-types";
 import type { INotificationsIntegration } from "../interfaces/notifications/notifications-integration";
+import { createNextcloudCalendarServerUrl } from "./nextcloud-url";
 
 // Register all existing timezones
 if (ICAL.TimezoneService.count === 0) {
@@ -189,7 +190,7 @@ export class NextcloudIntegration extends Integration implements ICalendarIntegr
 
   private async createCalendarClientAsync(agent?: Agent) {
     return new DAVClient({
-      serverUrl: this.integration.url,
+      serverUrl: createNextcloudCalendarServerUrl(this.integration.url),
       credentials: {
         username: this.getSecretValue("username"),
         password: this.getSecretValue("password"),

--- a/packages/integrations/src/nextcloud/test/nextcloud-integration.spec.ts
+++ b/packages/integrations/src/nextcloud/test/nextcloud-integration.spec.ts
@@ -1,0 +1,38 @@
+import type { Agent } from "node:https";
+import { DAVClient } from "tsdav";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { NextcloudIntegration } from "../nextcloud.integration";
+
+vi.mock("tsdav", () => ({ DAVClient: vi.fn() }));
+
+interface NextcloudCalendarClientFactory {
+  createCalendarClientAsync(agent: Agent): Promise<unknown>;
+}
+
+describe("NextcloudIntegration", () => {
+  beforeEach(() => {
+    vi.mocked(DAVClient).mockClear();
+  });
+
+  test("uses a calendar server URL that preserves the integration subpath", async () => {
+    const integration = new NextcloudIntegration({
+      id: "integration-id",
+      name: "Nextcloud",
+      url: "https://example.com/nextcloud",
+      externalUrl: null,
+      decryptedSecrets: [
+        { kind: "username", value: "admin" },
+        { kind: "password", value: "password" },
+      ],
+    });
+
+    await (integration as unknown as NextcloudCalendarClientFactory).createCalendarClientAsync({} as Agent);
+
+    expect(DAVClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverUrl: "https://example.com/nextcloud/remote.php/dav/",
+      }),
+    );
+  });
+});

--- a/packages/integrations/src/nextcloud/test/nextcloud-url.spec.ts
+++ b/packages/integrations/src/nextcloud/test/nextcloud-url.spec.ts
@@ -20,4 +20,10 @@ describe("createNextcloudCalendarServerUrl", () => {
       "https://example.com/nextcloud/remote.php/dav/",
     );
   });
+
+  test("does not duplicate an existing DAV endpoint", () => {
+    expect(createNextcloudCalendarServerUrl("https://example.com/nextcloud/remote.php/dav")).toBe(
+      "https://example.com/nextcloud/remote.php/dav/",
+    );
+  });
 });

--- a/packages/integrations/src/nextcloud/test/nextcloud-url.spec.ts
+++ b/packages/integrations/src/nextcloud/test/nextcloud-url.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+
+import { createNextcloudCalendarServerUrl } from "../nextcloud-url";
+
+describe("createNextcloudCalendarServerUrl", () => {
+  test("uses the DAV endpoint for a root installation", () => {
+    expect(createNextcloudCalendarServerUrl("https://cloud.example.com")).toBe(
+      "https://cloud.example.com/remote.php/dav/",
+    );
+  });
+
+  test("preserves the base path for a subpath installation", () => {
+    expect(createNextcloudCalendarServerUrl("https://example.com/nextcloud")).toBe(
+      "https://example.com/nextcloud/remote.php/dav/",
+    );
+  });
+
+  test("does not duplicate a trailing slash", () => {
+    expect(createNextcloudCalendarServerUrl("https://example.com/nextcloud/")).toBe(
+      "https://example.com/nextcloud/remote.php/dav/",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- send the Nextcloud calendar client to the canonical `/remote.php/dav/` endpoint
- preserve configured subpaths such as `/nextcloud`
- keep existing complete DAV endpoints idempotent

This is the focused current-v2 port of #6295 and fixes #3597.

## Verification

- focused Nextcloud tests: 5 passed
- `tsc --project packages/integrations/tsconfig.json --noEmit`
- `oxfmt --check` on all four changed files
- `git diff --check origin/release/v2...HEAD`

## Release readiness

Without this fix, `tsdav` discovery starts from the origin and drops reverse-proxy installation paths. The integration URL used elsewhere remains unchanged.
