### PR TITLE
fix: show board removal confirmation in a dialog

### DIFF
--- a/.agents/skills/codebase-context/SKILL.md
+++ b/.agents/skills/codebase-context/SKILL.md
@@ -37,4 +37,4 @@ Orient from the current checkout before editing. Treat package manifests, export
 - Cron jobs: `packages/cron-jobs/src/jobs/`
 - App routes: `apps/nextjs/src/app/[locale]/`
 
-When a code change affects users, invoke `documentation-sync`. When exposing tRPC through MCP, invoke `mcp-integration`.
+Invoke `documentation-sync` when users need the change explained or existing documentation becomes inaccurate; follow the Documentation Sync criteria in `AGENTS.md`. When exposing tRPC through MCP, invoke `mcp-integration`.

--- a/.agents/skills/codebase-context/SKILL.md
+++ b/.agents/skills/codebase-context/SKILL.md
@@ -37,4 +37,4 @@ Orient from the current checkout before editing. Treat package manifests, export
 - Cron jobs: `packages/cron-jobs/src/jobs/`
 - App routes: `apps/nextjs/src/app/[locale]/`
 
-Invoke `documentation-sync` when users need the change explained or existing documentation becomes inaccurate; follow the Documentation Sync criteria in `AGENTS.md`. When exposing tRPC through MCP, invoke `mcp-integration`.
+Invoke `documentation-sync` when hidden capabilities or information not evident to an advanced user change, or existing guidance becomes inaccurate; follow the Documentation Sync criteria in `AGENTS.md`. When exposing tRPC through MCP, invoke `mcp-integration`.

--- a/.agents/skills/documentation-sync/SKILL.md
+++ b/.agents/skills/documentation-sync/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: documentation-sync
-description: Keep Homarr's Docusaurus documentation aligned with user-facing code. Use when adding or changing integrations, widgets, APIs, environment variables, CLI commands, authentication, permissions, cron jobs, settings, or UI behavior that users must understand.
+description: Update Homarr documentation when users need setup, configuration, migration, or non-obvious behavior explained, or existing guidance becomes inaccurate. Skip routine bug fixes and self-explanatory UI changes.
 ---
 
 # Documentation Sync
 
-Update `apps/docs/` in the same change as user-facing behavior. Inspect adjacent pages and the docs types before copying a pattern; the source and docs evolve together.
+Apply the Documentation Sync criteria in `AGENTS.md` first. Only update `apps/docs/` when users need the information or existing guidance becomes inaccurate. Standard actions such as deleting an item and confirming deletion need no explanation merely because their UI changed.
 
-## Map the change
+When an update is warranted, inspect adjacent pages and the docs types before copying a pattern; the source and docs evolve together.
+
+## Locate a needed update
 
 | Code change                         | Documentation target                                                 |
 | ----------------------------------- | -------------------------------------------------------------------- |

--- a/.agents/skills/documentation-sync/SKILL.md
+++ b/.agents/skills/documentation-sync/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: documentation-sync
-description: Update Homarr documentation when users need setup, configuration, migration, or non-obvious behavior explained, or existing guidance becomes inaccurate. Skip routine bug fixes and self-explanatory UI changes.
+description: Write concise Homarr docs for advanced users, covering only hidden capabilities and information not evident from the UI. Use when that information changes or existing guidance becomes inaccurate; skip obvious controls and routine fixes.
 ---
 
 # Documentation Sync
 
-Apply the Documentation Sync criteria in `AGENTS.md` first. Only update `apps/docs/` when users need the information or existing guidance becomes inaccurate. Standard actions such as deleting an item and confirming deletion need no explanation merely because their UI changed.
+Apply the audience and scope rules in `AGENTS.md` first. Before adding a passage, identify what an advanced user could not learn directly from the interface. If there is no such information, omit it.
 
-When an update is warranted, inspect adjacent pages and the docs types before copying a pattern; the source and docs evolve together.
+For hidden capabilities such as the advanced widget feature, explain discovery, activation, and non-obvious behavior. For visible standard controls such as Delete, omit narration of what the label already conveys. Use the shortest explanation that preserves necessary technical detail; remove redundant prose in the passage being edited.
+
+When an update is warranted, inspect adjacent pages for structure and types, not as a verbosity target. The mappings below locate needed information; they do not require a page for every feature or code change.
 
 ## Locate a needed update
 
@@ -42,11 +44,11 @@ For a widget:
 
 - Add or update `apps/docs/docs/widgets/<slug>/index.ts` with the local `WidgetDefinition` pattern.
 - Add or update `index.mdx` with the established `WidgetHeader`, `WidgetConfig`, and `AddingWidget` components as applicable.
-- Document options, required integrations, permissions, empty states, and changed behavior that affect setup or use.
+- Explain only non-obvious option semantics, integration prerequisites, permission constraints, or behavior that the interface does not make clear.
 
 ## Completion criteria
 
-1. Describe the shipped behavior, not an implementation plan.
+1. Every passage adds information an advanced user cannot reasonably infer from the interface. Remove obvious, repetitive, or unnecessary prose.
 2. Keep names, defaults, paths, screenshots, links, and prerequisites consistent with code.
 3. Update every affected page and remove superseded guidance.
 4. Run the narrowest useful docs validation. Use `pnpm turbo build --filter=@homarr/docs` when links, MDX, generated definitions, or navigation can fail; otherwise run the docs package formatter on touched files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,9 @@ homarr/
 
 The documentation site lives at `apps/docs/` (Docusaurus 3, `@homarr/docs`).
 
-When modifying user-facing code, you MUST also update the corresponding documentation:
+Update documentation only when users need information to configure, use, or adapt to the change, or when existing documentation becomes inaccurate. Routine bug fixes and self-explanatory UI changes do not need docs. Assume users understand standard controls such as Delete and confirmation buttons.
+
+When documentation is needed, use these locations:
 
 - New integration → `apps/docs/docs/integrations/<slug>/index.mdx` + `index.ts`
 - New widget → `apps/docs/docs/widgets/<slug>/index.mdx` + `index.ts`
@@ -99,6 +101,6 @@ When modifying user-facing code, you MUST also update the corresponding document
 Portable skills live in `.agents/skills/`. Read the relevant `SKILL.md` before working in that domain; detailed references are loaded only when needed. Claude-compatible discovery is provided through `.claude/skills`.
 
 - `codebase-context` — architecture, package boundaries, and shared utilities
-- `documentation-sync` — required user-facing documentation updates
+- `documentation-sync` — documentation for changes users need explained
 - `mcp-integration` — safe tRPC-to-MCP exposure
 - `homarr-custom-widget` — safe Custom JSX v2 authoring

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,11 @@ homarr/
 
 The documentation site lives at `apps/docs/` (Docusaurus 3, `@homarr/docs`).
 
-Update documentation only when users need information to configure, use, or adapt to the change, or when existing documentation becomes inaccurate. Routine bug fixes and self-explanatory UI changes do not need docs. Assume users understand standard controls such as Delete and confirmation buttons.
+Write for smart, curious, advanced users. Documentation should contain only information they cannot reasonably discover or understand directly from the interface: hidden capabilities, non-obvious behavior, prerequisites, constraints, configuration contracts, and migration requirements.
+
+Keep docs concise. Every paragraph must add knowledge beyond visible labels and standard UI conventions. Explain how to discover and use a hidden advanced widget feature; omit explanations that the Delete button deletes an item in edit mode. Avoid UI walkthroughs, exhaustive control descriptions, and repetition. When editing a passage, remove obvious or redundant prose rather than preserving verbosity as a precedent.
+
+Update docs only when a change introduces or alters that non-obvious information, or makes existing guidance inaccurate. Routine fixes and self-explanatory UI changes need no docs update. A new feature alone does not require a page; apply the same reader-value test.
 
 When documentation is needed, use these locations:
 

--- a/apps/docs/docs/management/apps/index.mdx
+++ b/apps/docs/docs/management/apps/index.mdx
@@ -35,6 +35,13 @@ when they provide a link to the service.
 
 See [Icons](/docs/advanced/icons) for icon sources and uploads.
 
+## Removing an app from a board
+
+Enter edit mode, open the app widget's three-dot menu, and select **Remove item**. A confirmation dialog displays the
+widget's name. Select **Remove item** to confirm, or **Cancel** to keep it. The same dialog is available on mobile.
+
+This removes the widget from the board; the app remains available under **Management → Apps**.
+
 ## Permissions
 
 - `app-create` creates apps.

--- a/apps/docs/docs/management/apps/index.mdx
+++ b/apps/docs/docs/management/apps/index.mdx
@@ -35,13 +35,6 @@ when they provide a link to the service.
 
 See [Icons](/docs/advanced/icons) for icon sources and uploads.
 
-## Removing an app from a board
-
-Enter edit mode, open the app widget's three-dot menu, and select **Remove item**. A confirmation dialog displays the
-widget's name. Select **Remove item** to confirm, or **Cancel** to keep it. The same dialog is available on mobile.
-
-This removes the widget from the board; the app remains available under **Management → Apps**.
-
 ## Permissions
 
 - `app-create` creates apps.

--- a/apps/nextjs/src/components/board/items/item-menu.tsx
+++ b/apps/nextjs/src/components/board/items/item-menu.tsx
@@ -5,10 +5,9 @@ import { IconCopy, IconDotsVertical, IconLayoutKanban, IconPencil, IconTrash } f
 import { useSession } from "@homarr/auth/client";
 import { useEditMode } from "@homarr/boards/edit-mode";
 import { getWidgetName } from "@homarr/definitions";
-import { useModalAction } from "@homarr/modals";
+import { useConfirmModal, useModalAction } from "@homarr/modals";
 import { useSettings } from "@homarr/settings";
 import { useI18n } from "@homarr/translation/client";
-import { InlineConfirmMenuItem } from "@homarr/ui";
 import type { WidgetDefinition } from "@homarr/widgets/definition";
 import type { WidgetPreviewDimensions } from "@homarr/widgets/modals";
 
@@ -40,6 +39,7 @@ const BoardItemMenuInner = ({ item, definition, previewDimensions, resetErrorBou
   const tItem = useI18n("item");
   const t = useI18n();
   const { openModal } = useModalAction(LazyWidgetEditModal);
+  const { openConfirmModal } = useConfirmModal();
   const openMoveModal = useOpenItemMoveModal();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { updateItemOptions, updateItemAdvancedOptions, updateItemIntegrations, duplicateItem, removeItem } =
@@ -143,14 +143,21 @@ const BoardItemMenuInner = ({ item, definition, previewDimensions, resetErrorBou
           </Menu.Item>
         )}
         <Menu.Divider />
-        <InlineConfirmMenuItem
+        <Menu.Item
           color="red"
-          confirmLabel={tItem("remove.message")}
           leftSection={<IconTrash size={16} />}
-          onConfirm={() => removeItem({ itemId: item.id })}
+          onClick={() => {
+            setIsMenuOpen(false);
+            openConfirmModal({
+              title: tItem("remove.message"),
+              children: label,
+              labels: { confirm: tItem("action.remove") },
+              onConfirm: () => removeItem({ itemId: item.id }),
+            });
+          }}
         >
           {tItem("action.remove")}
-        </InlineConfirmMenuItem>
+        </Menu.Item>
       </Menu.Dropdown>
     </Menu>
   );


### PR DESCRIPTION
Replace the board item's inline, timed removal confirmation with the shared confirmation dialog. Selecting Remove item closes the menu and shows the widget label with Cancel and Remove item buttons on mobile and desktop.

Narrow the repository documentation rule to changes users need explained or corrections to inaccurate guidance. Routine bug fixes and self-explanatory controls require no docs changes.

Validated the actual menu and modal in an isolated harness using Mantine 9.6.0: iPhone WebKit and desktop Chromium passed cancel, confirm, and viewport visibility checks. Board state was stubbed; the reporter's exact device failure was not reproduced. Focused lint, formatting, and diff checks passed.
