### PR TITLE
fix(ci): use pinned pnpm for releases

### DIFF
--- a/.github/workflows/deployment-docker-image.yml
+++ b/.github/workflows/deployment-docker-image.yml
@@ -68,8 +68,6 @@ jobs:
         with:
           node-version: 24.18.0
           package-manager-cache: false
-      - run: npm i -g pnpm
-        if: env.SKIP_RELEASE == 'false'
       - name: Install dependencies
         if: env.SKIP_RELEASE == 'false'
         run: |


### PR DESCRIPTION
Remove the redundant unpinned global pnpm installation from the release workflow. The existing setup action already installs the version pinned in package.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the Docker image deployment workflow by removing a redundant package-manager setup step.
  - Dependency installation continues to work through the existing configured workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->