### PR TITLE
fix: respect color scheme in PWA manifest theme color

### DIFF
--- a/apps/nextjs/next.config.ts
+++ b/apps/nextjs/next.config.ts
@@ -69,6 +69,13 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        source: "/manifest.webmanifest",
+        headers: [
+          { key: "Accept-CH", value: "Sec-CH-Prefers-Color-Scheme" },
+          { key: "Vary", value: "Sec-CH-Prefers-Color-Scheme" },
+        ],
+      },
+      {
         source: "/sw.js",
         headers: [
           { key: "Content-Type", value: "application/javascript; charset=utf-8" },

--- a/apps/nextjs/src/app/manifest.ts
+++ b/apps/nextjs/src/app/manifest.ts
@@ -1,14 +1,32 @@
 import type { MetadataRoute } from "next";
+import { headers } from "next/headers";
 
-export default function manifest(): MetadataRoute.Manifest {
+import { getCurrentColorSchemeAsync } from "~/theme/color-scheme";
+
+const themeColors = {
+  light: "#fff",
+  dark: "#242424",
+} as const;
+
+export default async function manifest(): Promise<MetadataRoute.Manifest> {
+  const colorScheme = await getCurrentColorSchemeAsync();
+  const resolvedColorScheme =
+    colorScheme === "auto"
+      ? (await headers()).get("sec-ch-prefers-color-scheme") === "dark"
+        ? "dark"
+        : "light"
+      : colorScheme;
+
+  const themeColor = themeColors[resolvedColorScheme];
+
   return {
     name: "Homarr",
     short_name: "Homarr",
     description: "Your dashboard for managing your server.",
     start_url: "/",
     display: "standalone",
-    background_color: "#fff",
-    theme_color: "#fff",
+    background_color: themeColor,
+    theme_color: themeColor,
     icons: [
       {
         src: "/images/pwa/192.maskable.png",


### PR DESCRIPTION
## What does this PR do?

Fixes the white Android status bar in the installed PWA when Homarr is in dark mode.

The PWA manifest (`/manifest.webmanifest`) hard-coded `theme_color: "#fff"` and `background_color: "#fff"`. Unlike the HTML `<meta name="theme-color">` tags (which already handle `prefers-color-scheme` correctly), the manifest spec does **not** support media queries — so installed standalone apps always got a white status bar, regardless of the user's color scheme. There is no existing setting for this; it was a bug.

## Changes

- **`apps/nextjs/src/app/manifest.ts`** — the manifest is now generated dynamically:
  - Resolves the user's color scheme via `getCurrentColorSchemeAsync()` (cookie → server default)
  - `light` → `#fff`, `dark` → `#242424` (matches the app's actual dark background)
  - `auto` → falls back to the `Sec-CH-Prefers-Color-Scheme` client hint when present, else `#fff` (previous behavior, no regression)
- **`apps/nextjs/next.config.ts`** — sends `Accept-CH: Sec-CH-Prefers-Color-Scheme` + `Vary` on `/manifest.webmanifest` so browsers opt in and send the hint on subsequent manifest fetches (helps `auto` users after the first fetch; Chrome re-fetches the manifest periodically while installed).

## Verification

Tested against the dev server:

| Case | `theme_color` |
| --- | --- |
| cookie: `dark` | `#242424` |
| cookie: `light` | `#fff` |
| cookie: `auto` + hint `dark` | `#242424` |
| cookie: `auto` + hint `light` | `#fff` |
| no cookie (server default) | `#fff` |

`Accept-CH` and `Vary` headers confirmed present on `/manifest.webmanifest`.

## Notes

- Existing installs pick up the fix when the browser re-fetches the manifest (periodically, ~24h) or on reinstall.
- Firefox for Android additionally has a known upstream bug (Bugzilla [1964220](https://bugzilla.mozilla.org/show_bug.cgi?id=1964220)) where some versions ignore the manifest `theme_color` entirely — this PR is the correct app-side fix regardless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The web app manifest now automatically reflects the user’s preferred light or dark color scheme.
  * Manifest theme and background colors are selected based on the active appearance setting, including browser-provided color-scheme preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->