### PR TITLE
docs(mcp): restore custom widget authoring guidance

### DIFF
--- a/apps/docs/docs/management/mcp.mdx
+++ b/apps/docs/docs/management/mcp.mdx
@@ -63,10 +63,11 @@ Tools use the permissions of the API key owner or OAuth user. Queries read data;
 Inspect the **AI / MCP** tab or your client's tool list for available actions.
 
 Custom Widget and Workshop authoring tools, prompts, and resources require administrator access.
-For Custom Widgets, follow [Connect an agent](./custom-widgets/agent-authoring).
-Secret values are configured in Homarr and are never returned through MCP.
+For Custom Widgets, install the official skill and follow the preview-and-evidence workflow described in
+[Connect an agent](./custom-widgets/agent-authoring). Secret values are configured in Homarr and are never returned
+through MCP.
 
-The built-in [Assistant](./assistant) shares the MCP tool catalog, uses your Homarr session, and asks for approval
+The built-in [Assistant](./assistant) uses the same tool catalog with the current Homarr session and asks for approval
 before mutations by default.
 
 ## Verify the connection


### PR DESCRIPTION
Restore the official skill and preview workflow guidance, plus the Assistant permissions wording. Formatting check passes.