### PR TITLE
docs: publish Homarr 2.0 article

### DIFF
--- a/apps/docs/blog/2026/09-03-homarr-2.0/index.mdx
+++ b/apps/docs/blog/2026/09-03-homarr-2.0/index.mdx
@@ -6,7 +6,7 @@ authors:
   - tagashi
   - meierschlumpf
 tags: [homarr, update, version, assistant, custom widgets, dashboards, docker]
-draft: true
+draft: false
 ---
 
 Homarr 2.0 is our biggest upgrade so far. It keeps the same job: put your apps, services, and status on one dashboard.


### PR DESCRIPTION
Publishes the Homarr 2.0 release article by disabling draft mode.