### PR TITLE
fix(integrations): support UniFi controller default ports

### DIFF
--- a/apps/docs/docs/integrations/unifi-controller/index.mdx
+++ b/apps/docs/docs/integrations/unifi-controller/index.mdx
@@ -28,6 +28,14 @@ Therfore it should support CloudKey Gen1, CloudKey Gen2, UnifiOS-based UDM-Pro c
 
 <AddingIntegration />
 
+Use the local HTTPS address of your controller:
+
+- UniFi OS consoles such as Dream Router, Dream Machine, Cloud Gateway, and CloudKey use `https://<host>` (port 443).
+- Self-hosted UniFi Network Servers normally use `https://<host>:8443`.
+- If you omit the port, Homarr tries port 443 first and then port 8443 when the first port cannot be reached.
+
+Use a local administrator account. Cloud-only accounts and accounts with multi-factor authentication are not supported by the underlying client.
+
 ### Secrets
 
 <IntegrationSecrets

--- a/apps/docs/docs/integrations/unifi-controller/index.mdx
+++ b/apps/docs/docs/integrations/unifi-controller/index.mdx
@@ -16,7 +16,7 @@ import { networkControllerStatusWidget } from "@site/docs/widgets/network-contro
 <IntegrationHeader integration={unifiControllerIntegration} categories={["Network controller"]} />
 
 This integration is using the [node-unifi](https://www.npmjs.com/package/node-unifi) library under the hood to connect to the Unifi Controller.
-Therfore it should support CloudKey Gen1, CloudKey Gen2, UnifiOS-based UDM-Pro controllers as well as self-hosted UniFi controllers.
+Therefore it should support CloudKey Gen1, CloudKey Gen2, UnifiOS-based UDM-Pro controllers as well as self-hosted UniFi controllers.
 
 ### Widgets & Capabilities
 

--- a/packages/integrations/src/unifi-controller/test/unifi-controller-integration.spec.ts
+++ b/packages/integrations/src/unifi-controller/test/unifi-controller-integration.spec.ts
@@ -7,6 +7,7 @@ vi.hoisted(() => {
 });
 
 const controllerCtor = vi.fn();
+const controllerLogin = vi.fn().mockResolvedValue(true);
 
 vi.mock("@homarr/redis", () => ({
   createGetSetChannel: () => ({
@@ -34,6 +35,7 @@ vi.mock("@homarr/core/infrastructure/certificates", () => ({
 }));
 
 vi.mock("axios", () => ({
+  AxiosError: Error,
   default: {
     create: vi.fn().mockReturnValue({}),
   },
@@ -52,7 +54,7 @@ vi.mock("@homarr/node-unifi", () => {
       controllerCtor(options);
     }
     public async login(): Promise<true> {
-      return true;
+      return await controllerLogin(this.options.port);
     }
     public async getSitesStats(): Promise<unknown[]> {
       return [];
@@ -76,15 +78,31 @@ const createIntegration = (url: string) =>
   });
 
 describe("UnifiControllerIntegration port resolution", () => {
-  test("http://192.168.1.1 falls back to the 8443 default instead of 80", async () => {
+  test("a URL without a port uses the UniFi OS port 443", async () => {
     controllerCtor.mockClear();
+    controllerLogin.mockClear().mockResolvedValue(true);
     await createIntegration("http://192.168.1.1").getNetworkSummaryAsync();
 
-    expect(controllerCtor).toHaveBeenCalledWith(expect.objectContaining({ host: "192.168.1.1", port: 8443 }));
+    expect(controllerCtor).toHaveBeenCalledTimes(1);
+    expect(controllerCtor).toHaveBeenCalledWith(expect.objectContaining({ host: "192.168.1.1", port: 443 }));
+  });
+
+  test("a connection failure on port 443 falls back to the self-hosted controller port 8443", async () => {
+    controllerCtor.mockClear();
+    controllerLogin
+      .mockClear()
+      .mockRejectedValueOnce(Object.assign(new Error("connect ECONNREFUSED"), { isAxiosError: true }))
+      .mockResolvedValueOnce(true);
+
+    await createIntegration("http://controller.lan").getNetworkSummaryAsync();
+
+    expect(controllerCtor).toHaveBeenNthCalledWith(1, expect.objectContaining({ port: 443 }));
+    expect(controllerCtor).toHaveBeenNthCalledWith(2, expect.objectContaining({ port: 8443 }));
   });
 
   test("https://controller.lan:8443 keeps the user-specified port", async () => {
     controllerCtor.mockClear();
+    controllerLogin.mockClear().mockResolvedValue(true);
     await createIntegration("https://controller.lan:8443").getNetworkSummaryAsync();
 
     expect(controllerCtor).toHaveBeenCalledWith(expect.objectContaining({ host: "controller.lan", port: 8443 }));
@@ -92,6 +110,7 @@ describe("UnifiControllerIntegration port resolution", () => {
 
   test("https://192.168.1.1:8443 keeps the user-specified port", async () => {
     controllerCtor.mockClear();
+    controllerLogin.mockClear().mockResolvedValue(true);
     await createIntegration("https://192.168.1.1:8443").getNetworkSummaryAsync();
 
     expect(controllerCtor).toHaveBeenCalledWith(expect.objectContaining({ host: "192.168.1.1", port: 8443 }));
@@ -99,8 +118,24 @@ describe("UnifiControllerIntegration port resolution", () => {
 
   test("an unusual port like 10443 is honored verbatim", async () => {
     controllerCtor.mockClear();
+    controllerLogin.mockClear().mockResolvedValue(true);
     await createIntegration("https://192.168.1.1:10443").getNetworkSummaryAsync();
 
     expect(controllerCtor).toHaveBeenCalledWith(expect.objectContaining({ host: "192.168.1.1", port: 10443 }));
+  });
+
+  test("an authentication failure on port 443 does not try another port", async () => {
+    controllerCtor.mockClear();
+    controllerLogin.mockClear().mockRejectedValueOnce(
+      Object.assign(new Error("Request failed with status code 401"), {
+        isAxiosError: true,
+        response: { status: 401 },
+      }),
+    );
+
+    await expect(createIntegration("https://controller.lan").getNetworkSummaryAsync()).rejects.toThrow();
+
+    expect(controllerCtor).toHaveBeenCalledTimes(1);
+    expect(controllerCtor).toHaveBeenCalledWith(expect.objectContaining({ port: 443 }));
   });
 });

--- a/packages/integrations/src/unifi-controller/test/unifi-controller-integration.spec.ts
+++ b/packages/integrations/src/unifi-controller/test/unifi-controller-integration.spec.ts
@@ -80,35 +80,27 @@ describe("UnifiControllerIntegration port resolution", () => {
     controllerCtor.mockClear();
     await createIntegration("http://192.168.1.1").getNetworkSummaryAsync();
 
-    expect(controllerCtor).toHaveBeenCalledWith(
-      expect.objectContaining({ host: "192.168.1.1", port: 8443 }),
-    );
+    expect(controllerCtor).toHaveBeenCalledWith(expect.objectContaining({ host: "192.168.1.1", port: 8443 }));
   });
 
   test("https://controller.lan:8443 keeps the user-specified port", async () => {
     controllerCtor.mockClear();
     await createIntegration("https://controller.lan:8443").getNetworkSummaryAsync();
 
-    expect(controllerCtor).toHaveBeenCalledWith(
-      expect.objectContaining({ host: "controller.lan", port: 8443 }),
-    );
+    expect(controllerCtor).toHaveBeenCalledWith(expect.objectContaining({ host: "controller.lan", port: 8443 }));
   });
 
   test("https://192.168.1.1:8443 keeps the user-specified port", async () => {
     controllerCtor.mockClear();
     await createIntegration("https://192.168.1.1:8443").getNetworkSummaryAsync();
 
-    expect(controllerCtor).toHaveBeenCalledWith(
-      expect.objectContaining({ host: "192.168.1.1", port: 8443 }),
-    );
+    expect(controllerCtor).toHaveBeenCalledWith(expect.objectContaining({ host: "192.168.1.1", port: 8443 }));
   });
 
   test("an unusual port like 10443 is honored verbatim", async () => {
     controllerCtor.mockClear();
     await createIntegration("https://192.168.1.1:10443").getNetworkSummaryAsync();
 
-    expect(controllerCtor).toHaveBeenCalledWith(
-      expect.objectContaining({ host: "192.168.1.1", port: 10443 }),
-    );
+    expect(controllerCtor).toHaveBeenCalledWith(expect.objectContaining({ host: "192.168.1.1", port: 10443 }));
   });
 });

--- a/packages/integrations/src/unifi-controller/test/unifi-controller-integration.spec.ts
+++ b/packages/integrations/src/unifi-controller/test/unifi-controller-integration.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.SKIP_ENV_VALIDATION = "true";
+  process.env.SECRET_ENCRYPTION_KEY = "ff3f4f7ce30e870c9630de9e5d244ffa81101a24ed0dfe5f064beb53a7e684f1";
+  process.env.ENABLE_DNS_CACHING = "false";
+});
+
+const controllerCtor = vi.fn();
+
+vi.mock("@homarr/redis", () => ({
+  createGetSetChannel: () => ({
+    getAsync: vi.fn().mockResolvedValue(null),
+    setAsync: vi.fn().mockResolvedValue(undefined),
+    removeAsync: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock("@homarr/core/infrastructure/logs", () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  ErrorWithMetadata: class extends Error {},
+}));
+
+vi.mock("@homarr/core/infrastructure/http", () => ({
+  createCustomCheckServerIdentity: () => (() => undefined) as never,
+  fetchWithTrustedCertificatesAsync: vi.fn(),
+  createAxiosCertificateInstanceAsync: vi.fn().mockResolvedValue({}),
+  createCertificateAgentAsync: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@homarr/core/infrastructure/certificates", () => ({
+  getTrustedCertificateHostnamesAsync: vi.fn().mockResolvedValue([]),
+  getAllTrustedCertificatesAsync: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    create: vi.fn().mockReturnValue({}),
+  },
+}));
+
+vi.mock("http-cookie-agent/http", () => ({
+  HttpCookieAgent: class {},
+  HttpsCookieAgent: class {},
+}));
+
+vi.mock("@homarr/node-unifi", () => {
+  class FakeController {
+    public options: Record<string, unknown>;
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+      controllerCtor(options);
+    }
+    public async login(): Promise<true> {
+      return true;
+    }
+    public async getSitesStats(): Promise<unknown[]> {
+      return [];
+    }
+  }
+  return { default: { Controller: FakeController } };
+});
+
+import { UnifiControllerIntegration } from "../unifi-controller-integration";
+
+const createIntegration = (url: string) =>
+  new UnifiControllerIntegration({
+    id: "test-unifi",
+    name: "Test Unifi",
+    url,
+    externalUrl: null,
+    decryptedSecrets: [
+      { kind: "username", value: "admin" },
+      { kind: "password", value: "secret" },
+    ],
+  });
+
+describe("UnifiControllerIntegration port resolution", () => {
+  test("http://192.168.1.1 falls back to the 8443 default instead of 80", async () => {
+    controllerCtor.mockClear();
+    await createIntegration("http://192.168.1.1").getNetworkSummaryAsync();
+
+    expect(controllerCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ host: "192.168.1.1", port: 8443 }),
+    );
+  });
+
+  test("https://controller.lan:8443 keeps the user-specified port", async () => {
+    controllerCtor.mockClear();
+    await createIntegration("https://controller.lan:8443").getNetworkSummaryAsync();
+
+    expect(controllerCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ host: "controller.lan", port: 8443 }),
+    );
+  });
+
+  test("https://192.168.1.1:8443 keeps the user-specified port", async () => {
+    controllerCtor.mockClear();
+    await createIntegration("https://192.168.1.1:8443").getNetworkSummaryAsync();
+
+    expect(controllerCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ host: "192.168.1.1", port: 8443 }),
+    );
+  });
+
+  test("an unusual port like 10443 is honored verbatim", async () => {
+    controllerCtor.mockClear();
+    await createIntegration("https://192.168.1.1:10443").getNetworkSummaryAsync();
+
+    expect(controllerCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ host: "192.168.1.1", port: 10443 }),
+    );
+  });
+});

--- a/packages/integrations/src/unifi-controller/unifi-controller-integration.ts
+++ b/packages/integrations/src/unifi-controller/unifi-controller-integration.ts
@@ -61,35 +61,58 @@ export class UnifiControllerIntegration extends Integration implements NetworkCo
     checkServerIdentity: typeof tls.checkServerIdentity;
   }) {
     const url = new URL(this.integration.url);
-    // ponytail: node-unifi hardcodes https:// in its base URL and never serves HTTP.
-    // Respect the user's explicit port; fall back to 8443 (the integration's defaultPort)
-    // so a bare "http://192.168.1.1" maps to https://192.168.1.1:8443 instead of 80.
-    const port = url.port ? Number(url.port) : 8443;
     const certificateOptions = options ?? {
       ca: await getAllTrustedCertificatesAsync(),
       checkServerIdentity: createCustomCheckServerIdentity(await getTrustedCertificateHostnamesAsync()),
     };
 
-    const client = new Unifi.Controller({
-      host: url.hostname,
-      port,
-      username: this.getSecretValue("username"),
-      password: this.getSecretValue("password"),
-      createAxiosInstance({ cookies }) {
-        return axios.create({
-          adapter: "http",
-          httpAgent: new HttpCookieAgent({ cookies }),
-          httpsAgent: new HttpsCookieAgent({
-            cookies,
-            requestCert: true,
-            ...certificateOptions,
-          }),
-        });
-      },
-    });
+    // ponytail: node-unifi always connects over HTTPS, regardless of the protocol in the
+    // integration URL. UniFi OS consoles use port 443 while self-hosted controllers normally
+    // use 8443. If no port was provided, try both without hiding authentication errors.
+    const ports = url.port ? [Number(url.port)] : [443, 8443];
+    const createClientForPortAsync = async (port: number) => {
+      const client = new Unifi.Controller({
+        host: url.hostname,
+        port,
+        username: this.getSecretValue("username"),
+        password: this.getSecretValue("password"),
+        createAxiosInstance({ cookies }) {
+          return axios.create({
+            adapter: "http",
+            httpAgent: new HttpCookieAgent({ cookies }),
+            httpsAgent: new HttpsCookieAgent({
+              cookies,
+              requestCert: true,
+              ...certificateOptions,
+            }),
+          });
+        },
+      });
 
-    await client.login(this.getSecretValue("username"), this.getSecretValue("password"), null);
-    return client;
+      await client.login(this.getSecretValue("username"), this.getSecretValue("password"), null);
+      return client;
+    };
+
+    for (const [index, port] of ports.entries()) {
+      try {
+        return await createClientForPortAsync(port);
+      } catch (error) {
+        const isLastPort = index === ports.length - 1;
+        if (isLastPort || !this.isPortFallbackError(error)) {
+          throw error;
+        }
+      }
+    }
+
+    throw new Error("Unable to connect to the UniFi controller");
+  }
+
+  private isPortFallbackError(error: unknown) {
+    if (typeof error === "object" && error !== null && "isAxiosError" in error && error.isAxiosError === true) {
+      return !("response" in error) || error.response === undefined;
+    }
+
+    return error instanceof Error && error.message === "failed to detect UniFiOS status";
   }
 
   private getStatusValueOverAllSites<S extends HealthSubsystem>(

--- a/packages/integrations/src/unifi-controller/unifi-controller-integration.ts
+++ b/packages/integrations/src/unifi-controller/unifi-controller-integration.ts
@@ -2,7 +2,6 @@ import type tls from "node:tls";
 import axios from "axios";
 import { HttpCookieAgent, HttpsCookieAgent } from "http-cookie-agent/http";
 
-import { getPortFromUrl } from "@homarr/common";
 import {
   getAllTrustedCertificatesAsync,
   getTrustedCertificateHostnamesAsync,
@@ -62,6 +61,10 @@ export class UnifiControllerIntegration extends Integration implements NetworkCo
     checkServerIdentity: typeof tls.checkServerIdentity;
   }) {
     const url = new URL(this.integration.url);
+    // ponytail: node-unifi hardcodes https:// in its base URL and never serves HTTP.
+    // Respect the user's explicit port; fall back to 8443 (the integration's defaultPort)
+    // so a bare "http://192.168.1.1" maps to https://192.168.1.1:8443 instead of 80.
+    const port = url.port ? Number(url.port) : 8443;
     const certificateOptions = options ?? {
       ca: await getAllTrustedCertificatesAsync(),
       checkServerIdentity: createCustomCheckServerIdentity(await getTrustedCertificateHostnamesAsync()),
@@ -69,7 +72,7 @@ export class UnifiControllerIntegration extends Integration implements NetworkCo
 
     const client = new Unifi.Controller({
       host: url.hostname,
-      port: getPortFromUrl(url),
+      port,
       username: this.getSecretValue("username"),
       password: this.getSecretValue("password"),
       createAxiosInstance({ cookies }) {

--- a/packages/integrations/src/unifi-controller/unifi-controller-integration.ts
+++ b/packages/integrations/src/unifi-controller/unifi-controller-integration.ts
@@ -66,7 +66,7 @@ export class UnifiControllerIntegration extends Integration implements NetworkCo
       checkServerIdentity: createCustomCheckServerIdentity(await getTrustedCertificateHostnamesAsync()),
     };
 
-    // ponytail: node-unifi always connects over HTTPS, regardless of the protocol in the
+    // node-unifi always connects over HTTPS, regardless of the protocol in the
     // integration URL. UniFi OS consoles use port 443 while self-hosted controllers normally
     // use 8443. If no port was provided, try both without hiding authentication errors.
     const ports = url.port ? [Number(url.port)] : [443, 8443];


### PR DESCRIPTION
## Summary

- preserve explicitly configured UniFi controller ports
- try UniFi OS port 443 first when no port is supplied
- fall back to self-hosted controller port 8443 only for connection/controller-detection failures
- keep authentication failures visible instead of masking them with a retry
- document the correct URL and local-account requirements

This is the cleaned current-v2 port of #6210 and fixes #6207. The unrelated generated sitemap churn was not carried over, and the two outstanding review nits were resolved.

## Verification

- focused UniFi tests: 6 passed
- `tsc --project packages/integrations/tsconfig.json --noEmit`
- `oxfmt --check` on the changed source, test, and documentation files
- `git diff --check origin/release/v2...HEAD`

## Release readiness

The underlying node-unifi client always connects over HTTPS, so the current v2 use of URL-derived port 80 for a bare `http://controller` address is invalid.
