### PR TITLE
fix(firewall widget): allow content to shrink and scroll

### DIFF
--- a/packages/widgets/src/firewall/component.tsx
+++ b/packages/widgets/src/firewall/component.tsx
@@ -56,7 +56,7 @@ export default function FirewallWidget({ integrationIds, width, itemId }: Widget
   const t = useI18n();
 
   return (
-    <ScrollArea h="100%">
+    <ScrollArea h="100%" style={{ minHeight: 0 }}>
       <Group justify="space-between" w="100%" style={{ padding: "8px" }}>
         <FirewallMenu
           onChange={handleSelect}


### PR DESCRIPTION
## Summary

The Firewall widget's root ScrollArea had no minHeight override, so as a
flex item of the board card it defaulted to min-height: auto, which
resolves to its content's intrinsic height. At smaller widget heights the
content was pushed past the card's box and hard clipped instead of
scrolling; at larger heights it just left empty space below. Adding
minHeight: 0 lets it shrink to the card's actual size and use its own
scroll area, the same fix already used in a few other widgets with the
same structure.

## Validation

- pnpm turbo typecheck --filter=@homarr/widgets
- pnpm turbo lint --filter=@homarr/widgets
- pnpm turbo format --filter=@homarr/widgets -- --check
- existing widgets test suite (vitest)

Fixes #3898.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior in the firewall widget by ensuring its scrollable area can properly shrink within its container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->