### PR TITLE
fix: protect demo users from deletion and password changes

### DIFF
--- a/apps/docs/docs/management/users/index.mdx
+++ b/apps/docs/docs/management/users/index.mdx
@@ -18,6 +18,9 @@ password. Decimal units are the default. Change them from the user form or **Com
 Preferences → Data size units**. Byte rates follow the same preference; bit rates stay decimal and use labels such as
 Mb/s. Deleting a user does not delete boards they created.
 
+In demo mode (`DEMO_MODE=true`), user deletion and password changes are disabled for everyone, including administrators,
+even when `DEMO_READ_ONLY=false` allows other changes. This applies to the UI and API.
+
 ![The Users management page](../img/users.png)
 
 ## Groups

--- a/packages/api/src/router/user.ts
+++ b/packages/api/src/router/user.ts
@@ -497,6 +497,13 @@ export const userRouter = createTRPCRouter({
       mcp: { enabled: true, description: "Delete a user by ID. REQUIRED: userId (string)" },
     })
     .mutation(async ({ input, ctx }) => {
+      if (isDemoMode) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "User deletion is disabled in demo mode",
+        });
+      }
+
       // Only admins and user itself can delete a user
       if (ctx.session.user.id !== input.userId && !ctx.session.user.permissions.includes("admin")) {
         throw new TRPCError({
@@ -519,6 +526,13 @@ export const userRouter = createTRPCRouter({
       },
     })
     .mutation(async ({ ctx, input }) => {
+      if (isDemoMode) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Password changes are disabled in demo mode",
+        });
+      }
+
       const user = ctx.session.user;
       // Only admins can change other users' passwords
       if (!user.permissions.includes("admin") && user.id !== input.userId) {


### PR DESCRIPTION
## Summary
Block user deletion and password changes whenever `DEMO_MODE=true`, including writable demos and administrator actions. Document the restriction.

## Validation
- Targeted formatting and lint checks
- `git diff --check`
